### PR TITLE
feat: validator 추가 및 공통 타입 정의, 에러 코드 수정

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/common/error/ClubErrorCode.java
+++ b/badminton-api/src/main/java/org/badminton/api/common/error/ClubErrorCode.java
@@ -7,9 +7,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ClubErrorCode implements ErrorCodeIfs {
 
-	CLUB_NOT_FOUND(400, 1404, "존재하지 않는 동호회입니다."),
-	CLUB_ALREADY_EXISTS(400, 1402, "이미 존재하는 동호회입니다."),
-	;
+	CLUB_NOT_FOUND(ErrorCode.BAD_REQUEST.getErrorCode(), ErrorCode.CLUB_NOT_FOUND.getErrorCode(),
+		ErrorCode.CLUB_NOT_FOUND.getDescription()),
+	CLUB_ALREADY_EXISTS(ErrorCode.BAD_REQUEST.getErrorCode(), ErrorCode.CLUB_ALREADY_EXISTS.getErrorCode(),
+		ErrorCode.CLUB_ALREADY_EXISTS.getDescription());
 
 	private final Integer httpStatusCode;
 	private final Integer errorCode;

--- a/badminton-api/src/main/java/org/badminton/api/common/error/ErrorCode.java
+++ b/badminton-api/src/main/java/org/badminton/api/common/error/ErrorCode.java
@@ -1,22 +1,29 @@
 package org.badminton.api.common.error;
 
-import org.springframework.http.HttpStatus;
+public enum ErrorCode {
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+	OK(200, "성공"),
+	BAD_REQUEST(400, "잘못된 요청"),
+	SERVER_ERROR(500, "서버 에러"),
+	NULL_POINT(512, "Null Point"),
+	LEAGUE_ALREADY_EXISTS(1400, "이미 존재하는 경기입니다."),
+	LEAGUE_NOT_FOUND(1401, "존재하지 않은 경기입니다."),
+	CLUB_ALREADY_EXISTS(1402, "이미 존재하는 동호회입니다."),
+	CLUB_NOT_FOUND(1404, "존재하지 않은 동호회입니다.");
 
-@AllArgsConstructor
-@Getter
-public enum ErrorCode implements ErrorCodeIfs {
-
-	OK(HttpStatus.OK.value(), 200, "성공"),
-	BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), 400, "잘못된 요청"),
-	SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), 500, "서버 에러"),
-	NULL_POINT(HttpStatus.INTERNAL_SERVER_ERROR.value(), 512, "Null Point"),
-	;
-
-	private final Integer httpStatusCode;
 	private final Integer errorCode;
 	private final String description;
 
+	ErrorCode(Integer errorCode, String description) {
+		this.errorCode = errorCode;
+		this.description = description;
+	}
+
+	public Integer getErrorCode() {
+		return errorCode;
+	}
+
+	public String getDescription() {
+		return description;
+	}
 }

--- a/badminton-api/src/main/java/org/badminton/api/common/error/HttpErrorCode.java
+++ b/badminton-api/src/main/java/org/badminton/api/common/error/HttpErrorCode.java
@@ -1,0 +1,25 @@
+package org.badminton.api.common.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum HttpErrorCode implements ErrorCodeIfs {
+
+	OK(HttpStatus.OK.value(), ErrorCode.OK.getErrorCode(), ErrorCode.BAD_REQUEST.getDescription()),
+	BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), ErrorCode.BAD_REQUEST.getErrorCode(),
+		ErrorCode.BAD_REQUEST.getDescription()),
+	SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), ErrorCode.SERVER_ERROR.getErrorCode(),
+		ErrorCode.SERVER_ERROR.getDescription()),
+	NULL_POINT(HttpStatus.INTERNAL_SERVER_ERROR.value(), ErrorCode.NULL_POINT.getErrorCode(),
+		ErrorCode.NULL_POINT.getDescription()),
+	;
+
+	private final Integer httpStatusCode;
+	private final Integer errorCode;
+	private final String description;
+
+}

