### PR TITLE
feat: member 관련 CRUD 구현

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/config/swagger/SwaggerConfig.java
+++ b/badminton-api/src/main/java/org/badminton/api/config/swagger/SwaggerConfig.java
@@ -9,14 +9,26 @@ import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 
 @Configuration
 public class SwaggerConfig {
 
 	@Bean
 	public OpenAPI openAPI() {
+		SecurityScheme securityScheme = new SecurityScheme()
+			.type(SecurityScheme.Type.HTTP)
+			.scheme("bearer")
+			.bearerFormat("JWT")
+			.in(SecurityScheme.In.HEADER)
+			.name("Authorization");
+
+		SecurityRequirement securityRequirement = new SecurityRequirement().addList("Authorization");
+
 		return new OpenAPI()
-			.components(new Components())
+			.components(new Components().addSecuritySchemes("Authorization", securityScheme))
+			.addSecurityItem(securityRequirement)
 			.info(apiInfo());
 	}
 
@@ -30,7 +42,5 @@ public class SwaggerConfig {
 	@Bean
 	public ModelResolver modelResolver(ObjectMapper objectMapper) {
 		return new ModelResolver(objectMapper);
-
 	}
-
 }

--- a/badminton-api/src/main/java/org/badminton/api/member/MemberController.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/MemberController.java
@@ -1,8 +1,14 @@
 package org.badminton.api.member;
 
+import org.badminton.api.member.model.dto.MemberUpdateRequest;
+import org.badminton.api.member.service.MemberService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,14 +19,17 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("v1/member")
 public class MemberController {
+
+	private final MemberService memberService;
 
 	@Operation(
 		summary = "로그아웃을 합니다",
 		description = "쿠키에서 JWT 토큰을 제거해 로그아웃을 합니다",
 		tags = {"Member"}
 	)
-	@PostMapping("/api/logout")
+	@PostMapping("/logout")
 	public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response) {
 		Cookie cookie = new Cookie("JWT", null);
 		cookie.setMaxAge(0);
@@ -33,6 +42,23 @@ public class MemberController {
 		}
 
 		return new ResponseEntity<>("Logout successful", HttpStatus.OK);
+	}
+
+	@Operation(
+		summary = "프로필 사진을 수정합니다",
+		description = "프로필 사진을 수정합니다",
+		tags = {"Member"}
+
+	)
+	@PatchMapping
+	public ResponseEntity<String> update(HttpServletRequest request, @RequestBody MemberUpdateRequest updateRequest) {
+		memberService.updateMember(request, updateRequest);
+		return new ResponseEntity<>("update successful", HttpStatus.OK);
+	}
+
+	@DeleteMapping
+	public ResponseEntity<String> delete(HttpServletRequest request, HttpServletResponse response) {
+		return new ResponseEntity<>("delete successful", HttpStatus.OK);
 	}
 
 }

