### PR TITLE
refactor: record로 변경

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/club/controller/ClubController.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/controller/ClubController.java
@@ -2,11 +2,19 @@ package org.badminton.api.club.controller;
 
 import org.badminton.api.club.model.dto.ClubCreateRequest;
 import org.badminton.api.club.model.dto.ClubCreateResponse;
+import org.badminton.api.club.model.dto.ClubDeleteResponse;
+import org.badminton.api.club.model.dto.ClubReadResponse;
+import org.badminton.api.club.model.dto.ClubUpdateRequest;
+import org.badminton.api.club.model.dto.ClubUpdateResponse;
 import org.badminton.api.club.service.ClubService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,12 +28,41 @@ public class ClubController {
 
 	private final ClubService clubService;
 
+	@GetMapping
+	@Operation(summary = "동호회 조회",
+		description = "동호회를 조회합니다.",
+		tags = {"Club"})
+	public ResponseEntity<ClubReadResponse> readClub(@RequestParam Long clubId) {
+		ClubReadResponse clubReadResponse = clubService.readClub(clubId);
+		return ResponseEntity.ok(clubReadResponse);
+	}
+
 	@PostMapping
 	@Operation(summary = "동호회 추가",
 		description = "동호회를 추가합니다.",
 		tags = {"Club"})
-	public ResponseEntity<ClubCreateResponse> createClub(@Valid @RequestBody ClubCreateRequest clubAddRequest) {
-		ClubCreateResponse clubAddResponse = clubService.createClub(clubAddRequest);
+	public ResponseEntity<ClubCreateResponse> createClub(@Valid @RequestBody ClubCreateRequest clubCreateRequest) {
+		ClubCreateResponse clubAddResponse = clubService.createClub(clubCreateRequest);
 		return ResponseEntity.ok(clubAddResponse);
 	}
+
+	@PatchMapping
+	@Operation(summary = "동호회 수정",
+		description = "동호회를 수정합니다.",
+		tags = {"Club"})
+	public ResponseEntity<ClubUpdateResponse> updateClub(@RequestParam Long clubId,
+		@Valid @RequestBody ClubUpdateRequest clubUpdateRequest) {
+		ClubUpdateResponse clubUpdateResponse = clubService.updateClub(clubUpdateRequest, clubId);
+		return ResponseEntity.ok(clubUpdateResponse);
+	}
+
+	@DeleteMapping
+	@Operation(summary = "동호회 삭제",
+		description = "동호회를 삭제합니다.",
+		tags = {"Club"})
+	public ResponseEntity<ClubDeleteResponse> deleteClub(@RequestParam Long clubId) {
+		ClubDeleteResponse clubDeleteResponse = clubService.deleteClub(clubId);
+		return ResponseEntity.ok(clubDeleteResponse);
+	}
+
 }

--- a/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubCreateRequest.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubCreateRequest.java
@@ -2,21 +2,18 @@ package org.badminton.api.club.model.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@AllArgsConstructor
-@Getter
-public class ClubCreateRequest {
+public record ClubCreateRequest(
 
 	@NotBlank(message = "동호회 이름은 필수 입력 항목입니다.")
 	@Size(min = 2, max = 20)
-	private String clubName;
+	String clubName,
 
 	@NotBlank
 	@Size(max = 1000, message = "동호회 소개란에는 최대 1000자까지 입력할 수 있습니다.")
-	private String clubDescription;
+	String clubDescription,
 
 	// TODO: validation 추가 또는 VO 추가
-	private String clubImage;
+	String clubImage
+) {
 }

--- a/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubCreateResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubCreateResponse.java
@@ -4,17 +4,13 @@ import java.time.LocalDateTime;
 
 import org.badminton.domain.club.entity.ClubEntity;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class ClubCreateResponse {
-	private String clubName;
-	private String clubDescription;
-	private String clubImage;
-	private LocalDateTime createdAt;
-	private LocalDateTime modifiedAt;
+public record ClubCreateResponse(
+	String clubName,
+	String clubDescription,
+	String clubImage,
+	LocalDateTime createdAt,
+	LocalDateTime modifiedAt
+) {
 
 	public static ClubCreateResponse clubEntityToClubCreateResponse(ClubEntity clubEntity) {
 		return new ClubCreateResponse(clubEntity.getClubName(), clubEntity.getClubDescription(),

--- a/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubDeleteResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubDeleteResponse.java
@@ -2,14 +2,10 @@ package org.badminton.api.club.model.dto;
 
 import org.badminton.domain.club.entity.ClubEntity;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class ClubDeleteResponse {
-	private Long clubId;
-	private boolean isClubDeleted;
+public record ClubDeleteResponse(
+	Long clubId,
+	boolean isClubDeleted
+) {
 
 	public static ClubDeleteResponse clubEntityToClubDeleteResponse(ClubEntity clubEntity) {
 		return new ClubDeleteResponse(clubEntity.getClubId(), clubEntity.isClubDeleted());

--- a/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubReadResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubReadResponse.java
@@ -4,18 +4,13 @@ import java.time.LocalDateTime;
 
 import org.badminton.domain.club.entity.ClubEntity;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class ClubReadResponse {
-
-	private String clubName;
-	private String clubDescription;
-	private String clubImage;
-	private LocalDateTime createdAt;
-	private LocalDateTime modifiedAt;
+public record ClubReadResponse(
+	String clubName,
+	String clubDescription,
+	String clubImage,
+	LocalDateTime createdAt,
+	LocalDateTime modifiedAt
+) {
 
 	public static ClubReadResponse clubEntityToClubReadResponse(ClubEntity clubEntity) {
 		return new ClubReadResponse(clubEntity.getClubName(), clubEntity.getClubDescription(),

--- a/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubUpdateRequest.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubUpdateRequest.java
@@ -2,21 +2,17 @@ package org.badminton.api.club.model.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
-public class ClubUpdateRequest {
-
+public record ClubUpdateRequest(
 	@NotBlank(message = "동호회 이름은 필수 입력 항목입니다.")
 	@Size(min = 2, max = 20)
-	private String clubName;
+	String clubName,
 
 	@NotBlank
 	@Size(max = 1000, message = "동호회 소개란에는 최대 1000자까지 입력할 수 있습니다.")
-	private String clubDescription;
+	String clubDescription,
 
-	private String clubImage;
+	String clubImage
+) {
 
 }

--- a/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubUpdateResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubUpdateResponse.java
@@ -4,22 +4,20 @@ import java.time.LocalDateTime;
 
 import org.badminton.domain.club.entity.ClubEntity;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class ClubUpdateResponse {
-	private String clubName;
-	private String clubDescription;
-	private String clubImage;
-	private LocalDateTime createdAt;
-	private LocalDateTime modifiedAt;
-
+public record ClubUpdateResponse(
+	String clubName,
+	String clubDescription,
+	String clubImage,
+	LocalDateTime createdAt,
+	LocalDateTime modifiedAt
+) {
 	public static ClubUpdateResponse clubEntityToClubUpdateResponse(ClubEntity clubEntity) {
-		return new ClubUpdateResponse(clubEntity.getClubName(), clubEntity.getClubDescription(),
+		return new ClubUpdateResponse(
+			clubEntity.getClubName(),
+			clubEntity.getClubDescription(),
 			clubEntity.getClubImage(),
 			clubEntity.getCreatedAt(),
-			clubEntity.getModifiedAt());
+			clubEntity.getModifiedAt()
+		);
 	}
 }

--- a/badminton-api/src/main/java/org/badminton/api/club/service/ClubService.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/service/ClubService.java
@@ -29,7 +29,7 @@ public class ClubService {
 	// TODO: clubAddRequest에 이미지가 없으면 default 이미지를 넣어주도록 구현
 	@Transactional
 	public ClubCreateResponse createClub(ClubCreateRequest clubAddRequest) {
-		clubValidator.checkIfClubPresent(clubAddRequest.clubName());
+		clubValidator.checkIfClubNameDuplicate(clubAddRequest.clubName());
 		ClubEntity club = new ClubEntity(clubAddRequest.clubName(), clubAddRequest.clubDescription(),
 			clubAddRequest.clubImage());
 		clubValidator.saveClub(club);

--- a/badminton-api/src/main/java/org/badminton/api/club/service/ClubService.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/service/ClubService.java
@@ -29,9 +29,9 @@ public class ClubService {
 	// TODO: clubAddRequest에 이미지가 없으면 default 이미지를 넣어주도록 구현
 	@Transactional
 	public ClubCreateResponse createClub(ClubCreateRequest clubAddRequest) {
-		clubValidator.checkIfClubPresent(clubAddRequest.getClubName());
-		ClubEntity club = new ClubEntity(clubAddRequest.getClubName(), clubAddRequest.getClubDescription(),
-			clubAddRequest.getClubImage());
+		clubValidator.checkIfClubPresent(clubAddRequest.clubName());
+		ClubEntity club = new ClubEntity(clubAddRequest.clubName(), clubAddRequest.clubDescription(),
+			clubAddRequest.clubImage());
 		clubValidator.saveClub(club);
 		return ClubCreateResponse.clubEntityToClubCreateResponse(club);
 	}
@@ -39,8 +39,8 @@ public class ClubService {
 	@Transactional
 	public ClubUpdateResponse updateClub(ClubUpdateRequest clubUpdateRequest, Long clubId) {
 		ClubEntity club = clubValidator.provideClubByClubId(clubId);
-		club.updateClub(clubUpdateRequest.getClubName(), clubUpdateRequest.getClubDescription(),
-			clubUpdateRequest.getClubImage());
+		club.updateClub(clubUpdateRequest.clubName(), clubUpdateRequest.clubDescription(),
+			clubUpdateRequest.clubDescription());
 		clubValidator.saveClub(club);
 		return ClubUpdateResponse.clubEntityToClubUpdateResponse(club);
 	}

--- a/badminton-api/src/main/java/org/badminton/api/club/validator/ClubValidator.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/validator/ClubValidator.java
@@ -2,6 +2,7 @@ package org.badminton.api.club.validator;
 
 import org.badminton.api.common.error.ErrorCode;
 import org.badminton.api.common.exception.DuplicationException;
+import org.badminton.api.common.exception.ResourceNotFoundException;
 import org.badminton.domain.club.entity.ClubEntity;
 import org.badminton.domain.club.repository.ClubRepository;
 import org.springframework.stereotype.Component;
@@ -18,14 +19,17 @@ public class ClubValidator {
 		clubRepository.save(clubEntity);
 	}
 
-	public void checkIfClubPresent(String clubName) {
-		clubRepository.findByClubName(clubName).ifPresent(club -> {
+	public void checkIfClubNameDuplicate(String clubName) {
+		clubRepository.findByClubNameAndIsClubDeletedFalse(clubName).ifPresent(club -> {
 			throw new DuplicationException(ErrorCode.RESOURCE_ALREADY_EXIST, clubName.getClass().getSimpleName(),
 				clubName);
 		});
 	}
 
 	public ClubEntity provideClubByClubId(Long clubId) {
-		return clubRepository.findById(clubId).orElseThrow();
+		return clubRepository.findByClubIdAndIsClubDeletedFalse(clubId)
+			.orElseThrow(
+				() -> new ResourceNotFoundException(ErrorCode.RESOURCE_NOT_EXIST, clubId.getClass().getSimpleName(),
+					clubId));
 	}
 }

--- a/badminton-api/src/main/java/org/badminton/api/common/exception/ResourceNotFoundException.java
+++ b/badminton-api/src/main/java/org/badminton/api/common/exception/ResourceNotFoundException.java
@@ -1,0 +1,9 @@
+package org.badminton.api.common.exception;
+
+import org.badminton.api.common.error.ErrorCode;
+
+public class ResourceNotFoundException extends BadmintonException {
+	public ResourceNotFoundException(ErrorCode errorCode, String typeName, Long resourceId) {
+		super(errorCode, typeName, String.valueOf(resourceId));
+	}
+}

--- a/badminton-domain/src/main/java/org/badminton/domain/club/repository/ClubRepository.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/club/repository/ClubRepository.java
@@ -8,4 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ClubRepository extends JpaRepository<ClubEntity, Long> {
 
 	Optional<ClubEntity> findByClubName(String clubName);
+
+	Optional<ClubEntity> findByClubNameAndIsClubDeletedFalse(String clubName);
+
+	Optional<ClubEntity> findByClubIdAndIsClubDeletedFalse(Long clubId);
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍

### Record

불변의 값 객체(Value Object)

데이터 전달을 위한 DTO 용으로 사용한다.

어노테이션 없이 getter, equals(), hashCode(), toString() 메서드가 자동 생성된다.

1. private 떼도 된다. 필드에 final을 자동으로 추가해준다.
2. @Getter, @AllArgsConstructor 없어도 된다.


## 변경된 사항 📝


### Before

```
package org.badminton.api.club.model.dto;

import org.badminton.domain.club.entity.ClubEntity;

import lombok.AllArgsConstructor;
import lombok.Getter;

@Getter
@AllArgsConstructor
public class ClubDeleteResponse {
	private Long clubId;
	private boolean isClubDeleted;

	public static ClubDeleteResponse clubEntityToClubDeleteResponse(ClubEntity clubEntity) {
		return new ClubDeleteResponse(clubEntity.getClubId(), clubEntity.isClubDeleted());
	}
}
```

### After

```
package org.badminton.api.club.model.dto;

import org.badminton.domain.club.entity.ClubEntity;

public record ClubDeleteResponse(
	Long clubId,
	boolean isClubDeleted
) {

	public static ClubDeleteResponse clubEntityToClubDeleteResponse(ClubEntity clubEntity) {
		return new ClubDeleteResponse(clubEntity.getClubId(), clubEntity.isClubDeleted());
	}
}

```

## PR에서 중점적으로 확인되어야 하는 사항

레코드를 올바르게 사용했는지 확인 부탁드립니다!