### PR TITLE
feat: save image to aws s3

### DIFF
--- a/badminton-api/build.gradle
+++ b/badminton-api/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation group: 'me.paulschwarz', name: 'spring-dotenv', version: '4.0.0'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.5.RELEASE'
 
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'

--- a/badminton-api/src/main/java/org/badminton/api/aws/s3/controller/ClubImageController.java
+++ b/badminton-api/src/main/java/org/badminton/api/aws/s3/controller/ClubImageController.java
@@ -1,0 +1,41 @@
+package org.badminton.api.aws.s3.controller;
+
+import org.badminton.api.aws.s3.model.dto.ClubImageUploadRequest;
+import org.badminton.api.aws.s3.service.ClubImageService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/v1/club/image")
+public class ClubImageController {
+	private final ClubImageService clubImageService;
+
+	@Operation(
+		summary = "클럽 이미지 업로드",
+		description = "이미지를 S3에 업로드하는 API 입니다.",
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+			required = true,
+			content = @Content(
+				mediaType = "multipart/form-data",
+				schema = @Schema(implementation = ClubImageUploadRequest.class)
+			)
+		)
+	)
+	@PostMapping
+	public ResponseEntity<String> saveImage(@RequestPart("multipartFile") MultipartFile multipartFile) {
+		ClubImageUploadRequest request = new ClubImageUploadRequest(multipartFile);
+		return ResponseEntity.ok(clubImageService.uploadFile(request));
+	}
+	//TODO : 임시 테이블을 만들어 저장하고 배치에서 동호회 url 을 조회 후 미사용 객체들을 모두 삭제
+
+}

--- a/badminton-api/src/main/java/org/badminton/api/aws/s3/model/config/MultipartJackson2HttpMessageConverter.java
+++ b/badminton-api/src/main/java/org/badminton/api/aws/s3/model/config/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,35 @@
+package org.badminton.api.aws.s3.model.config;
+
+import java.lang.reflect.Type;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+	/**
+	 * Converter for support http request with header Content-Type: multipart/form-data
+	 */
+	public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+		super(objectMapper, MediaType.MULTIPART_FORM_DATA);
+	}
+
+	@Override
+	public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+		return false;
+	}
+
+	@Override
+	public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+		return false;
+	}
+
+	@Override
+	protected boolean canWrite(MediaType mediaType) {
+		return false;
+	}
+}

--- a/badminton-api/src/main/java/org/badminton/api/aws/s3/model/dto/ClubImageUploadRequest.java
+++ b/badminton-api/src/main/java/org/badminton/api/aws/s3/model/dto/ClubImageUploadRequest.java
@@ -1,0 +1,15 @@
+package org.badminton.api.aws.s3.model.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonNaming(PropertyNamingStrategies.LowerCamelCaseStrategy.class)
+public record ClubImageUploadRequest(
+	@Schema(description = "업로드할 이미지 파일", type = "string", format = "binary")
+	MultipartFile multipartFile
+) {
+}

--- a/badminton-api/src/main/java/org/badminton/api/aws/s3/service/ClubImageService.java
+++ b/badminton-api/src/main/java/org/badminton/api/aws/s3/service/ClubImageService.java
@@ -50,6 +50,6 @@ public class ClubImageService {
 	private String makeFileName(String originalFilename) {
 		String[] originFile = originalFilename.split("\\.");
 		String extension = originFile[originFile.length - 1];
-		return UUID.randomUUID() + "/" + "banner." + extension;
+		return "club-banner/" + UUID.randomUUID() + "/" + "banner." + extension;
 	}
 }

--- a/badminton-api/src/main/java/org/badminton/api/aws/s3/service/ClubImageService.java
+++ b/badminton-api/src/main/java/org/badminton/api/aws/s3/service/ClubImageService.java
@@ -1,0 +1,55 @@
+package org.badminton.api.aws.s3.service;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.badminton.api.aws.s3.model.dto.ClubImageUploadRequest;
+import org.badminton.api.common.exception.EmptyFileException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ClubImageService {
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	private final AmazonS3 s3Client;
+
+	public String uploadFile(ClubImageUploadRequest file) {
+		MultipartFile uploadFile = file.multipartFile();
+		if (uploadFile.isEmpty() || Objects.isNull(uploadFile.getOriginalFilename())) {
+			throw new EmptyFileException();
+		}
+		String fileName = makeFileName(uploadFile.getOriginalFilename());
+
+		ObjectMetadata objectMetadata = new ObjectMetadata();
+		objectMetadata.setContentLength(uploadFile.getSize());
+		objectMetadata.setContentType(uploadFile.getContentType());
+
+		try {
+			s3Client.putObject(new PutObjectRequest(bucket, fileName,
+				uploadFile.getInputStream(), objectMetadata)
+				.withCannedAcl(CannedAccessControlList.PublicRead));
+			return s3Client.getUrl(bucket, fileName).toString();
+		} catch (IOException exception) {
+			throw new EmptyFileException(exception);
+		}
+
+	}
+
+	private String makeFileName(String originalFilename) {
+		String[] originFile = originalFilename.split("\\.");
+		String extension = originFile[originFile.length - 1];
+		return UUID.randomUUID() + "/" + "banner." + extension;
+	}
+}