--- a/badminton-api/src/main/java/org/badminton/api/common/error/LeagueErrorCode.java
+++ b/badminton-api/src/main/java/org/badminton/api/common/error/LeagueErrorCode.java
@@ -1,0 +1,18 @@
+package org.badminton.api.common.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum LeagueErrorCode implements ErrorCodeIfs {
+
+	LEAGUE_NOT_FOUND(ErrorCode.BAD_REQUEST.getErrorCode(), ErrorCode.LEAGUE_NOT_FOUND.getErrorCode(),
+		ErrorCode.LEAGUE_NOT_FOUND.getDescription()),
+	LEAGUE_ALREADY_EXISTS(ErrorCode.BAD_REQUEST.getErrorCode(), ErrorCode.LEAGUE_ALREADY_EXISTS.getErrorCode(),
+		ErrorCode.LEAGUE_ALREADY_EXISTS.getDescription());
+
+	private final Integer httpStatusCode;
+	private final Integer errorCode;
+	private final String description;
+}

--- a/badminton-api/src/main/java/org/badminton/api/league/controller/LeagueController.java
+++ b/badminton-api/src/main/java/org/badminton/api/league/controller/LeagueController.java
@@ -1,13 +1,15 @@
-package org.badminton.api.league;
+package org.badminton.api.league.controller;
 
 import org.badminton.api.league.model.dto.LeagueCreateRequest;