--- a/badminton-api/src/main/java/org/badminton/api/member/MemberController.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/MemberController.java
@@ -1,13 +1,7 @@
 package org.badminton.api.member;
 
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
-
-import org.badminton.api.member.jwt.JwtUtil;
 import org.badminton.api.member.model.dto.MemberUpdateRequest;
 import org.badminton.api.member.service.MemberService;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,7 +12,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -30,54 +23,40 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MemberController {
 
-	//TODO: 리팩토링
-
 	private final MemberService memberService;
-	private final JwtUtil jwtUtil;
-	@Value("${NAVER_CLIENT_ID}")
-	private String naverClientId;
-
-	@Value("${NAVER_CLIENT_SECRET}")
-	private String naverClientSecret;
 
 	@Operation(
 		summary = "프로필 사진을 수정합니다",
 		description = "프로필 사진을 수정합니다",
 		tags = {"Member"}
-
 	)
 	@PatchMapping
-	public ResponseEntity<String> update(HttpServletRequest request, @RequestBody MemberUpdateRequest updateRequest) {
-		memberService.updateMember(request, updateRequest);
-		return new ResponseEntity<>("update successful", HttpStatus.OK);
+	public ResponseEntity<String> update(HttpServletRequest request,
+		@RequestBody MemberUpdateRequest updateRequest) {
+		try {
+			memberService.updateMember(request, updateRequest);
+			return new ResponseEntity<>("update successful", HttpStatus.OK);
+		} catch (IllegalArgumentException e) {
+			return new ResponseEntity<>("update failed", HttpStatus.BAD_REQUEST);
+		} catch (Exception e) {
+			return new ResponseEntity<>("update failed", HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+
 	}
 
+	@Operation(
+		summary = "회원 탈퇴를 합니다",
+		description = "멤버 필드의 isDeleted 를 true 로 변경합니다",
+		tags = {"Member"}
+	)
 	@DeleteMapping
 	public ResponseEntity<String> delete(HttpServletRequest request, HttpServletResponse response) {
-		String jwtToken = jwtUtil.extractJwtTokenFromRequest(request);
-		if (jwtToken == null) {
-			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Jwt 토큰을 찾을 수 없습니다");
+		try {
+			memberService.deleteMember(request, response);
+			return new ResponseEntity<>("delete successful", HttpStatus.OK);
+		} catch (Exception e) {
+			return new ResponseEntity<>("delete failed", HttpStatus.INTERNAL_SERVER_ERROR);
 		}
-
-		String accessToken = jwtUtil.getAccessToken(jwtToken);
-		String registrationId = jwtUtil.getRegistrationId(jwtToken);
-
-		// 연결 끊기 로직 (Google, Naver, Kakao)
-		if ("google".equals(registrationId)) {
-			googleUnlink(accessToken);
-		} else if ("naver".equals(registrationId)) {
-			naverUnlink(accessToken);
-		} else if ("kakao".equals(registrationId)) {
-			kakaoUnlink(accessToken);
-		}
-		memberService.markAsDeleted(jwtUtil.getProviderId(jwtToken));
-
-		Cookie cookie = new Cookie("JWT", null);
-		cookie.setMaxAge(0);
-		cookie.setPath("/");
-		response.addCookie(cookie);
-
-		return ResponseEntity.ok("탈퇴 성공, OAuth 연결끊기 성공!");
 	}
 
 	@Operation(
@@ -86,89 +65,9 @@ public class MemberController {
 		tags = {"Member"}
 	)
 	@PostMapping("/logout")
-	public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
-
-		String jwtToken = jwtUtil.extractJwtTokenFromRequest(request);
-		if (jwtToken == null) {
-			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Jwt 토큰을 찾을 수 없습니다");
-		}
-
-		String accessToken = jwtUtil.getAccessToken(jwtToken);
-		String registrationId = jwtUtil.getRegistrationId(jwtToken);
-
-		if ("google".equals(registrationId)) {
-			googleUnlink(accessToken);
-		} else if ("naver".equals(registrationId)) {
-			naverUnlink(accessToken);
-		} else if ("kakao".equals(registrationId)) {
-			kakaoUnlink(accessToken);
-		}
-
-		Cookie cookie = new Cookie("JWT", null);
-		cookie.setMaxAge(0);
-		cookie.setPath("/");
-		response.addCookie(cookie);
-
+	public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response) {
+		memberService.logoutMember(request, response);
 		return ResponseEntity.ok("로그아웃 성공 , OAuth 연결끊기 성공!");
-	}
-
-	private void naverUnlink(String accessToken) {
-		String revokeUrl = String.format(
-			"https://nid.naver.com/oauth2.0/token?grant_type=delete&client_id=%s&client_secret=%s&access_token=%s&service_provider=NAVER",
-			naverClientId, naverClientSecret, accessToken);
-		try {
-			URL url = new URL(revokeUrl);
-			HttpURLConnection connection = (HttpURLConnection)url.openConnection();
-			connection.setRequestMethod("GET");
-			connection.setRequestProperty("Content-Length", "0");
-
-			int responseCode = connection.getResponseCode();
-			if (responseCode == 200) {
-				log.info("Naver account successfully unlinked");
-			} else {
-				log.error("Failed to unlink Naver account, response code: {}", responseCode);
-			}
-		} catch (IOException e) {
-			log.error("Error occurred while unlinking Naver account", e);
-		}
-	}
-
-	private void kakaoUnlink(String accessToken) {
-		String revokeUrl = "https://kapi.kakao.com/v1/user/unlink";
-		try {
-			URL url = new URL(revokeUrl);
-			HttpURLConnection connection = (HttpURLConnection)url.openConnection();
-			connection.setRequestMethod("POST");
-			connection.setRequestProperty("Authorization", "Bearer " + accessToken);
-
-			int responseCode = connection.getResponseCode();
-			if (responseCode == 200) {
-				log.info("Kakao account successfully unlinked");
-			} else {
-				log.error("Failed to unlink Kakao account, response code: {}", responseCode);
-			}
-		} catch (IOException e) {
-			log.error("Error occurred while unlinking Kakao account", e);
-		}
-	}
-
-	private void googleUnlink(String accessToken) {
-		String revokeUrl = "https://accounts.google.com/o/oauth2/revoke?token=" + accessToken;
-		try {
-			URL url = new URL(revokeUrl);
-			HttpURLConnection connection = (HttpURLConnection)url.openConnection();
-			connection.setRequestMethod("GET"); // GET 요청으로 변경
-			connection.setRequestProperty("Content-Length", "0"); // Content-Length 설정
-
-			int responseCode = connection.getResponseCode();
-			if (responseCode == 200) {
-				log.info("Google account successfully unlinked");
-			} else {
-				log.error("Failed to unlink Google account, response code: {}", responseCode);
-			}
-		} catch (IOException e) {
-			log.error("Error occurred while unlinking Google account", e);
-		}
 	}
 
 }

--- a/badminton-api/src/main/java/org/badminton/api/member/MemberController.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/MemberController.java
@@ -54,6 +54,8 @@ public class MemberController {
 		try {
 			memberService.deleteMember(request, response);
 			return new ResponseEntity<>("delete successful", HttpStatus.OK);
+		} catch (IllegalArgumentException e) {
+			return new ResponseEntity<>("delete failed", HttpStatus.BAD_REQUEST);
 		} catch (Exception e) {
 			return new ResponseEntity<>("delete failed", HttpStatus.INTERNAL_SERVER_ERROR);
 		}
@@ -66,8 +68,15 @@ public class MemberController {
 	)
 	@PostMapping("/logout")
 	public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response) {
-		memberService.logoutMember(request, response);
-		return ResponseEntity.ok("로그아웃 성공 , OAuth 연결끊기 성공!");
+		try {
+			memberService.logoutMember(request, response);
+			return ResponseEntity.ok("로그아웃 성공 , OAuth 연결끊기 성공!");
+		} catch (IllegalArgumentException e) {
+			return new ResponseEntity<>("logout failed", HttpStatus.BAD_REQUEST);
+		} catch (Exception e) {
+			return new ResponseEntity<>("logout failed", HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+
 	}
 
 }

--- a/badminton-api/src/main/java/org/badminton/api/member/MemberController.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/MemberController.java
@@ -1,7 +1,13 @@
 package org.badminton.api.member;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.badminton.api.member.jwt.JwtUtil;
 import org.badminton.api.member.model.dto.MemberUpdateRequest;
 import org.badminton.api.member.service.MemberService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,13 +22,23 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("v1/member")
+@Slf4j
 public class MemberController {
 
+	//TODO: 리팩토링
+
 	private final MemberService memberService;
+	private final JwtUtil jwtUtil;
+	@Value("${NAVER_CLIENT_ID}")
+	private String naverClientId;
+
+	@Value("${NAVER_CLIENT_SECRET}")
+	private String naverClientSecret;
 
 	@Operation(
 		summary = "로그아웃을 합니다",
@@ -30,18 +46,89 @@ public class MemberController {
 		tags = {"Member"}
 	)
 	@PostMapping("/logout")
-	public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response) {
+	public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
+
+		String jwtToken = jwtUtil.extractJwtTokenFromRequest(request);
+		if (jwtToken == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Jwt 토큰을 찾을 수 없습니다");
+		}
+
+		String accessToken = jwtUtil.getAccessToken(jwtToken);
+		String registrationId = jwtUtil.getRegistrationId(jwtToken);
+
+		if ("google".equals(registrationId)) {
+			googleUnlink(accessToken);
+		} else if ("naver".equals(registrationId)) {
+			naverUnlink(accessToken);
+		} else if ("kakao".equals(registrationId)) {
+			kakaoUnlink(accessToken);
+		}
+
 		Cookie cookie = new Cookie("JWT", null);
 		cookie.setMaxAge(0);
 		cookie.setPath("/");
-		cookie.setHttpOnly(true);
 		response.addCookie(cookie);
 
-		if (request.getSession(false) != null) {
-			request.getSession().invalidate();
-		}
+		return ResponseEntity.ok("로그아웃 성공 , OAuth 연결끊기 성공!");
+	}
 
-		return new ResponseEntity<>("Logout successful", HttpStatus.OK);
+	private void naverUnlink(String accessToken) {
+		String revokeUrl = String.format(
+			"https://nid.naver.com/oauth2.0/token?grant_type=delete&client_id=%s&client_secret=%s&access_token=%s&service_provider=NAVER",
+			naverClientId, naverClientSecret, accessToken);
+		try {
+			URL url = new URL(revokeUrl);
+			HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+			connection.setRequestMethod("GET");
+			connection.setRequestProperty("Content-Length", "0");
+
+			int responseCode = connection.getResponseCode();
+			if (responseCode == 200) {
+				log.info("Naver account successfully unlinked");
+			} else {
+				log.error("Failed to unlink Naver account, response code: {}", responseCode);
+			}
+		} catch (IOException e) {
+			log.error("Error occurred while unlinking Naver account", e);
+		}
+	}
+
+	private void kakaoUnlink(String accessToken) {
+		String revokeUrl = "https://kapi.kakao.com/v1/user/unlink";
+		try {
+			URL url = new URL(revokeUrl);
+			HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+			connection.setRequestMethod("POST");
+			connection.setRequestProperty("Authorization", "Bearer " + accessToken);
+
+			int responseCode = connection.getResponseCode();
+			if (responseCode == 200) {
+				log.info("Kakao account successfully unlinked");
+			} else {
+				log.error("Failed to unlink Kakao account, response code: {}", responseCode);
+			}
+		} catch (IOException e) {
+			log.error("Error occurred while unlinking Kakao account", e);
+		}
+	}
+
+	private void googleUnlink(String accessToken) {
+		String revokeUrl = "https://accounts.google.com/o/oauth2/revoke?token=" + accessToken;
+		try {
+			URL url = new URL(revokeUrl);
+			HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+			connection.setRequestMethod("GET"); // GET 요청으로 변경
+			connection.setRequestProperty("Content-Length", "0"); // Content-Length 설정
+
+			int responseCode = connection.getResponseCode();
+			if (responseCode == 200) {
+				log.info("Google account successfully unlinked");
+			} else {
+				log.error("Failed to unlink Google account, response code: {}", responseCode);
+			}
+		} catch (IOException e) {
+			log.error("Error occurred while unlinking Google account", e);
+		}
 	}
 
 	@Operation(

--- a/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtFilter.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtFilter.java
@@ -74,12 +74,13 @@ public class JwtFilter extends OncePerRequestFilter {
 		String email = jwtUtil.getEmail(token);
 		String profileImage = jwtUtil.getProfileImage(token);
 		String accessToken = jwtUtil.getAccessToken(token);
+		String registrationId = jwtUtil.getRegistrationId(token);
 
 		MemberResponse memberResponse = new MemberResponse(MemberAuthorization.AUTHORIZATION_USER.name(), name, email,
 			providerId, profileImage);
 		log.info("memberDto: {}", memberResponse);
 
-		CustomOAuth2Member customOAuth2Member = new CustomOAuth2Member(memberResponse, accessToken);
+		CustomOAuth2Member customOAuth2Member = new CustomOAuth2Member(memberResponse, accessToken, registrationId);
 
 		Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2Member, null,
 			customOAuth2Member.getAuthorities());

--- a/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtFilter.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtFilter.java
@@ -73,12 +73,13 @@ public class JwtFilter extends OncePerRequestFilter {
 		String name = jwtUtil.getName(token);
 		String email = jwtUtil.getEmail(token);
 		String profileImage = jwtUtil.getProfileImage(token);
+		String accessToken = jwtUtil.getAccessToken(token);
 
 		MemberResponse memberResponse = new MemberResponse(MemberAuthorization.AUTHORIZATION_USER.name(), name, email,
 			providerId, profileImage);
 		log.info("memberDto: {}", memberResponse);
 
-		CustomOAuth2Member customOAuth2Member = new CustomOAuth2Member(memberResponse);
+		CustomOAuth2Member customOAuth2Member = new CustomOAuth2Member(memberResponse, accessToken);
 
 		Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2Member, null,
 			customOAuth2Member.getAuthorities());

--- a/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtFilter.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtFilter.java
@@ -72,9 +72,10 @@ public class JwtFilter extends OncePerRequestFilter {
 		log.info("JWT authorization: {}", authorization);
 		String name = jwtUtil.getName(token);
 		String email = jwtUtil.getEmail(token);
+		String profileImage = jwtUtil.getProfileImage(token);
 
 		MemberResponse memberResponse = new MemberResponse(MemberAuthorization.AUTHORIZATION_USER.name(), name, email,
-			providerId);
+			providerId, profileImage);
 		log.info("memberDto: {}", memberResponse);
 
 		CustomOAuth2Member customOAuth2Member = new CustomOAuth2Member(memberResponse);

--- a/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtFilter.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtFilter.java
@@ -37,25 +37,15 @@ public class JwtFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
 
-		String JWT = null;
-		Cookie[] cookies = request.getCookies();
-		for (Cookie cookie : cookies) {
-			log.info("cookie: {}", cookie.getName());
-			if (cookie.getName().equals("JWT")) {
-				JWT = cookie.getValue();
-			}
-		}
+		String jwtToken = jwtUtil.extractJwtTokenFromRequest(request);
 
-		if (JWT == null) {
+		if (jwtToken == null) {
 			log.info("JWT cookie not found");
 			filterChain.doFilter(request, response);
-
 			return;
 		}
 
-		String token = JWT;
-
-		if (jwtUtil.isExpired(token)) {
+		if (jwtUtil.isExpired(jwtToken)) {
 			log.info("JWT token expired");
 			Cookie expiredCookie = new Cookie("JWT", null);
 			expiredCookie.setMaxAge(0);
@@ -67,14 +57,14 @@ public class JwtFilter extends OncePerRequestFilter {
 			return;
 		}
 
-		String providerId = jwtUtil.getProviderId(token);
-		String authorization = jwtUtil.getAuthorization(token);
+		String providerId = jwtUtil.getProviderId(jwtToken);
+		String authorization = jwtUtil.getAuthorization(jwtToken);
 		log.info("JWT authorization: {}", authorization);
-		String name = jwtUtil.getName(token);
-		String email = jwtUtil.getEmail(token);
-		String profileImage = jwtUtil.getProfileImage(token);
-		String accessToken = jwtUtil.getAccessToken(token);
-		String registrationId = jwtUtil.getRegistrationId(token);
+		String name = jwtUtil.getName(jwtToken);
+		String email = jwtUtil.getEmail(jwtToken);
+		String profileImage = jwtUtil.getProfileImage(jwtToken);
+		String accessToken = jwtUtil.getAccessToken(jwtToken);
+		String registrationId = jwtUtil.getRegistrationId(jwtToken);
 
 		MemberResponse memberResponse = new MemberResponse(MemberAuthorization.AUTHORIZATION_USER.name(), name, email,
 			providerId, profileImage);

--- a/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtUtil.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtUtil.java
@@ -18,6 +18,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class JwtUtil {
 
+	//TODO: refresh 토큰 추가
+
 	private final SecretKey secretKey;
 
 	public JwtUtil(@Value("${spring.jwt.secret}") String secret) {

--- a/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtUtil.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtUtil.java
@@ -44,6 +44,15 @@ public class JwtUtil {
 			.get("email", String.class);
 	}
 
+	public String getProfileImage(String token) {
+		return Jwts.parser()
+			.verifyWith(secretKey)
+			.build()
+			.parseSignedClaims(token)
+			.getPayload()
+			.get("profileImage", String.class);
+	}
+
 	public String getName(String token) {
 
 		return Jwts.parser()
@@ -75,13 +84,15 @@ public class JwtUtil {
 			.before(new Date());
 	}
 
-	public String createJwt(String providerId, String authorization, String name, String email, Long expiredMs) {
+	public String createJwt(String providerId, String authorization, String name, String email, String profileImage,
+		Long expiredMs) {
 
 		return Jwts.builder()
 			.claim("providerId", providerId)
 			.claim("authorization", authorization)
 			.claim("name", name)
 			.claim("email", email) // providerId, role, name, email 을 클레임(데이터)로 추가
+			.claim("profileImage", profileImage)
 			.issuedAt(new Date(System.currentTimeMillis())) // 토큰 발행 시각 설정
 			.expiration(new Date(System.currentTimeMillis() + expiredMs)) // 만료 시각 설정 (현재 시각 + expiredMs)
 			.signWith(secretKey) // secretKey 로 서명

--- a/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtUtil.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtUtil.java
@@ -29,17 +29,8 @@ public class JwtUtil {
 	}
 
 	public String extractProviderIdFromRequest(HttpServletRequest request) {
-		Cookie[] cookies = request.getCookies();
-		if (cookies != null) {
-			for (Cookie cookie : cookies) {
-				if ("JWT".equals(cookie.getName())) {
-					String jwtToken = cookie.getValue();
-					log.info("JWT Token from Cookie: {}", jwtToken);
-					return getProviderId(jwtToken);
-				}
-			}
-		}
-		throw new IllegalArgumentException("JWT 쿠키가 없습니다");
+		String JwtToken = extractJwtTokenFromRequest(request);
+		return getProviderId(JwtToken);
 	}
 
 	public String extractJwtTokenFromRequest(HttpServletRequest request) {
@@ -53,72 +44,42 @@ public class JwtUtil {
 		}
 		throw new IllegalArgumentException("JWT 쿠키가 없습니다");
 	}
-
+	
 	public String getProviderId(String token) {
-
-		return Jwts.parser()
-			.verifyWith(secretKey) // secretKey 를 사용해서 JWT 서명을 검증
-			.build()
-			.parseSignedClaims(token) // 서명된 JWT 를 파싱하고, 데이터(클레임)를 추출
-			.getPayload()
-			.get("providerId", String.class); // "providerId" 클레임을 String 으로 변환
+		return getDetail(token, "providerId");
 	}
 
 	public String getEmail(String token) {
-
-		return Jwts.parser()
-			.verifyWith(secretKey)
-			.build()
-			.parseSignedClaims(token)
-			.getPayload()
-			.get("email", String.class);
+		return getDetail(token, "email");
 	}
 
 	public String getProfileImage(String token) {
-		return Jwts.parser()
-			.verifyWith(secretKey)
-			.build()
-			.parseSignedClaims(token)
-			.getPayload()
-			.get("profileImage", String.class);
+		return getDetail(token, "profileImage");
 	}
 
 	public String getName(String token) {
-
-		return Jwts.parser()
-			.verifyWith(secretKey)
-			.build()
-			.parseSignedClaims(token)
-			.getPayload()
-			.get("name", String.class);
+		return getDetail(token, "name");
 	}
 
 	public String getAuthorization(String token) {
-
-		return Jwts.parser()
-			.verifyWith(secretKey)
-			.build()
-			.parseSignedClaims(token)
-			.getPayload()
-			.get("authorization", String.class);
+		return getDetail(token, "authorization");
 	}
 
 	public String getAccessToken(String token) {
-		return Jwts.parser()
-			.verifyWith(secretKey)
-			.build()
-			.parseSignedClaims(token)
-			.getPayload()
-			.get("accessToken", String.class);
+		return getDetail(token, "accessToken");
 	}
 
 	public String getRegistrationId(String token) {
+		return getDetail(token, "registrationId");
+	}
+
+	public String getDetail(String token, String detail) {
 		return Jwts.parser()
 			.verifyWith(secretKey)
 			.build()
 			.parseSignedClaims(token)
 			.getPayload()
-			.get("registrationId", String.class);
+			.get(detail, String.class);
 	}
 
 	public Boolean isExpired(String token) {

--- a/badminton-api/src/main/java/org/badminton/api/member/model/dto/CustomOAuth2Member.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/model/dto/CustomOAuth2Member.java
@@ -43,4 +43,8 @@ public class CustomOAuth2Member implements OAuth2User {
 	public String getEmail() {
 		return memberResponse.email();
 	}
+
+	public String getProfileImage() {
+		return memberResponse.profileImage();
+	}
 }

--- a/badminton-api/src/main/java/org/badminton/api/member/model/dto/CustomOAuth2Member.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/model/dto/CustomOAuth2Member.java
@@ -16,6 +16,8 @@ public class CustomOAuth2Member implements OAuth2User {
 	private final MemberResponse memberResponse;
 	@Getter
 	private final String accessToken;
+	@Getter
+	private final String registrationId;
 
 	@Override
 	public Map<String, Object> getAttributes() {

--- a/badminton-api/src/main/java/org/badminton/api/member/model/dto/CustomOAuth2Member.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/model/dto/CustomOAuth2Member.java
@@ -7,12 +7,15 @@ import java.util.Map;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class CustomOAuth2Member implements OAuth2User {
 
 	private final MemberResponse memberResponse;
+	@Getter
+	private final String accessToken;
 
 	@Override
 	public Map<String, Object> getAttributes() {
@@ -47,4 +50,5 @@ public class CustomOAuth2Member implements OAuth2User {
 	public String getProfileImage() {
 		return memberResponse.profileImage();
 	}
+
 }

--- a/badminton-api/src/main/java/org/badminton/api/member/model/dto/GoogleResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/model/dto/GoogleResponse.java
@@ -28,4 +28,8 @@ public class GoogleResponse implements OAuthResponse {
 	public String getName() {
 		return attribute.get("name").toString();
 	}
+
+	public String getProfileImage() {
+		return attribute.get("picture").toString();
+	}
 }

--- a/badminton-api/src/main/java/org/badminton/api/member/model/dto/KakaoResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/model/dto/KakaoResponse.java
@@ -6,10 +6,12 @@ public class KakaoResponse implements OAuthResponse {
 
 	private final Map<String, Object> attributes;
 	private final Map<String, Object> kakaoAccount;
+	private final Map<String, Object> profile;
 
 	public KakaoResponse(Map<String, Object> attributes) {
 		this.attributes = attributes;
 		this.kakaoAccount = (Map<String, Object>)attributes.get("kakao_account");
+		this.profile = (Map<String, Object>)kakaoAccount.get("profile");
 	}
 
 	@Override
@@ -32,4 +34,10 @@ public class KakaoResponse implements OAuthResponse {
 		Map<String, Object> profile = (Map<String, Object>)kakaoAccount.get("profile");
 		return profile.get("nickname").toString();
 	}
+
+	@Override
+	public String getProfileImage() {
+		return profile.get("profile_image_url").toString();
+	}
+
 }

--- a/badminton-api/src/main/java/org/badminton/api/member/model/dto/MemberRequest.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/model/dto/MemberRequest.java
@@ -11,7 +11,7 @@ public record MemberRequest(
 	@Schema(description = "회원 역할", example = "AUTHORIZATION_USER")
 	MemberAuthorization authorization,
 
-	@Schema(description = "회원 이름", example = "이선우")
+	@Schema(description = "회원 이름", example = "이영희")
 	String name,
 
 	@Schema(description = "oAuth 로그인 이메일", example = "qosle@naver.com")
@@ -20,7 +20,7 @@ public record MemberRequest(
 	@Schema(description = "oAuth 제공 ID", example = "1070449979547641023123")
 	String providerId,
 
-	@Schema(description = "oAuth 이미지", example = "1070449979547641023123")
+	@Schema(description = "프로필 사진", example = "1070449979547641023123")
 	String profileImage
 ) {
 

--- a/badminton-api/src/main/java/org/badminton/api/member/model/dto/MemberRequest.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/model/dto/MemberRequest.java
@@ -18,12 +18,15 @@ public record MemberRequest(
 	String email,
 
 	@Schema(description = "oAuth 제공 ID", example = "1070449979547641023123")
-	String providerId
+	String providerId,
+
+	@Schema(description = "oAuth 이미지", example = "1070449979547641023123")
+	String profileImage
 ) {
 
 	public static MemberEntity memberRequestToEntity(MemberRequest memberRequest) {
 		return new MemberEntity(memberRequest.email(), memberRequest.name(), memberRequest.providerId(),
-			memberRequest.authorization());
+			memberRequest.profileImage, memberRequest.authorization());
 	}
 }
 

--- a/badminton-api/src/main/java/org/badminton/api/member/model/dto/MemberResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/model/dto/MemberResponse.java
@@ -17,12 +17,16 @@ public record MemberResponse(
 	String email,
 
 	@Schema(description = "oAuth 제공 ID", example = "1070449979547641023123")
-	String providerId
+	String providerId,
+
+	@Schema(description = "oAuth 제공 이미지", example = "1070449979547641023123")
+	String profileImage
+
 ) {
 
 	public static MemberResponse memberEntityToResponse(MemberEntity memberEntity) {
 		return new MemberResponse(memberEntity.getAuthorization(), memberEntity.getName(), memberEntity.getEmail(),
-			memberEntity.getProviderId());
+			memberEntity.getProviderId(), memberEntity.getProfileImage());
 	}
 }
 

--- a/badminton-api/src/main/java/org/badminton/api/member/model/dto/MemberUpdateRequest.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/model/dto/MemberUpdateRequest.java
@@ -1,0 +1,13 @@
+package org.badminton.api.member.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Schema(description = "회원 수정 DTO")
+@Getter
+public class MemberUpdateRequest {
+	
+	@Schema(description = "프로필 사진", example = "http://img1.kakaocdn.net/thumb/R640x640.q70/?fname=http://t1.kakaocdn.net/account_images/default_profile.jpeg")
+	String profileImage;
+
+}

--- a/badminton-api/src/main/java/org/badminton/api/member/model/dto/NaverResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/model/dto/NaverResponse.java
@@ -30,4 +30,9 @@ public class NaverResponse implements OAuthResponse {
 	public String getName() {
 		return attribute.get("name").toString();
 	}
+
+	public String getProfileImage() {
+		return attribute.get("profile_image").toString();
+	}
+
 }

--- a/badminton-api/src/main/java/org/badminton/api/member/model/dto/OAuthResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/model/dto/OAuthResponse.java
@@ -9,4 +9,6 @@ public interface OAuthResponse {
 	String getEmail(); // 이메일
 
 	String getName(); // 설정한 이름
+
+	String getProfileImage();
 }

--- a/badminton-api/src/main/java/org/badminton/api/member/oauth2/CustomSuccessHandler.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/oauth2/CustomSuccessHandler.java
@@ -44,6 +44,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		log.info("profileImage: {}", profileImage);
 
 		String accessToken = customUserDetails.getAccessToken();
+		String registrationId = customUserDetails.getRegistrationId();
 
 		Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
 		Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
@@ -51,7 +52,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		String authorization = auth.getAuthority();
 
 		String token = jwtUtil.createJwt(providerId, authorization, name, email, profileImage,
-			accessToken, 60 * 60 * 60L); // 초 * 분 * 시
+			accessToken, registrationId, 24 * 60 * 60 * 1000L); // 초 * 분 * 시
 
 		// response.setHeader("Authorization", "Bearer " + token);
 

--- a/badminton-api/src/main/java/org/badminton/api/member/oauth2/CustomSuccessHandler.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/oauth2/CustomSuccessHandler.java
@@ -43,13 +43,15 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		String profileImage = customUserDetails.getProfileImage();
 		log.info("profileImage: {}", profileImage);
 
+		String accessToken = customUserDetails.getAccessToken();
+
 		Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
 		Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
 		GrantedAuthority auth = iterator.next();
 		String authorization = auth.getAuthority();
 
 		String token = jwtUtil.createJwt(providerId, authorization, name, email, profileImage,
-			60 * 60 * 60L); // 초 * 분 * 시
+			accessToken, 60 * 60 * 60L); // 초 * 분 * 시
 
 		// response.setHeader("Authorization", "Bearer " + token);
 

--- a/badminton-api/src/main/java/org/badminton/api/member/oauth2/CustomSuccessHandler.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/oauth2/CustomSuccessHandler.java
@@ -40,12 +40,16 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 		String email = customUserDetails.getEmail();
 
+		String profileImage = customUserDetails.getProfileImage();
+		log.info("profileImage: {}", profileImage);
+
 		Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
 		Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
 		GrantedAuthority auth = iterator.next();
 		String authorization = auth.getAuthority();
 
-		String token = jwtUtil.createJwt(providerId, authorization, name, email, 60 * 60 * 60L); // 초 * 분 * 시
+		String token = jwtUtil.createJwt(providerId, authorization, name, email, profileImage,
+			60 * 60 * 60L); // 초 * 분 * 시
 
 		// response.setHeader("Authorization", "Bearer " + token);
 

--- a/badminton-api/src/main/java/org/badminton/api/member/service/CustomOAuth2MemberService.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/service/CustomOAuth2MemberService.java
@@ -45,6 +45,8 @@ public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
 				return null;
 			}
 		}
+		log.info("attribute:{}", oAuth2User.getAttributes());
+
 		// String providerId = oAuth2Response.getProvider() + " " + oAuth2Response.getProviderId();
 		String providerId = oAuth2Response.getProviderId();
 		MemberEntity existData = memberRepository.findByProviderId(providerId);
@@ -53,7 +55,7 @@ public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
 
 			MemberRequest memberRequest = new MemberRequest(MemberAuthorization.AUTHORIZATION_USER,
 				oAuth2Response.getName(),
-				oAuth2Response.getEmail(), providerId);
+				oAuth2Response.getEmail(), providerId, oAuth2Response.getProfileImage());
 
 			MemberEntity memberEntity = memberRequestToEntity(memberRequest);
 

--- a/badminton-api/src/main/java/org/badminton/api/member/service/CustomOAuth2MemberService.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/service/CustomOAuth2MemberService.java
@@ -74,6 +74,11 @@ public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
 			// return new CustomOAuth2Member(memberResponse);
 		} else {
 
+			if (existData.isDeleted()) {
+				existData.reactivateMember();
+				memberRepository.save(existData);
+			}
+
 			// memberRepository.save(existData);
 
 			memberResponse = memberEntityToResponse(existData);

--- a/badminton-api/src/main/java/org/badminton/api/member/service/CustomOAuth2MemberService.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/service/CustomOAuth2MemberService.java
@@ -87,10 +87,11 @@ public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
 			memberResponse.email(),
 			memberResponse.profileImage(),
 			accessToken,
-			60 * 60 * 1000L
+			registrationId,
+			24 * 60 * 60 * 1000L
 		);
 
 		log.info("jwt: {}", jwt);
-		return new CustomOAuth2Member(memberResponse, accessToken);
+		return new CustomOAuth2Member(memberResponse, accessToken, registrationId);
 	}
 }

--- a/badminton-api/src/main/java/org/badminton/api/member/service/MemberService.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/service/MemberService.java
@@ -1,0 +1,32 @@
+package org.badminton.api.member.service;
+
+import org.badminton.api.member.jwt.JwtUtil;
+import org.badminton.api.member.model.dto.MemberResponse;
+import org.badminton.api.member.model.dto.MemberUpdateRequest;
+import org.badminton.domain.member.entity.MemberEntity;
+import org.badminton.domain.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+	private final JwtUtil jwtUtil;
+
+	public MemberResponse updateMember(HttpServletRequest request, MemberUpdateRequest memberUpdateRequest) {
+
+		String providerId = jwtUtil.extractProviderIdFromRequest(request);
+		MemberEntity memberEntity = memberRepository.findByProviderId(providerId);
+
+		memberEntity.updateMember(memberUpdateRequest.getProfileImage());
+		memberRepository.save(memberEntity);
+		return MemberResponse.memberEntityToResponse(memberEntity);
+	}
+
+}

--- a/badminton-api/src/main/java/org/badminton/api/member/service/MemberService.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/service/MemberService.java
@@ -1,19 +1,23 @@
 package org.badminton.api.member.service;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.badminton.api.member.jwt.JwtUtil;
-import org.badminton.api.member.model.dto.MemberResponse;
 import org.badminton.api.member.model.dto.MemberUpdateRequest;
-import org.badminton.domain.member.entity.MemberAuthorization;
 import org.badminton.domain.member.entity.MemberEntity;
 import org.badminton.domain.member.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -24,18 +28,63 @@ public class MemberService {
 
 	private final MemberRepository memberRepository;
 	private final JwtUtil jwtUtil;
+	@Value("${NAVER_CLIENT_ID}")
+	private String naverClientId;
 
-	public MemberResponse updateMember(HttpServletRequest request, MemberUpdateRequest memberUpdateRequest) {
+	@Value("${NAVER_CLIENT_SECRET}")
+	private String naverClientSecret;
 
+	public void updateMember(HttpServletRequest request, MemberUpdateRequest memberUpdateRequest) {
 		String providerId = jwtUtil.extractProviderIdFromRequest(request);
+		if (providerId == null) {
+			throw new IllegalArgumentException("jwt provider id is null");
+		}
 		MemberEntity memberEntity = memberRepository.findByProviderId(providerId);
+		if (memberEntity == null) {
+			throw new IllegalArgumentException("Member not found");
+		}
 
 		memberEntity.updateMember(memberUpdateRequest.getProfileImage());
 		memberRepository.save(memberEntity);
-		return MemberResponse.memberEntityToResponse(memberEntity);
 	}
 
-	public void markAsDeleted(String providerId) {
+	public void logoutMember(HttpServletRequest request, HttpServletResponse response) {
+		unLinkOAuth(request);
+		Cookie cookie = new Cookie("JWT", null);
+		cookie.setMaxAge(0);
+		cookie.setPath("/");
+		response.addCookie(cookie);
+	}
+
+	public void deleteMember(HttpServletRequest request, HttpServletResponse response) {
+		String jwtToken = unLinkOAuth(request);
+		changeIsDeleted(jwtUtil.getProviderId(jwtToken));
+		Cookie cookie = new Cookie("JWT", null);
+		cookie.setMaxAge(0);
+		cookie.setPath("/");
+		response.addCookie(cookie);
+	}
+
+	private String unLinkOAuth(HttpServletRequest request) {
+		String jwtToken = jwtUtil.extractJwtTokenFromRequest(request);
+		if (jwtToken == null) {
+			throw new IllegalArgumentException("Invalid JWT token");
+		}
+		String accessToken = jwtUtil.getAccessToken(jwtToken);
+		String registrationId = jwtUtil.getRegistrationId(jwtToken);
+
+		// 연결 끊기 로직 (Google, Naver, Kakao)
+		if ("google".equals(registrationId)) {
+			googleUnlink(accessToken);
+		} else if ("naver".equals(registrationId)) {
+			naverUnlink(accessToken);
+		} else if ("kakao".equals(registrationId)) {
+			kakaoUnlink(accessToken);
+		}
+		return jwtToken;
+	}
+
+	public void changeIsDeleted(String providerId) {
 		MemberEntity memberEntity = memberRepository.findByProviderId(providerId);
 
 		memberEntity.deleteMember();
@@ -43,32 +92,11 @@ public class MemberService {
 		log.info("Member marked as deleted: {}", providerId);
 	}
 
-	public MemberEntity handleLogin(String providerId, String email, String name, String profileImage,
-		String authorization) {
-		MemberEntity memberEntity = memberRepository.findByProviderId(providerId);
-
-		// 기존 회원이 존재하고 isDeleted가 true인 경우, 계정을 다시 활성화
-		if (memberEntity != null) {
-			if (memberEntity.isDeleted()) {
-				memberEntity.reactivateMember();
-				log.info("Reactivating member: {}", providerId);
-			}
-			memberEntity.updateMember(profileImage);
-		} else {
-			// 신규 회원 생성
-			memberEntity = new MemberEntity(email, name, providerId, profileImage,
-				MemberAuthorization.valueOf(authorization));
-		}
-
-		memberRepository.save(memberEntity);
-		return memberEntity;
-	}
-
 	@Scheduled(cron = "0 0 0 * * *")
-	public void DeleteMembers() {
+	public void deleteMembersFromDb() {
 		log.info("Deleting members");
 
-		List<MemberEntity> deleteMembers = memberRepository.findAllByIsAndMemberDeletedTrue();
+		List<MemberEntity> deleteMembers = memberRepository.findAllByIsDeletedTrue();
 
 		for (MemberEntity memberEntity : deleteMembers) {
 			LocalDateTime lastConnectionAt = memberEntity.getLastConnectionAt();
@@ -80,6 +108,65 @@ public class MemberService {
 			}
 		}
 		log.info("Deleting members");
+	}
+
+	public void naverUnlink(String accessToken) {
+		String revokeUrl = String.format(
+			"https://nid.naver.com/oauth2.0/token?grant_type=delete&client_id=%s&client_secret=%s&access_token=%s&service_provider=NAVER",
+			naverClientId, naverClientSecret, accessToken);
+		try {
+			URL url = new URL(revokeUrl);
+			HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+			connection.setRequestMethod("GET");
+			connection.setRequestProperty("Content-Length", "0");
+
+			int responseCode = connection.getResponseCode();
+			if (responseCode == 200) {
+				log.info("Naver account successfully unlinked");
+			} else {
+				log.error("Failed to unlink Naver account, response code: {}", responseCode);
+			}
+		} catch (IOException e) {
+			log.error("Error occurred while unlinking Naver account", e);
+		}
+	}
+
+	public void kakaoUnlink(String accessToken) {
+		String revokeUrl = "https://kapi.kakao.com/v1/user/unlink";
+		try {
+			URL url = new URL(revokeUrl);
+			HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+			connection.setRequestMethod("POST");
+			connection.setRequestProperty("Authorization", "Bearer " + accessToken);
+
+			int responseCode = connection.getResponseCode();
+			if (responseCode == 200) {
+				log.info("Kakao account successfully unlinked");
+			} else {
+				log.error("Failed to unlink Kakao account, response code: {}", responseCode);
+			}
+		} catch (IOException e) {
+			log.error("Error occurred while unlinking Kakao account", e);
+		}
+	}
+
+	public void googleUnlink(String accessToken) {
+		String revokeUrl = "https://accounts.google.com/o/oauth2/revoke?token=" + accessToken;
+		try {
+			URL url = new URL(revokeUrl);
+			HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+			connection.setRequestMethod("GET"); // GET 요청으로 변경
+			connection.setRequestProperty("Content-Length", "0"); // Content-Length 설정
+
+			int responseCode = connection.getResponseCode();
+			if (responseCode == 200) {
+				log.info("Google account successfully unlinked");
+			} else {
+				log.error("Failed to unlink Google account, response code: {}", responseCode);
+			}
+		} catch (IOException e) {
+			log.error("Error occurred while unlinking Google account", e);
+		}
 	}
 
 }

--- a/badminton-api/src/main/java/org/badminton/api/member/service/MemberService.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/service/MemberService.java
@@ -69,7 +69,7 @@ public class MemberService {
 		removeJwtCookie(response);
 	}
 
-	private static void removeJwtCookie(HttpServletResponse response) {
+	private void removeJwtCookie(HttpServletResponse response) {
 		Cookie cookie = new Cookie("JWT", null);
 		cookie.setMaxAge(0);
 		cookie.setPath("/");

--- a/badminton-api/src/main/java/org/badminton/api/member/service/MemberService.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/service/MemberService.java
@@ -1,10 +1,16 @@
 package org.badminton.api.member.service;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
 import org.badminton.api.member.jwt.JwtUtil;
 import org.badminton.api.member.model.dto.MemberResponse;
 import org.badminton.api.member.model.dto.MemberUpdateRequest;
+import org.badminton.domain.member.entity.MemberAuthorization;
 import org.badminton.domain.member.entity.MemberEntity;
 import org.badminton.domain.member.repository.MemberRepository;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -27,6 +33,53 @@ public class MemberService {
 		memberEntity.updateMember(memberUpdateRequest.getProfileImage());
 		memberRepository.save(memberEntity);
 		return MemberResponse.memberEntityToResponse(memberEntity);
+	}
+
+	public void markAsDeleted(String providerId) {
+		MemberEntity memberEntity = memberRepository.findByProviderId(providerId);
+
+		memberEntity.deleteMember();
+		memberRepository.save(memberEntity);
+		log.info("Member marked as deleted: {}", providerId);
+	}
+
+	public MemberEntity handleLogin(String providerId, String email, String name, String profileImage,
+		String authorization) {
+		MemberEntity memberEntity = memberRepository.findByProviderId(providerId);
+
+		// 기존 회원이 존재하고 isDeleted가 true인 경우, 계정을 다시 활성화
+		if (memberEntity != null) {
+			if (memberEntity.isDeleted()) {
+				memberEntity.reactivateMember();
+				log.info("Reactivating member: {}", providerId);
+			}
+			memberEntity.updateMember(profileImage);
+		} else {
+			// 신규 회원 생성
+			memberEntity = new MemberEntity(email, name, providerId, profileImage,
+				MemberAuthorization.valueOf(authorization));
+		}
+
+		memberRepository.save(memberEntity);
+		return memberEntity;
+	}
+
+	@Scheduled(cron = "0 0 0 * * *")
+	public void DeleteMembers() {
+		log.info("Deleting members");
+
+		List<MemberEntity> deleteMembers = memberRepository.findAllByIsAndMemberDeletedTrue();
+
+		for (MemberEntity memberEntity : deleteMembers) {
+			LocalDateTime lastConnectionAt = memberEntity.getLastConnectionAt();
+			if (lastConnectionAt != null) {
+				if (ChronoUnit.DAYS.between(lastConnectionAt, LocalDateTime.now()) > 7) {
+					memberRepository.delete(memberEntity);
+					log.info("Delete member: {}", memberEntity.getProviderId());
+				}
+			}
+		}
+		log.info("Deleting members");
 	}
 
 }

--- a/badminton-api/src/main/resources/application.yaml
+++ b/badminton-api/src/main/resources/application.yaml
@@ -43,7 +43,7 @@ spring:
             client-secret: ${KAKAO_CLIENT_SECRET}
             redirect-uri: ${SERVER_URL}/login/oauth2/code/kakao
             authorization-grant-type: authorization_code
-            scope: profile_nickname, account_email
+            scope: profile_nickname, account_email, profile_image
             client-authentication-method: client_secret_post
           google:
             client-name: google

--- a/badminton-api/src/main/resources/application.yaml
+++ b/badminton-api/src/main/resources/application.yaml
@@ -63,3 +63,9 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+      revoke-url:
+        naver: "https://nid.naver.com/oauth2.0/token?grant_type=delete&client_id={client_id}&client_secret={client_secret}&access_token={access_token}&service_provider=NAVER"
+        kakao: "https://kapi.kakao.com/v1/user/unlink"
+        google: "https://accounts.google.com/o/oauth2/revoke?token={access_token}"
+
+

--- a/badminton-domain/src/main/java/org/badminton/domain/member/entity/MemberEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/member/entity/MemberEntity.java
@@ -28,10 +28,16 @@ public class MemberEntity extends BaseTimeEntity {
 
 	private String authorization;
 
-	public MemberEntity(String email, String name, String providerId, MemberAuthorization authorization) {
+	private String profileImage;
+
+	private boolean isDeleted;
+
+	public MemberEntity(String email, String name, String providerId, String profileImage,
+		MemberAuthorization authorization) {
 		this.email = email;
 		this.name = name;
 		this.providerId = providerId;
 		this.authorization = authorization.name();
+		this.profileImage = profileImage;
 	}
 }

--- a/badminton-domain/src/main/java/org/badminton/domain/member/entity/MemberEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/member/entity/MemberEntity.java
@@ -40,4 +40,9 @@ public class MemberEntity extends BaseTimeEntity {
 		this.authorization = authorization.name();
 		this.profileImage = profileImage;
 	}
+
+	public void updateMember(String profileImage) {
+		this.profileImage = profileImage;
+	}
+
 }

--- a/badminton-domain/src/main/java/org/badminton/domain/member/entity/MemberEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/member/entity/MemberEntity.java
@@ -1,5 +1,7 @@
 package org.badminton.domain.member.entity;
 
+import java.time.LocalDateTime;
+
 import org.badminton.domain.common.BaseTimeEntity;
 
 import jakarta.persistence.Entity;
@@ -30,7 +32,9 @@ public class MemberEntity extends BaseTimeEntity {
 
 	private String profileImage;
 
-	private boolean isDeleted;
+	private boolean isDeleted = false;
+
+	private LocalDateTime lastConnectionAt;
 
 	public MemberEntity(String email, String name, String providerId, String profileImage,
 		MemberAuthorization authorization) {
@@ -43,6 +47,23 @@ public class MemberEntity extends BaseTimeEntity {
 
 	public void updateMember(String profileImage) {
 		this.profileImage = profileImage;
+	}
+
+	public void deleteMember() {
+		this.isDeleted = true;
+		this.updateLastConnection();
+	}
+
+	public void updateLastConnection() {
+		this.lastConnectionAt = LocalDateTime.now();
+	}
+
+	public void reactivateMember() {
+		this.isDeleted = false;
+	}
+	
+	public boolean isMemberDeleted() {
+		return this.isDeleted;
 	}
 
 }

--- a/badminton-domain/src/main/java/org/badminton/domain/member/repository/MemberRepository.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/member/repository/MemberRepository.java
@@ -1,8 +1,12 @@
 package org.badminton.domain.member.repository;
 
+import java.util.List;
+
 import org.badminton.domain.member.entity.MemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 	MemberEntity findByProviderId(String providerId);
+
+	List<MemberEntity> findAllByIsAndMemberDeletedTrue();
 }

--- a/badminton-domain/src/main/java/org/badminton/domain/member/repository/MemberRepository.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/member/repository/MemberRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 	MemberEntity findByProviderId(String providerId);
 
-	List<MemberEntity> findAllByIsAndMemberDeletedTrue();
+	List<MemberEntity> findAllByIsDeletedTrue();
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍

member, oAuth 관련해서 CRUD 구현했습니다 😄 

## 변경된 사항 📝

- Swagger에 RequestHeader 추가
- member profile-image update 로직 구현
- jwt 토큰에 액세스 토큰, registrationId(naver,kakao,google) 추가
- oAuth 로그아웃 로직 구현
- member 탈퇴 로직 구현
- Scheduled로 isDeleted true인 멤버 lastConnectionAt기준으로 일주일이 지나면 db에서 멤버 삭제

![image](https://github.com/user-attachments/assets/a3209d91-962b-4d60-ab58-965dba3092bd)

Swagger에서 Authorize 에 jwt 토큰 추가 가능

## PR에서 중점적으로 확인되어야 하는 사항

예외처리는 추후 병합한 후에 리팩토링 예정입니다!
