### PR TITLE
feat: member create club

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/HomeController.java
+++ b/badminton-api/src/main/java/org/badminton/api/HomeController.java
@@ -1,0 +1,36 @@
+package org.badminton.api;
+
+import java.util.Map;
+
+import org.badminton.api.member.oauth2.dto.CustomOAuth2Member;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class HomeController {
+
+	@GetMapping("/")
+	@ResponseBody
+	public String home() {
+		return "This is the index page";
+	}
+
+	@GetMapping("/myPage")
+	public ResponseEntity<Object> myPage(Authentication authentication) {
+		if (authentication != null && authentication.isAuthenticated()) {
+			CustomOAuth2Member member = (CustomOAuth2Member)authentication.getPrincipal();
+			return ResponseEntity.ok(member); // 200 OK 상태 코드로 응답
+		} else {
+			Map<String, String> response = Map.of("message", "Guest, 회원가입한 유저만 접속 가능합니다.");
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response); // 401 Unauthorized 상태 코드로 응답
+		}
+	}
+
+}

--- a/badminton-api/src/main/java/org/badminton/api/club/controller/ClubController.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/controller/ClubController.java
@@ -8,6 +8,7 @@ import org.badminton.api.club.model.dto.ClubUpdateRequest;
 import org.badminton.api.club.model.dto.ClubUpdateResponse;
 import org.badminton.api.club.service.ClubService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -41,8 +42,9 @@ public class ClubController {
 	@Operation(summary = "동호회 추가",
 		description = "동호회를 추가합니다.",
 		tags = {"Club"})
-	public ResponseEntity<ClubCreateResponse> createClub(@Valid @RequestBody ClubCreateRequest clubCreateRequest) {
-		ClubCreateResponse clubAddResponse = clubService.createClub(clubCreateRequest);
+	public ResponseEntity<ClubCreateResponse> createClub(@Valid @RequestBody ClubCreateRequest clubCreateRequest,
+		Authentication authentication) {
+		ClubCreateResponse clubAddResponse = clubService.createClub(clubCreateRequest, authentication);
 		return ResponseEntity.ok(clubAddResponse);
 	}
 

--- a/badminton-api/src/main/java/org/badminton/api/club/service/ClubService.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/service/ClubService.java
@@ -7,7 +7,16 @@ import org.badminton.api.club.model.dto.ClubReadResponse;
 import org.badminton.api.club.model.dto.ClubUpdateRequest;
 import org.badminton.api.club.model.dto.ClubUpdateResponse;
 import org.badminton.api.club.validator.ClubValidator;
+import org.badminton.api.common.error.ErrorCode;
+import org.badminton.api.common.exception.member.MemberNotExistException;
+import org.badminton.api.member.oauth2.dto.CustomOAuth2Member;
 import org.badminton.domain.club.entity.ClubEntity;
+import org.badminton.domain.clubmember.entity.ClubMemberEntity;
+import org.badminton.domain.clubmember.entity.ClubMemberRole;
+import org.badminton.domain.clubmember.repository.ClubMemberRepository;
+import org.badminton.domain.member.entity.MemberEntity;
+import org.badminton.domain.member.repository.MemberRepository;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
@@ -20,6 +29,8 @@ import lombok.extern.slf4j.Slf4j;
 public class ClubService {
 
 	private final ClubValidator clubValidator;
+	private final ClubMemberRepository clubMemberRepository;
+	private final MemberRepository memberRepository;
 
 	public ClubReadResponse readClub(Long clubId) {
 		ClubEntity club = clubValidator.provideClubByClubId(clubId);
@@ -28,10 +39,20 @@ public class ClubService {
 
 	// TODO: clubAddRequest에 이미지가 없으면 default 이미지를 넣어주도록 구현
 	@Transactional
-	public ClubCreateResponse createClub(ClubCreateRequest clubAddRequest) {
+	public ClubCreateResponse createClub(ClubCreateRequest clubAddRequest, Authentication authentication) {
+		CustomOAuth2Member member = (CustomOAuth2Member)authentication.getPrincipal();
+		Long memberId = member.getMemberId();
+		MemberEntity memberEntity = memberRepository.findByMemberId(memberId)
+			.orElseThrow(() -> new MemberNotExistException(
+				ErrorCode.MEMBER_NOT_EXIST, String.valueOf(memberId)));
+
 		clubValidator.checkIfClubNameDuplicate(clubAddRequest.clubName());
 		ClubEntity club = new ClubEntity(clubAddRequest.clubName(), clubAddRequest.clubDescription(),
 			clubAddRequest.clubImage());
+
+		ClubMemberEntity clubMemberEntity = new ClubMemberEntity(club, memberEntity, ClubMemberRole.ROLE_OWNER);
+		clubMemberRepository.save(clubMemberEntity);
+
 		clubValidator.saveClub(club);
 		return ClubCreateResponse.clubEntityToClubCreateResponse(club);
 	}

--- a/badminton-api/src/main/java/org/badminton/api/config/security/SecurityConfig.java
+++ b/badminton-api/src/main/java/org/badminton/api/config/security/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
 		http
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/", "/groups", "/oauth2/**", "/login/**", "/error", "/api/*", "/swagger-ui/**",
-					"/v3/api-docs/**", "/v1/**")
+					"/v3/api-docs/**")
 				.permitAll()
 				.anyRequest()
 				.authenticated());

--- a/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtFilter.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtFilter.java
@@ -28,8 +28,7 @@ public class JwtFilter extends OncePerRequestFilter {
 	protected boolean shouldNotFilter(HttpServletRequest request) {
 		String path = request.getRequestURI();
 		return path.equals("/") || path.equals("/groups") || path.startsWith("/oauth2") || path.startsWith("/login")
-			|| path.startsWith("/api") || path.startsWith("/swagger-ui") || path.startsWith("/v3/api-docs")
-			|| path.startsWith("/v1");
+			|| path.startsWith("/api") || path.startsWith("/swagger-ui") || path.startsWith("/v3/api-docs");
 
 	}
 
@@ -61,13 +60,15 @@ public class JwtFilter extends OncePerRequestFilter {
 		String providerId = jwtUtil.getProviderId(jwtToken);
 		String authorization = jwtUtil.getAuthorization(jwtToken);
 		log.info("JWT authorization: {}", authorization);
+		Long memberId = Long.valueOf(jwtUtil.getMemberId(jwtToken));
 		String name = jwtUtil.getName(jwtToken);
 		String email = jwtUtil.getEmail(jwtToken);
 		String profileImage = jwtUtil.getProfileImage(jwtToken);
 		String accessToken = jwtUtil.getAccessToken(jwtToken);
 		String registrationId = jwtUtil.getRegistrationId(jwtToken);
 
-		MemberResponse memberResponse = new MemberResponse(MemberAuthorization.AUTHORIZATION_USER.name(), name,
+		MemberResponse memberResponse = new MemberResponse(memberId, MemberAuthorization.AUTHORIZATION_USER.name(),
+			name,
 			email,
 			providerId, profileImage);
 		log.info("memberDto: {}", memberResponse);

--- a/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtUtil.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtUtil.java
@@ -61,6 +61,10 @@ public class JwtUtil {
 		return getDetail(token, "name");
 	}
 
+	public String getMemberId(String token) {
+		return getDetail(token, "memberId");
+	}
+
 	public String getAuthorization(String token) {
 		return getDetail(token, "authorization");
 	}
@@ -93,10 +97,12 @@ public class JwtUtil {
 			.before(new Date());
 	}
 
-	public String createJwt(String providerId, String authorization, String name, String email, String profileImage
+	public String createJwt(String memberId, String providerId, String authorization, String name, String email,
+		String profileImage
 		, String accessToken, String registrationId, Long expiredMs) {
 
 		return Jwts.builder()
+			.claim("memberId", memberId)
 			.claim("providerId", providerId)
 			.claim("authorization", authorization)
 			.claim("name", name)

--- a/badminton-api/src/main/java/org/badminton/api/member/model/dto/MemberResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/model/dto/MemberResponse.java
@@ -7,6 +7,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "회원 요청 DTO")
 public record MemberResponse(
 
+	@Schema(description = "회원 id", example = "1")
+	Long memberId,
+
 	@Schema(description = "회원 역할", example = "AUTHORIZATION_USER")
 	String authorization,
 
@@ -25,7 +28,8 @@ public record MemberResponse(
 ) {
 
 	public static MemberResponse memberEntityToResponse(MemberEntity memberEntity) {
-		return new MemberResponse(memberEntity.getAuthorization(), memberEntity.getName(), memberEntity.getEmail(),
+		return new MemberResponse(memberEntity.getMemberId(), memberEntity.getAuthorization(), memberEntity.getName(),
+			memberEntity.getEmail(),
 			memberEntity.getProviderId(), memberEntity.getProfileImage());
 	}
 }

--- a/badminton-api/src/main/java/org/badminton/api/member/oauth2/CustomSuccessHandler.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/oauth2/CustomSuccessHandler.java
@@ -33,6 +33,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		//OAuth2User
 		CustomOAuth2Member customUserDetails = (CustomOAuth2Member)authentication.getPrincipal(); // 인증된 사용자 객체 가져오기
 
+		String memberId = String.valueOf(customUserDetails.getMemberId());
+
 		String providerId = customUserDetails.getProviderId();
 
 		String name = customUserDetails.getName();
@@ -50,7 +52,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		GrantedAuthority auth = iterator.next();
 		String authorization = auth.getAuthority();
 
-		String token = jwtUtil.createJwt(providerId, authorization, name, email, profileImage,
+		String token = jwtUtil.createJwt(memberId, providerId, authorization, name, email, profileImage,
 			accessToken, registrationId, 24 * 60 * 60 * 1000L); // 초 * 분 * 시
 
 		request.getSession().invalidate();

--- a/badminton-api/src/main/java/org/badminton/api/member/oauth2/dto/CustomOAuth2Member.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/oauth2/dto/CustomOAuth2Member.java
@@ -46,6 +46,10 @@ public class CustomOAuth2Member implements OAuth2User {
 		return memberResponse.providerId();
 	}
 
+	public Long getMemberId() {
+		return memberResponse.memberId();
+	}
+
 	public String getEmail() {
 		return memberResponse.email();
 	}

--- a/badminton-api/src/main/java/org/badminton/api/member/service/CustomOAuth2MemberService.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/service/CustomOAuth2MemberService.java
@@ -79,7 +79,9 @@ public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
 
 			memberResponse = memberEntityToResponse(existData);
 		}
+		String memberId = String.valueOf(memberResponse.memberId());
 		String jwt = jwtUtil.createJwt(
+			memberId,
 			providerId,
 			memberResponse.authorization(),
 			memberResponse.name(),

--- a/badminton-api/src/main/resources/application.yaml
+++ b/badminton-api/src/main/resources/application.yaml
@@ -3,7 +3,7 @@ spring:
     name: badminton
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
       show-sql: true
       properties:
         hibernate:

--- a/badminton-api/src/main/resources/application.yaml
+++ b/badminton-api/src/main/resources/application.yaml
@@ -3,7 +3,7 @@ spring:
     name: badminton
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
       show-sql: true
       properties:
         hibernate:

--- a/badminton-domain/src/main/java/org/badminton/domain/club/entity/ClubEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/club/entity/ClubEntity.java
@@ -1,12 +1,18 @@
 package org.badminton.domain.club.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.badminton.domain.clubmember.entity.ClubMemberEntity;
 import org.badminton.domain.common.BaseTimeEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -30,6 +36,9 @@ public class ClubEntity extends BaseTimeEntity {
 	private String clubImage;
 
 	private boolean isClubDeleted;
+
+	@OneToMany(fetch = FetchType.LAZY, mappedBy = "club")
+	private List<ClubMemberEntity> clubMembers = new ArrayList<>();
 
 	public ClubEntity(String clubName, String clubDescription, String clubImage) {
 		this.clubName = clubName;

--- a/badminton-domain/src/main/java/org/badminton/domain/clubmember/entity/ClubMemberBanEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/clubmember/entity/ClubMemberBanEntity.java
@@ -1,0 +1,29 @@
+package org.badminton.domain.clubmember.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "club_member_ban")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ClubMemberBanEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long clubMemberBanId;
+
+	private boolean isBanned;
+
+	private String banType;
+
+	private LocalDateTime banStartAt;
+}

--- a/badminton-domain/src/main/java/org/badminton/domain/clubmember/entity/ClubMemberEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/clubmember/entity/ClubMemberEntity.java
@@ -1,7 +1,5 @@
 package org.badminton.domain.clubmember.entity;
 
-import java.time.LocalDateTime;
-
 import org.badminton.domain.club.entity.ClubEntity;
 import org.badminton.domain.common.BaseTimeEntity;
 import org.badminton.domain.member.entity.MemberEntity;
@@ -31,12 +29,6 @@ public class ClubMemberEntity extends BaseTimeEntity {
 
 	private String role;
 
-	private boolean isBanned;
-
-	private String banType;
-
-	private LocalDateTime banStartAt;
-
 	@ManyToOne
 	@JoinColumn(name = "clubId")
 	private ClubEntity club;
@@ -44,4 +36,11 @@ public class ClubMemberEntity extends BaseTimeEntity {
 	@ManyToOne
 	@JoinColumn(name = "memberId")
 	private MemberEntity member;
+
+	public ClubMemberEntity(ClubEntity club, MemberEntity member, ClubMemberRole role) {
+		this.club = club;
+		this.member = member;
+		this.role = role.name();
+		this.isDeleted = false;
+	}
 }

--- a/badminton-domain/src/main/java/org/badminton/domain/clubmember/entity/ClubMemberEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/clubmember/entity/ClubMemberEntity.java
@@ -1,0 +1,47 @@
+package org.badminton.domain.clubmember.entity;
+
+import java.time.LocalDateTime;
+
+import org.badminton.domain.club.entity.ClubEntity;
+import org.badminton.domain.common.BaseTimeEntity;
+import org.badminton.domain.member.entity.MemberEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "club_member")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ClubMemberEntity extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long clubMemberId;
+
+	private boolean isDeleted;
+
+	private String role;
+
+	private boolean isBanned;
+
+	private String banType;
+
+	private LocalDateTime banStartAt;
+
+	@ManyToOne
+	@JoinColumn(name = "clubId")
+	private ClubEntity club;
+
+	@ManyToOne
+	@JoinColumn(name = "memberId")
+	private MemberEntity member;
+}

--- a/badminton-domain/src/main/java/org/badminton/domain/clubmember/entity/ClubMemberRole.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/clubmember/entity/ClubMemberRole.java
@@ -1,0 +1,17 @@
+package org.badminton.domain.clubmember.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum ClubMemberRole {
+	ROLE_OWNER("owner"),
+	ROLE_MANAGER("manager"),
+	ROLE_USER("user");
+
+	private final String description;
+
+	ClubMemberRole(String description) {
+		this.description = description;
+	}
+
+}

--- a/badminton-domain/src/main/java/org/badminton/domain/clubmember/repository/ClubMemberRepository.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/clubmember/repository/ClubMemberRepository.java
@@ -7,8 +7,8 @@ import org.badminton.domain.clubmember.entity.ClubMemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClubMemberRepository extends JpaRepository<ClubMemberEntity, Long> {
-	Optional<List<ClubMemberEntity>> findAllByClubId(Long clubId);
+	Optional<List<ClubMemberEntity>> findAllByClub_ClubId(Long clubId);
 
-	Optional<ClubMemberEntity> findByMemberId(Long memberId);
+	Optional<ClubMemberEntity> findByMember_MemberId(Long memberId);
 
 }

--- a/badminton-domain/src/main/java/org/badminton/domain/clubmember/repository/ClubMemberRepository.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/clubmember/repository/ClubMemberRepository.java
@@ -1,0 +1,14 @@
+package org.badminton.domain.clubmember.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.badminton.domain.clubmember.entity.ClubMemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClubMemberRepository extends JpaRepository<ClubMemberEntity, Long> {
+	Optional<List<ClubMemberEntity>> findAllByClubId(Long clubId);
+
+	Optional<ClubMemberEntity> findByMemberId(Long memberId);
+
+}

--- a/badminton-domain/src/main/java/org/badminton/domain/member/repository/MemberRepository.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/member/repository/MemberRepository.java
@@ -9,5 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 	Optional<MemberEntity> findByProviderId(String providerId);
 
+	Optional<MemberEntity> findByMemberId(Long memberId);
+
 	List<MemberEntity> findAllByIsDeletedTrue();
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍

- member가 동호회를 생성하고 clubMemberEntity에 member의 role이 ROLE_OWNER로 저장되는 로직 구현

## 변경된 사항 📝

- jwt토큰에 memberId 추가
- security, jwt 필터 변경
- clubMemberEntity, repository 생성

## PR에서 중점적으로 확인되어야 하는 사항

- clubMemberBanEntity는 일단 생성만 해두었고 추후 리팩토링 할 예정입니다 😄 