+import org.badminton.api.league.model.dto.LeagueCreateResponse;
 import org.badminton.api.league.service.LeagueService;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -19,14 +21,10 @@ public class LeagueController {
 	@Operation(
 		summary = "경기를 생성합니다.",
 		description = "경기 생성하고를 데이터베이스에 저장합니다.",
-		tags = {"League"}, // 태그 분류
-		requestBody = @RequestBody(
-			description = "경기 저장 시 필요한 스키마",
-			required = true
-		)
+		tags = {"league"}
 	)
 	@PostMapping
-	public void leagueCreate(@org.springframework.web.bind.annotation.RequestBody LeagueCreateRequest request) {
-		leagueService.createLeague(request);
+	public ResponseEntity<LeagueCreateResponse> leagueCreate(@RequestBody LeagueCreateRequest request) {
+		return ResponseEntity.ok(leagueService.createLeague(request));
 	}
 }

--- a/badminton-api/src/main/java/org/badminton/api/league/model/dto/LeagueCreateRequest.java
+++ b/badminton-api/src/main/java/org/badminton/api/league/model/dto/LeagueCreateRequest.java
@@ -37,7 +37,11 @@ public record LeagueCreateRequest(
 	LocalDateTime closedAt,
 
 	@Schema(description = "참가 인원", example = "16")
-	Long playerCount
+	Long playerCount,
+
+	@Schema(description = "매칭 조건", example = "TIER")
+	String matchingRequirement
+
 ) {
 	public static LeagueEntity leagueCreateRequestToEntity(LeagueCreateRequest request) {
 		return new LeagueEntity(
@@ -48,7 +52,8 @@ public record LeagueCreateRequest(
 			request.closedAt(),
 			request.status().name(),
 			request.playerCount(),
-			request.matchType().name()
+			request.matchType().name(),
+			request.matchingRequirement()
 		);
 	}
 }

--- a/badminton-api/src/main/java/org/badminton/api/league/model/dto/LeagueCreateResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/league/model/dto/LeagueCreateResponse.java
@@ -38,7 +38,10 @@ public record LeagueCreateResponse(
 	LocalDateTime createdAt,
 
 	@Schema(description = "수정 일자", example = "2024-09-10T15:30:00")
-	LocalDateTime modifiedAt
+	LocalDateTime modifiedAt,
+
+	@Schema(description = "매칭 조건", example = "TIER")
+	String matchingRequirement
 ) {
 
 	public LeagueCreateResponse(LeagueEntity entity) {
@@ -52,7 +55,8 @@ public record LeagueCreateResponse(
 			entity.getClosedAt(),
 			entity.getPlayerCount(),
 			entity.getCreatedAt(),
-			entity.getModifiedAt()
+			entity.getModifiedAt(),
+			entity.getMatchingRequirement()
 		);
 	}
 

--- a/badminton-api/src/main/java/org/badminton/api/league/model/dto/LeagueCreateResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/league/model/dto/LeagueCreateResponse.java
@@ -7,14 +7,9 @@ import org.badminton.domain.common.enums.MemberTier;
 import org.badminton.domain.league.entity.LeagueEntity;
 import org.badminton.domain.league.enums.LeagueStatus;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record LeagueCreateRequest(
-
+public record LeagueCreateResponse(
 	@Schema(description = "경기 이름", example = "배드민턴 경기")
 	String leagueName,
 
@@ -37,18 +32,32 @@ public record LeagueCreateRequest(
 	LocalDateTime closedAt,
 
 	@Schema(description = "참가 인원", example = "16")
-	Long playerCount
+	Long playerCount,
+
+	@Schema(description = "생성 일자", example = "2024-09-10T15:30:00")
+	LocalDateTime createdAt,
+
+	@Schema(description = "수정 일자", example = "2024-09-10T15:30:00")
+	LocalDateTime modifiedAt
 ) {
-	public static LeagueEntity leagueCreateRequestToEntity(LeagueCreateRequest request) {
-		return new LeagueEntity(
-			request.leagueName(),
-			request.description(),
-			request.leagueAt(),
-			request.tierLimit().name(),
-			request.closedAt(),
-			request.status().name(),
-			request.playerCount(),
-			request.matchType().name()
+
+	public LeagueCreateResponse(LeagueEntity entity) {
+		this(
+			entity.getLeagueName(),
+			entity.getDescription(),
+			MemberTier.valueOf(entity.getTierLimit()),
+			LeagueStatus.valueOf(entity.getStatus()),
+			MatchType.valueOf(entity.getMatchType()),
+			entity.getLeagueAt(),
+			entity.getClosedAt(),
+			entity.getPlayerCount(),
+			entity.getCreatedAt(),
+			entity.getModifiedAt()
 		);
+	}
+
+	// 정적 팩토리 메서드
+	public static LeagueCreateResponse leagueCreateEntityToResponse(LeagueEntity entity) {
+		return new LeagueCreateResponse(entity);
 	}
 }

--- a/badminton-api/src/main/java/org/badminton/api/league/service/LeagueService.java
+++ b/badminton-api/src/main/java/org/badminton/api/league/service/LeagueService.java
@@ -1,6 +1,9 @@
 package org.badminton.api.league.service;
 
 import org.badminton.api.league.model.dto.LeagueCreateRequest;
+import org.badminton.api.league.model.dto.LeagueCreateResponse;
+import org.badminton.api.league.validator.LeagueValidator;
+import org.badminton.domain.league.entity.LeagueEntity;
 import org.badminton.domain.league.repository.LeagueRepository;
 import org.springframework.stereotype.Service;
 
@@ -10,9 +13,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class LeagueService {
 	private final LeagueRepository leagueRepository;
+	private final LeagueValidator leagueValidator;
 
-	public void createLeague(LeagueCreateRequest createRequest) {
-		leagueRepository.save(LeagueCreateRequest.createRequestToEntity(createRequest));
+	public LeagueCreateResponse createLeague(LeagueCreateRequest createRequest) {
+		leagueValidator.checkIfLeagueExists(createRequest.leagueName());
+		LeagueEntity savedLeague = leagueRepository.save(
+			LeagueCreateRequest.leagueCreateRequestToEntity(createRequest));
+		return LeagueCreateResponse.leagueCreateEntityToResponse(savedLeague);
 	}
-
 }

--- a/badminton-api/src/main/java/org/badminton/api/league/validator/LeagueValidator.java
+++ b/badminton-api/src/main/java/org/badminton/api/league/validator/LeagueValidator.java
@@ -1,0 +1,21 @@
+package org.badminton.api.league.validator;
+
+import static org.badminton.api.common.error.LeagueErrorCode.*;
+
+import org.badminton.api.common.exception.BadmintonException;
+import org.badminton.domain.league.repository.LeagueRepository;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class LeagueValidator {
+	private final LeagueRepository leagueRepository;
+
+	public void checkIfLeagueExists(String leagueName) {
+		leagueRepository.findByLeagueName(leagueName).ifPresent(league -> {
+			throw new BadmintonException(LEAGUE_ALREADY_EXISTS);
+		});
+	}
+}

--- a/badminton-api/src/main/java/org/badminton/api/match/controller/SinglesMatchController.java
+++ b/badminton-api/src/main/java/org/badminton/api/match/controller/SinglesMatchController.java
@@ -1,0 +1,27 @@
+package org.badminton.api.match.controller;
+
+import org.badminton.api.match.service.SinglesMatchService;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/v1/match")
+public class SinglesMatchController {
+	private final SinglesMatchService singlesMatchService;
+
+	@Operation(
+		summary = "싱글 매칭 대진표를 생성합니다..",
+		description = "싱글 매칭 대진표를 생성하여 저장합니다.",
+		tags = {"match"}
+	)
+	@PostMapping("{leagueId}")
+	public void singlesMatchCreate(@PathVariable("leagueId") Long leagueId) {
+		singlesMatchService.singlesMatchCreate(leagueId);
+	}
+}

--- a/badminton-api/src/main/java/org/badminton/api/match/model/dto/SinglesMatchCreateRequest.java
+++ b/badminton-api/src/main/java/org/badminton/api/match/model/dto/SinglesMatchCreateRequest.java
@@ -1,0 +1,40 @@
+package org.badminton.api.match.model.dto;
+
+import org.badminton.domain.match.entity.SinglesMatchEntity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SinglesMatchCreateRequest(
+	@Schema(description = "경기 아이디", example = "1L")
+	Long leagueId,
+
+	@Schema(description = "유저 아이디", example = "1L")
+	Long memberId,
+
+	@Schema(description = "상대방 아이디", example = "1L")
+	Long opponentId,
+
+	@Schema(description = "경기 결과", example = "WIN")
+	String matchResult,
+
+	@Schema(description = "나의 경기 스코어", example = "25L")
+	Long myScore,
+
+	@Schema(description = "상대방 경기 스코어", example = "14L")
+	Long opponentScore,
+
+	@Schema(description = "대진 회차", example = "2L")
+	Long setIndex
+) {
+	public static SinglesMatchEntity singlesMatchCreateRequestToEntity(SinglesMatchCreateRequest request) {
+		return new SinglesMatchEntity(
+			request.leagueId,
+			request.memberId,
+			request.opponentId,
+			request.matchResult,
+			request.myScore,
+			request.opponentScore,
+			request.setIndex
+		);
+	}
+}

--- a/badminton-api/src/main/java/org/badminton/api/match/service/SinglesMatchService.java
+++ b/badminton-api/src/main/java/org/badminton/api/match/service/SinglesMatchService.java
@@ -1,0 +1,52 @@
+package org.badminton.api.match.service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.badminton.api.match.validator.SinglesMatchValidator;
+import org.badminton.api.match.validator.policy.MatchingPolicy;
+import org.badminton.api.match.validator.policy.MatchingPolicyType;
+import org.badminton.domain.match.repository.SinglesMatchRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SinglesMatchService {
+	private final SinglesMatchRepository singlesMatchRepository;
+	private final SinglesMatchValidator singlesMatchValidator;
+
+	public void singlesMatchCreate(Long leagueId) {
+		// league 정책을 불러옴
+		String matchingRequirement = "RANDOM";
+
+		//leagueId로 경기를 하는 사람 리스트를 불러옴
+		List<Long> memberIds = new ArrayList<>();
+		memberIds.add(1L);
+		memberIds.add(2L);
+		memberIds.add(3L);
+		memberIds.add(4L);
+		memberIds.add(5L);
+
+		MatchingPolicy matchingPolicy = singlesMatchValidator.checkMatchPolicy(
+			MatchingPolicyType.valueOf(matchingRequirement));
+
+		HashMap<Long, Long> matchResult = matchingPolicy.match(memberIds);
+
+		for (Map.Entry<Long, Long> id : matchResult.entrySet()) {
+			Long firstId = id.getKey();
+			Long secondId = id.getValue();
+			if (Objects.equals(firstId, secondId)) {
+				singlesMatchValidator.checkValidationAndSave(leagueId, firstId, secondId);
+				continue;
+			}
+			singlesMatchValidator.checkValidationAndSave(leagueId, firstId, secondId);
+			singlesMatchValidator.checkValidationAndSave(leagueId, secondId, firstId);
+
+		}
+	}
+}

--- a/badminton-api/src/main/java/org/badminton/api/match/validator/SinglesMatchValidator.java
+++ b/badminton-api/src/main/java/org/badminton/api/match/validator/SinglesMatchValidator.java
@@ -1,0 +1,44 @@
+package org.badminton.api.match.validator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.badminton.api.match.model.dto.SinglesMatchCreateRequest;
+import org.badminton.api.match.validator.policy.MatchingPolicy;
+import org.badminton.api.match.validator.policy.MatchingPolicyType;
+import org.badminton.api.match.validator.policy.RandomMatchingPolicy;
+import org.badminton.domain.match.entity.SinglesMatchEntity;
+import org.badminton.domain.match.repository.SinglesMatchRepository;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SinglesMatchValidator {
+	//TODO : 검증 코드 추가
+
+	private final SinglesMatchRepository singlesMatchRepository;
+
+	public MatchingPolicy checkMatchPolicy(MatchingPolicyType policyType) {
+		Map<MatchingPolicyType, MatchingPolicy> policy = new HashMap<>();
+		policy.put(MatchingPolicyType.RANDOM, new RandomMatchingPolicy());
+
+		return policy.get(policyType);
+	}
+
+	public void checkValidationAndSave(Long leagueId, Long memberId, Long oppositeId) {
+		SinglesMatchCreateRequest request = new SinglesMatchCreateRequest(
+			leagueId,
+			memberId,
+			oppositeId,
+			"BEFORE",
+			0L,
+			0L,
+			0L);
+
+		SinglesMatchEntity entity = SinglesMatchCreateRequest.singlesMatchCreateRequestToEntity(request);
+
+		singlesMatchRepository.save(entity);
+	}
+}

--- a/badminton-api/src/main/java/org/badminton/api/match/validator/policy/MatchingPolicy.java
+++ b/badminton-api/src/main/java/org/badminton/api/match/validator/policy/MatchingPolicy.java
@@ -1,0 +1,8 @@
+package org.badminton.api.match.validator.policy;
+
+import java.util.HashMap;
+import java.util.List;
+
+public interface MatchingPolicy {
+	HashMap<Long, Long> match(List<Long> memberIds);
+}

--- a/badminton-api/src/main/java/org/badminton/api/match/validator/policy/MatchingPolicyType.java
+++ b/badminton-api/src/main/java/org/badminton/api/match/validator/policy/MatchingPolicyType.java
@@ -1,0 +1,6 @@
+package org.badminton.api.match.validator.policy;
+
+public enum MatchingPolicyType {
+	RANDOM,
+	AVERAGE
+}

--- a/badminton-api/src/main/java/org/badminton/api/match/validator/policy/RandomMatchingPolicy.java
+++ b/badminton-api/src/main/java/org/badminton/api/match/validator/policy/RandomMatchingPolicy.java
@@ -1,0 +1,27 @@
+package org.badminton.api.match.validator.policy;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Random;
+
+public class RandomMatchingPolicy implements MatchingPolicy {
+	@Override
+	public HashMap<Long, Long> match(List<Long> memberIds) {
+
+		Collections.shuffle(memberIds, new Random());
+
+		HashMap<Long, Long> result = new HashMap<>();
+
+		for (int i = 0; i < memberIds.size(); i = i + 2) {
+			if (memberIds.size() % 2 != 0 && i == memberIds.size() - 1) {
+				result.put(memberIds.get(i), memberIds.get(i));
+				break;
+			}
+			Long first = memberIds.get(i);
+			Long second = memberIds.get(i + 1);
+			result.put(first, second);
+		}
+		return result;
+	}
+}

--- a/badminton-domain/src/main/java/org/badminton/domain/common/enums/MatchType.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/common/enums/MatchType.java
@@ -1,0 +1,6 @@
+package org.badminton.domain.common.enums;
+
+public enum MatchType {
+	SINGLE,
+	DOUBLES;
+}

--- a/badminton-domain/src/main/java/org/badminton/domain/common/enums/MemberTier.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/common/enums/MemberTier.java
@@ -1,0 +1,10 @@
+package org.badminton.domain.common.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum MemberTier {
+	GOLD,
+	SILVER,
+	BRONZE;
+}

--- a/badminton-domain/src/main/java/org/badminton/domain/league/entity/LeagueEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/league/entity/LeagueEntity.java
@@ -2,6 +2,8 @@ package org.badminton.domain.league.entity;
 
 import java.time.LocalDateTime;
 
+import org.badminton.domain.common.BaseTimeEntity;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,13 +19,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "league")
-public class LeagueEntity {
+public class LeagueEntity extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long leagueId;
 
-	private String name;
+	private String leagueName;
 
 	private String description;
 
@@ -39,14 +41,10 @@ public class LeagueEntity {
 
 	private Long playerCount;
 
-	private LocalDateTime createdAt;
-
-	private LocalDateTime modifiedAt;
-
-	public LeagueEntity(String name, String description, LocalDateTime leagueAt,
+	public LeagueEntity(String leagueName, String description, LocalDateTime leagueAt,
 		String tierLimit, LocalDateTime closedAt, String status, Long playerCount,
-		String matchType, LocalDateTime createdAt, LocalDateTime modifiedAt) {
-		this.name = name;
+		String matchType) {
+		this.leagueName = leagueName;
 		this.description = description;
 		this.leagueAt = leagueAt;
 		this.tierLimit = tierLimit;
@@ -54,7 +52,5 @@ public class LeagueEntity {
 		this.status = status;
 		this.playerCount = playerCount;
 		this.matchType = matchType;
-		this.createdAt = createdAt;
-		this.modifiedAt = modifiedAt;
 	}
 }

--- a/badminton-domain/src/main/java/org/badminton/domain/league/entity/LeagueEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/league/entity/LeagueEntity.java
@@ -41,9 +41,11 @@ public class LeagueEntity extends BaseTimeEntity {
 
 	private Long playerCount;
 
+	private String matchingRequirement;
+
 	public LeagueEntity(String leagueName, String description, LocalDateTime leagueAt,
 		String tierLimit, LocalDateTime closedAt, String status, Long playerCount,
-		String matchType) {
+		String matchType, String matchingRequirement) {
 		this.leagueName = leagueName;
 		this.description = description;
 		this.leagueAt = leagueAt;
@@ -52,5 +54,6 @@ public class LeagueEntity extends BaseTimeEntity {
 		this.status = status;
 		this.playerCount = playerCount;
 		this.matchType = matchType;
+		this.matchingRequirement = matchingRequirement;
 	}
 }

--- a/badminton-domain/src/main/java/org/badminton/domain/league/enums/LeagueStatus.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/league/enums/LeagueStatus.java
@@ -1,0 +1,6 @@
+package org.badminton.domain.league.enums;
+
+public enum LeagueStatus {
+	OPEN,
+	CLOSED;
+}

--- a/badminton-domain/src/main/java/org/badminton/domain/league/repository/LeagueRepository.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/league/repository/LeagueRepository.java
@@ -1,7 +1,10 @@
 package org.badminton.domain.league.repository;
 
+import java.util.Optional;
+
 import org.badminton.domain.league.entity.LeagueEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LeagueRepository extends JpaRepository<LeagueEntity, Long> {
+	Optional<LeagueEntity> findByLeagueName(String leagueName);
 }

--- a/badminton-domain/src/main/java/org/badminton/domain/match/entity/SinglesMatchEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/match/entity/SinglesMatchEntity.java
@@ -1,0 +1,48 @@
+package org.badminton.domain.match.entity;
+
+import org.badminton.domain.common.BaseTimeEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "singles_match")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class SinglesMatchEntity extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long singlesMatchId;
+
+	private Long leagueId;
+
+	private Long memberId;
+
+	private Long opponentId;
+
+	private String matchResult;
+
+	private Long myScore;
+
+	private Long opponentScore;
+
+	private Long setIndex;
+
+	public SinglesMatchEntity(Long leagueId, Long memberId, Long opponentId, String matchResult, Long myScore,
+		Long opponentScore, Long setIndex) {
+		this.leagueId = leagueId;
+		this.memberId = memberId;
+		this.opponentId = opponentId;
+		this.matchResult = matchResult;
+		this.myScore = myScore;
+		this.opponentScore = opponentScore;
+		this.setIndex = setIndex;
+	}
+}

--- a/badminton-domain/src/main/java/org/badminton/domain/match/repository/SinglesMatchRepository.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/match/repository/SinglesMatchRepository.java
@@ -1,0 +1,8 @@
+package org.badminton.domain.match.repository;
+
+import org.badminton.domain.match.entity.SinglesMatchEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SinglesMatchRepository extends JpaRepository<SinglesMatchEntity, Long> {
+
+}


### PR DESCRIPTION
## PR에 대한 설명 🔍
- errorCode 관련 코드 번호가 흩어져 있어서 코드 번호 중복 가능성이 있어서 공통으로 처리할 수 있는 타입을 추가했습니다.
- Create 기능 관련 Validator 추가, Response 정의

## 변경된 사항 📝
### Before
- 공통타입 미 정의로 인한 에러코드 중복 가능성 내제
- 경기 생성 후 Response 가 없었음

### After
- 공통타입 적용으로 하나의 클래스에서 에러코드 정의
- 경기 생성 후 Response 정의


## PR에서 중점적으로 확인되어야 하는 사항
- 코드 번호를 관리 할 수 있는 조금 더 나은 방법이 있다면 코멘트 남겨주세요
- Response가 적절한지 확인해 주셨으면 좋겠습니다.
