### PR TITLE
init: multi module 설정 추가

### DIFF
--- a/badminton-api/build.gradle
+++ b/badminton-api/build.gradle
@@ -1,32 +1,19 @@
-plugins {
-    id 'java'
-    id 'org.springframework.boot'
-    id 'io.spring.dependency-management'
-}
-
-group = 'com.final'
-version = '0.0.1-SNAPSHOT'
-
-repositories {
-    mavenCentral()
-}
-
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-}
-
 dependencies {
     implementation project(':badminton-domain')
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
 }
 
 test {
     useJUnitPlatform()
+}
+
+bootJar {
+    enabled = true
+}
+
+jar {
+    enabled = false
 }

--- a/badminton-api/src/main/java/org/badminton/api/BadmintonApplication.java
+++ b/badminton-api/src/main/java/org/badminton/api/BadmintonApplication.java
@@ -2,8 +2,10 @@ package org.badminton.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class BadmintonApplication {
 
 	public static void main(String[] args) {

--- a/badminton-api/src/main/java/org/badminton/api/club/ClubController.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/ClubController.java
@@ -1,0 +1,24 @@
+package org.badminton.api.club;
+
+import org.badminton.domain.club.entity.ClubEntity;
+import org.badminton.domain.club.repository.ClubRepository;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/club")
+public class ClubController {
+
+	private final ClubRepository clubRepository;
+
+	@GetMapping("")
+	public String save() {
+		var club = new ClubEntity();
+		clubRepository.save(club);
+		return "안녕";
+	}
+}

--- a/badminton-api/src/main/java/org/badminton/api/config/jpa/JpaConfig.java
+++ b/badminton-api/src/main/java/org/badminton/api/config/jpa/JpaConfig.java
@@ -1,0 +1,11 @@
+package org.badminton.api.config.jpa;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EntityScan(basePackages = "org.badminton.domain")
+@EnableJpaRepositories(basePackages = "org.badminton.domain")
+public class JpaConfig {
+}

--- a/badminton-api/src/main/java/org/badminton/api/config/objectmapper/ObjectMapperConfig.java
+++ b/badminton-api/src/main/java/org/badminton/api/config/objectmapper/ObjectMapperConfig.java
@@ -1,0 +1,37 @@
+package org.badminton.api.config.objectmapper;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class ObjectMapperConfig {
+
+	@Bean
+	public ObjectMapper objectMapper() {
+		var objectMapper = new ObjectMapper();
+
+		objectMapper.registerModule(new Jdk8Module());  // jdk 8 버전 이후 클래스
+
+		objectMapper.registerModule(new JavaTimeModule());  // << local date
+
+		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+			false);   // 모르는 json field에 대해서는 무시 한다.
+
+		objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+
+		// 날짜 관련 직렬화
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+		// 스네이크 케이스
+		objectMapper.setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy());
+
+		return objectMapper;
+	}
+}

--- a/badminton-api/src/main/java/org/badminton/api/config/swagger/SwaggerConfig.java
+++ b/badminton-api/src/main/java/org/badminton/api/config/swagger/SwaggerConfig.java
@@ -1,8 +1,11 @@
-package com.final2.badminton.config;
+package org.badminton.api.config.swagger;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -22,6 +25,12 @@ public class SwaggerConfig {
 			.title("배드민턴 칠까 서비스 API 명세서")
 			.description("배드민턴 칠까? API 명세서")
 			.version("1.0.0");
+	}
+
+	@Bean
+	public ModelResolver modelResolver(ObjectMapper objectMapper) {
+		return new ModelResolver(objectMapper);
+
 	}
 
 }

--- a/badminton-domain/build.gradle
+++ b/badminton-domain/build.gradle
@@ -1,17 +1,12 @@
-plugins {
-    id 'java'
-}
-
-
-repositories {
-    mavenCentral()
-}
-
 dependencies {
-    testImplementation platform('org.junit:junit-bom:5.10.0')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 }
 
-test {
-    useJUnitPlatform()
+bootJar {
+    enabled = false
+}
+
+jar {
+    enabled = true
 }

--- a/badminton-domain/src/main/java/org/badminton/domain/club/entity/ClubEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/club/entity/ClubEntity.java
@@ -1,0 +1,22 @@
+package org.badminton.domain.club.entity;
+
+import org.badminton.domain.common.BaseTimeEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "club")
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ClubEntity extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+}

--- a/badminton-domain/src/main/java/org/badminton/domain/club/repository/ClubRepository.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/club/repository/ClubRepository.java
@@ -1,0 +1,7 @@
+package org.badminton.domain.club.repository;
+
+import org.badminton.domain.club.entity.ClubEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClubRepository extends JpaRepository<ClubEntity, Long> {
+}

--- a/badminton-domain/src/main/java/org/badminton/domain/common/BaseTimeEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/common/BaseTimeEntity.java
@@ -1,0 +1,26 @@
+package org.badminton.domain.common;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+	@CreatedDate
+	@Column(name = "created_at", updatable = false, nullable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "modified_at", nullable = false)
+	private LocalDateTime modifiedAt;
+
+}

--- a/badminton-domain/src/main/resources/application.properties
+++ b/badminton-domain/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.config.import=optional:application-secret.properties

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,26 @@ plugins {
 }
 
 allprojects {
+    apply plugin: 'java'
+    apply plugin: 'org.springframework.boot'
+    apply plugin: 'io.spring.dependency-management'
+
+    dependencies {
+        compileOnly 'org.projectlombok:lombok'
+        annotationProcessor 'org.projectlombok:lombok'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    }
+
     repositories {
         mavenCentral()
+    }
+    tasks.named('test') {
+        useJUnitPlatform()
+    }
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+        }
     }
 }
 
@@ -18,27 +36,8 @@ jar {
     enabled = false
 }
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
-}
-
 
 repositories {
     mavenCentral()
 }
 
-dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
-    annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
-}


### PR DESCRIPTION
## PR에 대한 설명 🔍

multi module gradle 설정 리팩토링

## 변경된 사항 📝

1. 최상위 gradle 파일에 공통적으로 적용할 설정 추가

- allprojects 안에 설정 추가
```
allprojects {
    apply plugin: 'java'
    apply plugin: 'org.springframework.boot'
    apply plugin: 'io.spring.dependency-management'

    dependencies {
        compileOnly 'org.projectlombok:lombok'
        annotationProcessor 'org.projectlombok:lombok'
        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
    }

    repositories {
        mavenCentral()
    }
    tasks.named('test') {
        useJUnitPlatform()
    }
    java {
        toolchain {
            languageVersion = JavaLanguageVersion.of(17)
        }
    }
}
```

2. Jpa Config 설정 추가
다른 프로젝트  이름 -> entity, repository 찾으려면 설정 파일 필요

3. ObjectMapperConfig
swagger에서 camel case -> snake case로 변환

4. swagger config 파일 위치 변경 -> badminton-api
기존 src 폴더  제거


## PR에서 중점적으로 확인되어야 하는 사항

badminton-api에 포함
- controller, service, dto
badminton-domain에 포함
- repository, entity

틀린 내용이 있다면 코멘트 남겨주세요!😄