--- a/badminton-api/src/main/java/org/badminton/api/common/error/ErrorCode.java
+++ b/badminton-api/src/main/java/org/badminton/api/common/error/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
 	MISSING_PARAMETER(400, "필수 파라미터가 지정되지 않았습니다."),
 	LIMIT_EXCEEDED(400, "파라미터 또는 리소스 속성값이 제한을 초과했습니다."),
 	OUT_OF_RANGE(400, "파라미터 또는 리소스 속성값이 범위를 벗어났습니다."),
+	FILE_NOT_EXIST(400, "파일이 존재하지 않거나 잘못된 파일입니다."),
 
 	// 401 Errors
 	UNAUTHORIZED(401, "요구되는 인증 정보가 누락되었거나 잘못되었습니다."),

--- a/badminton-api/src/main/java/org/badminton/api/common/exception/EmptyFileException.java
+++ b/badminton-api/src/main/java/org/badminton/api/common/exception/EmptyFileException.java
@@ -1,0 +1,13 @@
+package org.badminton.api.common.exception;
+
+import org.badminton.api.common.error.ErrorCode;
+
+public class EmptyFileException extends BadmintonException {
+	public EmptyFileException() {
+		super(ErrorCode.FILE_NOT_EXIST);
+	}
+
+	public EmptyFileException(Exception exception) {
+		super(ErrorCode.FILE_NOT_EXIST, exception);
+	}
+}

--- a/badminton-api/src/main/java/org/badminton/api/config/s3/AwsS3Config.java
+++ b/badminton-api/src/main/java/org/badminton/api/config/s3/AwsS3Config.java
@@ -1,0 +1,31 @@
+package org.badminton.api.config.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class AwsS3Config {
+	@Value("${cloud.aws.credentials.access-key}") // application.yml 에 명시한 내용
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public AmazonS3Client amazonS3Client() {
+		BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+		return (AmazonS3Client)AmazonS3ClientBuilder.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+			.build();
+	}
+}

--- a/badminton-api/src/main/resources/application.yaml
+++ b/badminton-api/src/main/resources/application.yaml
@@ -66,5 +66,22 @@ spring:
         naver: "https://nid.naver.com/oauth2.0/token?grant_type=delete&client_id={client_id}&client_secret={client_secret}&access_token={access_token}&service_provider=NAVER"
         kakao: "https://kapi.kakao.com/v1/user/unlink"
         google: "https://accounts.google.com/o/oauth2/revoke?token={access_token}"
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 3MB
+      max-request-size: 3MB
 
+  # AWS S3
+cloud:
+  aws:
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}
+    region:
+      static: ap-northeast-2  # 버킷의 리전
+    s3:
+      bucket: badminton-team   # 버킷 이름
+    stack:
+      auto: false
 

--- a/badminton-api/src/test/java/org/badminton/api/league/service/LeagueServiceTest.java
+++ b/badminton-api/src/test/java/org/badminton/api/league/service/LeagueServiceTest.java
@@ -1,0 +1,43 @@
+package org.badminton.api.league.service;
+
+import org.badminton.domain.club.repository.ClubRepository;
+import org.badminton.domain.league.repository.LeagueRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LeagueServiceTest {
+
+	@Mock
+	private LeagueRepository leagueRepository;
+
+	@Mock
+	private ClubRepository clubRepository;
+
+	@InjectMocks
+	private LeagueService leagueService;
+
+	@Test
+	@DisplayName("경기 생성을 테스트합니다.")
+	void createLeague() {
+		//given
+		//when
+		//then
+	}
+
+	@Test
+	void getLeague() {
+	}
+
+	@Test
+	void updateLeague() {
+	}
+
+	@Test
+	void deleteLeague() {
+	}
+}


### PR DESCRIPTION
## PR에 대한 설명 🔍
- 동호회 사진을 S3에 업로드 하는 기능입니다.


## 변경된 사항 📝
S3에 데이터를 저장하면 다음과 같은 경로로 만들어 집니다. 
```
club-banner > 고유의 uuid > banner.확장자
```
회원 사진을 추가 및 다른 사진을 저장하는 기능이 추가되면 
다음과같이 경로를 수정해서 저장하면 됩니다. ( 이 부분을 인터페이스로 분기처리해도 될 듯합니다.)
```
기능이름 > 고유의 uuid > banner.확장자 
```

<img width="455" alt="image" src="https://github.com/user-attachments/assets/515e4f64-e9c2-428c-924c-344842fe1185">

## PR에서 중점적으로 확인되어야 하는 사항
S3를 구현하기 위한 코드라 리펙토링 되어 있지 않습니다. 
코드 관련해서 객체지향의 원칙이 위배되는 점을 찾아주세요! 