### PR TITLE
feat: error code interface 정의 및 exception, exception handler 추가

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/club/validator/ClubValidator.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/validator/ClubValidator.java
@@ -1,5 +1,8 @@
 package org.badminton.api.club.validator;
 
+import static org.badminton.api.common.error.ClubErrorCode.*;
+
+import org.badminton.api.common.exception.BadmintonException;
 import org.badminton.domain.club.entity.ClubEntity;
 import org.badminton.domain.club.repository.ClubRepository;
 import org.springframework.stereotype.Component;
@@ -18,7 +21,7 @@ public class ClubValidator {
 
 	public void checkIfClubPresent(String clubName) {
 		clubRepository.findByClubName(clubName).ifPresent(club -> {
-			throw new IllegalArgumentException("이미 존재하는 동호회입니다.");
+			throw new BadmintonException(CLUB_ALREADY_EXISTS);
 		});
 	}
 

--- a/badminton-api/src/main/java/org/badminton/api/common/error/ClubErrorCode.java
+++ b/badminton-api/src/main/java/org/badminton/api/common/error/ClubErrorCode.java
@@ -1,0 +1,18 @@
+package org.badminton.api.common.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ClubErrorCode implements ErrorCodeIfs {
+
+	CLUB_NOT_FOUND(400, 1404, "존재하지 않는 동호회입니다."),
+	CLUB_ALREADY_EXISTS(400, 1402, "이미 존재하는 동호회입니다."),
+	;
+
+	private final Integer httpStatusCode;
+	private final Integer errorCode;
+	private final String description;
+
+}

--- a/badminton-api/src/main/java/org/badminton/api/common/error/ErrorCode.java
+++ b/badminton-api/src/main/java/org/badminton/api/common/error/ErrorCode.java
@@ -1,0 +1,22 @@
+package org.badminton.api.common.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode implements ErrorCodeIfs {
+
+	OK(HttpStatus.OK.value(), 200, "성공"),
+	BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), 400, "잘못된 요청"),
+	SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), 500, "서버 에러"),
+	NULL_POINT(HttpStatus.INTERNAL_SERVER_ERROR.value(), 512, "Null Point"),
+	;
+
+	private final Integer httpStatusCode;
+	private final Integer errorCode;
+	private final String description;
+
+}

--- a/badminton-api/src/main/java/org/badminton/api/common/error/ErrorCodeIfs.java
+++ b/badminton-api/src/main/java/org/badminton/api/common/error/ErrorCodeIfs.java
@@ -1,0 +1,10 @@
+package org.badminton.api.common.error;
+
+public interface ErrorCodeIfs {
+
+	Integer getHttpStatusCode();
+
+	Integer getErrorCode();
+
+	String getDescription();
+}

--- a/badminton-api/src/main/java/org/badminton/api/common/exception/BadmintonException.java
+++ b/badminton-api/src/main/java/org/badminton/api/common/exception/BadmintonException.java
@@ -1,0 +1,18 @@
+package org.badminton.api.common.exception;
+
+import org.badminton.api.common.error.ErrorCodeIfs;
+
+import lombok.Getter;
+
+@Getter
+public class BadmintonException extends RuntimeException implements BadmintonExceptionIfs {
+
+	private final ErrorCodeIfs errorCodeIfs;
+	private final String errorDescription;
+
+	public BadmintonException(ErrorCodeIfs errorCodeIfs) {
+		super(errorCodeIfs.getDescription());
+		this.errorCodeIfs = errorCodeIfs;
+		this.errorDescription = errorCodeIfs.getDescription();
+	}
+}

--- a/badminton-api/src/main/java/org/badminton/api/common/exception/BadmintonExceptionIfs.java
+++ b/badminton-api/src/main/java/org/badminton/api/common/exception/BadmintonExceptionIfs.java
@@ -1,0 +1,9 @@
+package org.badminton.api.common.exception;
+
+import org.badminton.api.common.error.ErrorCodeIfs;
+
+public interface BadmintonExceptionIfs {
+	ErrorCodeIfs getErrorCodeIfs();
+
+	String getErrorDescription();
+}

--- a/badminton-api/src/main/java/org/badminton/api/exceptionhandler/BadmintonExceptionHandler.java
+++ b/badminton-api/src/main/java/org/badminton/api/exceptionhandler/BadmintonExceptionHandler.java
@@ -1,0 +1,26 @@
+package org.badminton.api.exceptionhandler;
+
+import org.badminton.api.common.exception.BadmintonException;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+@Order(value = Integer.MIN_VALUE)
+public class BadmintonExceptionHandler {
+
+	@ExceptionHandler(value = BadmintonException.class)
+	public ResponseEntity<String> handleBadmintonException(
+		BadmintonException badmintonException
+	) {
+		var errorCode = badmintonException.getErrorCodeIfs();
+		return ResponseEntity.status(errorCode.getHttpStatusCode())
+			.body(
+				"에러 코드 " + errorCode.getErrorCode() + ": " + badmintonException.getErrorDescription()
+			);
+	}
+}

--- a/badminton-api/src/main/java/org/badminton/api/exceptionhandler/GlobalExceptionHandler.java
+++ b/badminton-api/src/main/java/org/badminton/api/exceptionhandler/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package org.badminton.api.exceptionhandler;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+@Order(value = Integer.MAX_VALUE)
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<String> handleException(Exception e) {
+		log.error("Exception 예외 발생: {}", e.getMessage(), e);
+		return ResponseEntity
+			.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(e.getMessage());
+	}
+
+}


### PR DESCRIPTION
## PR에 대한 설명 🔍

custom error code, exception, exception handler 추가

## 변경된 사항 📝

custom error code를 유연하게 추가하기 위해 인터페이스를 정의했습니다.
이 인터페이스를 구현하여 자유롭게 도메인별로 에러 코드를 만들어 사용하시면 될 것 같습니다.

혹시 예외 처리나 에러코드 관련하여 다른 방법이 있거나 더 좋은 코드가 있다면 꼭 말씀해주세요 😄


## PR에서 중점적으로 확인되어야 하는 사항


커스텀 예외를 처리하고 싶을 때 아래와 같이 던지면 됩니다 !

1. Custom Error Code를 추가한다.

- 이름 예시: `ClubErrorCode`, `LeagueErrorCode`, `MemberErrorCode`

* ErrorCodeIfs (에러코드 인터페이스) 구현하여 만들어주세요.

- 코드 예시:

```
@Getter
@AllArgsConstructor
public enum ClubErrorCode implements ErrorCodeIfs {

	CLUB_NOT_FOUND(400, 1404, "존재하지 않는 동호회입니다."),
	CLUB_ALREADY_EXISTS(400, 1402, "이미 존재하는 동호회입니다."),
	;

	private final Integer httpStatusCode;
	private final Integer errorCode;
	private final String description;

}

```

첫 번째 파라미터 : http 상태 코드
두 번째 파라미터 : 에러 코드
세 번째 파라미터 : 에러에 대한 상세 설명

2. Validator에서 에러를 던질 때

```
public void checkIfClubPresent(String clubName) {
		clubRepository.findByClubName(clubName).ifPresent(club -> {
			throw new BadmintonException(CLUB_ALREADY_EXISTS);
		});
	}
```
BadmintonException을 상속받아 새로운 예외 클래스를 만들어 사용해도 됩니다.
새로 생성한 ClubErrorCode를 넣어서 던지면 됩니다.
