### PR TITLE
feat: 동호회 회원 등급 로직

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/club/service/ClubService.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/service/ClubService.java
@@ -12,6 +12,8 @@ import org.badminton.domain.club.entity.ClubEntity;
 import org.badminton.domain.clubmember.entity.ClubMemberEntity;
 import org.badminton.domain.clubmember.entity.ClubMemberRole;
 import org.badminton.domain.clubmember.repository.ClubMemberRepository;
+import org.badminton.domain.leaguerecord.entity.LeagueRecordEntity;
+import org.badminton.domain.leaguerecord.repository.LeagueRecordRepository;
 import org.badminton.domain.member.entity.MemberEntity;
 import org.badminton.domain.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
@@ -28,6 +30,7 @@ public class ClubService {
 	private final ClubValidator clubValidator;
 	private final ClubMemberRepository clubMemberRepository;
 	private final MemberRepository memberRepository;
+	private final LeagueRecordRepository leagueRecordRepository;
 
 	public ClubReadResponse readClub(Long clubId) {
 		ClubEntity club = clubValidator.provideClubByClubId(clubId);
@@ -49,6 +52,10 @@ public class ClubService {
 		clubMemberRepository.save(clubMemberEntity);
 
 		clubValidator.saveClub(club);
+
+		LeagueRecordEntity leagueRecord = new LeagueRecordEntity(clubMemberEntity);
+		leagueRecordRepository.save(leagueRecord);
+
 		return ClubCreateResponse.clubEntityToClubCreateResponse(club);
 	}
 

--- a/badminton-api/src/main/java/org/badminton/api/clubmember/model/dto/ClubMemberInfoResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/clubmember/model/dto/ClubMemberInfoResponse.java
@@ -1,8 +1,10 @@
 package org.badminton.api.clubmember.model.dto;
 
+import org.badminton.api.leaguerecord.dto.LeagueRecordInfoResponse;
 import org.badminton.api.member.model.dto.MemberDetailResponse;
 import org.badminton.domain.clubmember.entity.ClubMemberEntity;
 import org.badminton.domain.clubmember.entity.ClubMemberRole;
+import org.badminton.domain.leaguerecord.entity.LeagueRecordEntity;
 import org.badminton.domain.member.entity.MemberEntity;
 
 public record ClubMemberInfoResponse(
@@ -12,10 +14,12 @@ public record ClubMemberInfoResponse(
 	String profileImage,
 	Long clubMemberId,
 	String clubName,
-	ClubMemberRole role
+	ClubMemberRole role,
+	LeagueRecordInfoResponse leagueRecordInfoResponse
+
 ) implements MemberDetailResponse {
 	public static ClubMemberInfoResponse entityToClubMemberInfoResponse(MemberEntity memberEntity,
-		ClubMemberEntity clubMemberEntity) {
+		ClubMemberEntity clubMemberEntity, LeagueRecordEntity leagueRecordEntity) {
 		return new ClubMemberInfoResponse(
 			memberEntity.getMemberId(),
 			memberEntity.getName(),
@@ -23,7 +27,8 @@ public record ClubMemberInfoResponse(
 			memberEntity.getProfileImage(),
 			clubMemberEntity.getClubMemberId(),
 			clubMemberEntity.getClub().getClubName(),
-			clubMemberEntity.getRole()
+			clubMemberEntity.getRole(),
+			LeagueRecordInfoResponse.entityToLeagueRecordInfoResponse(leagueRecordEntity)
 		);
 	}
 

--- a/badminton-api/src/main/java/org/badminton/api/clubmember/service/ClubMemberService.java
+++ b/badminton-api/src/main/java/org/badminton/api/clubmember/service/ClubMemberService.java
@@ -9,6 +9,8 @@ import org.badminton.domain.club.repository.ClubRepository;
 import org.badminton.domain.clubmember.entity.ClubMemberEntity;
 import org.badminton.domain.clubmember.entity.ClubMemberRole;
 import org.badminton.domain.clubmember.repository.ClubMemberRepository;
+import org.badminton.domain.leaguerecord.entity.LeagueRecordEntity;
+import org.badminton.domain.leaguerecord.repository.LeagueRecordRepository;
 import org.badminton.domain.member.entity.MemberEntity;
 import org.badminton.domain.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
@@ -22,6 +24,7 @@ public class ClubMemberService {
 	private final ClubMemberRepository clubMemberRepository;
 	private final ClubRepository clubRepository;
 	private final MemberRepository memberRepository;
+	private final LeagueRecordRepository leagueRecordRepository;
 
 	public ClubMemberJoinResponse joinClub(Long memberId, Long clubId) {
 		ClubEntity clubEntity = clubRepository.findByClubIdAndIsClubDeletedFalse(clubId)
@@ -37,6 +40,10 @@ public class ClubMemberService {
 		ClubMemberEntity clubMemberEntity = new ClubMemberEntity(clubEntity, memberEntity, ClubMemberRole.ROLE_USER);
 
 		clubMemberRepository.save(clubMemberEntity);
+
+		LeagueRecordEntity leagueRecord = new LeagueRecordEntity(clubMemberEntity);
+		leagueRecordRepository.save(leagueRecord);
+
 		return ClubMemberJoinResponse.clubMemberEntityToClubMemberJoinResponse(
 			clubMemberEntity);
 

--- a/badminton-api/src/main/java/org/badminton/api/common/exception/clubmember/ClubMemberNotExistException.java
+++ b/badminton-api/src/main/java/org/badminton/api/common/exception/clubmember/ClubMemberNotExistException.java
@@ -12,4 +12,13 @@ public class ClubMemberNotExistException extends BadmintonException {
 	public ClubMemberNotExistException(Long clubId, Long memberId, Exception e) {
 		super(ErrorCode.CLUB_MEMBER_NOT_EXIST, "[동호회 아이디 : " + clubId + " 회원 아이디 : " + memberId + "]", e);
 	}
+
+	public ClubMemberNotExistException(Long clubMemberId) {
+		super(ErrorCode.CLUB_MEMBER_NOT_EXIST, "[동호회 회원 아이디 : " + clubMemberId + "]");
+	}
+
+	public ClubMemberNotExistException(Long clubMemberId, Exception e) {
+		super(ErrorCode.CLUB_MEMBER_NOT_EXIST, "[동호회 회원 아이디 : " + clubMemberId + "]", e);
+	}
+
 }

--- a/badminton-api/src/main/java/org/badminton/api/leaguerecord/dto/LeagueRecordInfoResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/leaguerecord/dto/LeagueRecordInfoResponse.java
@@ -1,0 +1,23 @@
+package org.badminton.api.leaguerecord.dto;
+
+import org.badminton.domain.common.enums.MemberTier;
+import org.badminton.domain.leaguerecord.entity.LeagueRecordEntity;
+
+public record LeagueRecordInfoResponse(
+	int winCount,
+	int loseCount,
+	int drawCount,
+	int matchCount,
+	MemberTier tier
+) {
+	public static LeagueRecordInfoResponse entityToLeagueRecordInfoResponse(LeagueRecordEntity leagueRecordEntity) {
+		return new LeagueRecordInfoResponse(
+			leagueRecordEntity.getWinCount(),
+			leagueRecordEntity.getLoseCount(),
+			leagueRecordEntity.getDrawCount(),
+			leagueRecordEntity.getMatchCount(),
+			leagueRecordEntity.getTier()
+		);
+	}
+
+}

--- a/badminton-api/src/main/java/org/badminton/api/leaguerecord/service/LeagueRecordService.java
+++ b/badminton-api/src/main/java/org/badminton/api/leaguerecord/service/LeagueRecordService.java
@@ -1,0 +1,75 @@
+package org.badminton.api.leaguerecord.service;
+
+import org.badminton.api.common.exception.clubmember.ClubMemberNotExistException;
+import org.badminton.domain.common.enums.MemberTier;
+import org.badminton.domain.leaguerecord.entity.LeagueRecordEntity;
+import org.badminton.domain.leaguerecord.repository.LeagueRecordRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LeagueRecordService {
+
+	private final LeagueRecordRepository leagueRecordRepository;
+
+	@Transactional
+	public void addWin(Long clubMemberId) {
+		LeagueRecordEntity record = getLeagueRecord(clubMemberId);
+		record.updateWinCount(record.getWinCount() + 1);
+		record.updateMatchCount(record.getMatchCount() + 1);
+		updateTier(clubMemberId);
+		leagueRecordRepository.save(record);
+	}
+
+	@Transactional
+	public void addLose(Long clubMemberId) {
+		LeagueRecordEntity record = getLeagueRecord(clubMemberId);
+		record.updateLoseCount(record.getLoseCount() + 1);
+		record.updateMatchCount(record.getMatchCount() + 1);
+		updateTier(clubMemberId);
+		leagueRecordRepository.save(record);
+
+	}
+
+	@Transactional
+	public void addDraw(Long clubMemberId) {
+		LeagueRecordEntity record = getLeagueRecord(clubMemberId);
+		record.updateDrawCount(record.getDrawCount() + 1);
+		record.updateMatchCount(record.getMatchCount() + 1);
+		updateTier(clubMemberId);
+		leagueRecordRepository.save(record);
+	}
+
+	@Transactional(readOnly = true)
+	public double getWinRate(Long clubMemberId) {
+		LeagueRecordEntity record = getLeagueRecord(clubMemberId);
+		if (record.getMatchCount() == 0) {
+			return 0.0;
+		}
+		return (double)record.getWinCount() / record.getMatchCount() * 100;
+	}
+
+	private void updateTier(Long clubMemberId) {
+		double winRate = getWinRate(clubMemberId);
+		LeagueRecordEntity record = getLeagueRecord(clubMemberId);
+		int matchCount = record.getMatchCount();
+
+		if (matchCount >= 20 && winRate >= 80) {
+			record.updateTier(MemberTier.GOLD);
+		} else if (matchCount >= 10 && winRate >= 60) {
+			record.updateTier(MemberTier.SILVER);
+		} else {
+			record.updateTier(MemberTier.BRONZE);
+		}
+	}
+
+	@Transactional(readOnly = true)
+	public LeagueRecordEntity getLeagueRecord(Long clubMemberId) {
+		return leagueRecordRepository.findByClubMember_ClubMemberId(clubMemberId)
+			.orElseThrow(() -> new ClubMemberNotExistException(clubMemberId));
+	}
+
+}

--- a/badminton-api/src/main/java/org/badminton/api/member/controller/MemberController.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package org.badminton.api.member.controller;
 
+import org.badminton.api.leaguerecord.service.LeagueRecordService;
 import org.badminton.api.member.jwt.JwtUtil;
 import org.badminton.api.member.model.dto.MemberDeleteResponse;
 import org.badminton.api.member.model.dto.MemberDetailResponse;
@@ -8,6 +9,7 @@ import org.badminton.api.member.model.dto.MemberUpdateResponse;
 import org.badminton.api.member.oauth2.dto.CustomOAuth2Member;
 import org.badminton.api.member.service.MemberService;
 import org.badminton.domain.clubmember.repository.ClubMemberRepository;
+import org.badminton.domain.leaguerecord.repository.LeagueRecordRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -33,6 +35,36 @@ public class MemberController {
 	private final MemberService memberService;
 	private final JwtUtil jwtUtil;
 	private final ClubMemberRepository clubMemberRepository;
+	private final LeagueRecordService leagueRecordService;
+	private final LeagueRecordRepository leagueRecordRepository;
+
+	//TODO: 티어 정상 작동 테스트용, 지울예정입니다
+	@Operation(
+		summary = "승리 기록 추가",
+		description = "회원의 리그 기록에 승리를 추가합니다",
+		tags = {"LeagueRecord"}
+	)
+	@PostMapping("/win")
+	public ResponseEntity<String> addWin(@AuthenticationPrincipal CustomOAuth2Member member) {
+		Long memberId = member.getMemberId();
+		Long clubMemberId = clubMemberRepository.findByMember_MemberId(memberId).get().getClubMemberId();
+		leagueRecordService.addWin(clubMemberId);
+		return ResponseEntity.ok("Win added successfully");
+	}
+
+	//TODO: 티어 정상 작동 테스트용, 지울예정입니다
+	@Operation(
+		summary = "패배 기록 추가",
+		description = "회원의 리그 기록에 패배를 추가합니다",
+		tags = {"LeagueRecord"}
+	)
+	@PostMapping("/lose")
+	public ResponseEntity<String> addLose(@AuthenticationPrincipal CustomOAuth2Member member) {
+		Long memberId = member.getMemberId();
+		Long clubMemberId = clubMemberRepository.findByMember_MemberId(memberId).get().getClubMemberId();
+		leagueRecordService.addLose(clubMemberId);
+		return ResponseEntity.ok("Loss added successfully");
+	}
 
 	@Operation(
 		summary = "액세스 토큰을 재발급합니다",

--- a/badminton-api/src/main/java/org/badminton/api/member/service/MemberService.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/service/MemberService.java
@@ -16,6 +16,8 @@ import org.badminton.api.member.oauth2.dto.CustomOAuth2Member;
 import org.badminton.api.member.validator.MemberValidator;
 import org.badminton.domain.clubmember.entity.ClubMemberEntity;
 import org.badminton.domain.clubmember.repository.ClubMemberRepository;
+import org.badminton.domain.leaguerecord.entity.LeagueRecordEntity;
+import org.badminton.domain.leaguerecord.repository.LeagueRecordRepository;
 import org.badminton.domain.member.entity.MemberEntity;
 import org.badminton.domain.member.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,6 +41,7 @@ public class MemberService {
 	private final MemberValidator memberValidator;
 	private final MemberRepository memberRepository;
 	private final ClubMemberRepository clubMemberRepository;
+	private final LeagueRecordRepository leagueRecordRepository;
 
 	@Value("${spring.security.oauth2.revoke-url.naver}")
 	private String naverRevokeUrl;
@@ -60,8 +63,13 @@ public class MemberService {
 		Optional<ClubMemberEntity> clubMemberEntity = clubMemberRepository.findByMember_MemberId(memberId);
 
 		return clubMemberEntity
-			.map(clubMember -> (MemberDetailResponse)ClubMemberInfoResponse.entityToClubMemberInfoResponse(memberEntity,
-				clubMember))
+			.map(clubMember -> {
+				LeagueRecordEntity leagueRecordEntity = leagueRecordRepository.findByClubMember(clubMember)
+					.orElse(new LeagueRecordEntity(clubMember));
+
+				return (MemberDetailResponse)ClubMemberInfoResponse.entityToClubMemberInfoResponse(memberEntity,
+					clubMember, leagueRecordEntity);
+			})
 			.orElseGet(() -> (MemberDetailResponse)MemberInfoResponse.entityToMemberInfoResponse(memberEntity));
 	}
 

--- a/badminton-api/src/main/resources/application.yaml
+++ b/badminton-api/src/main/resources/application.yaml
@@ -17,7 +17,7 @@ spring:
     basename: messages
   sql:
     init:
-      mode: never
+      mode: always
   datasource:
     url: ${DATABASE_URL}
     username: ${DATABASE_USER_NAME}

--- a/badminton-domain/src/main/java/org/badminton/domain/clubmember/entity/ClubMemberEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/clubmember/entity/ClubMemberEntity.java
@@ -2,16 +2,19 @@ package org.badminton.domain.clubmember.entity;
 
 import org.badminton.domain.club.entity.ClubEntity;
 import org.badminton.domain.common.BaseTimeEntity;
+import org.badminton.domain.leaguerecord.entity.LeagueRecordEntity;
 import org.badminton.domain.member.entity.MemberEntity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -39,6 +42,9 @@ public class ClubMemberEntity extends BaseTimeEntity {
 	@ManyToOne
 	@JoinColumn(name = "memberId")
 	private MemberEntity member;
+
+	@OneToOne(mappedBy = "clubMember", fetch = FetchType.LAZY)
+	private LeagueRecordEntity leagueRecord;
 
 	public ClubMemberEntity(ClubEntity club, MemberEntity member, ClubMemberRole role) {
 		this.club = club;

--- a/badminton-domain/src/main/java/org/badminton/domain/leaguerecord/entity/LeagueRecordEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/leaguerecord/entity/LeagueRecordEntity.java
@@ -45,42 +45,6 @@ public class LeagueRecordEntity extends BaseTimeEntity {
 	@JoinColumn(name = "clubMemberId")
 	private ClubMemberEntity clubMember;
 
-	public void addWind() {
-		this.winCount++;
-		this.matchCount++;
-		updateTier();
-	}
-
-	public void addLose() {
-		this.loseCount++;
-		this.matchCount++;
-		updateTier();
-	}
-
-	public void addDraw() {
-		this.drawCount++;
-		this.matchCount++;
-		updateTier();
-	}
-
-	public double getWinRate() {
-		if (matchCount == 0) {
-			return 0.0;
-		}
-		return (double)winCount / matchCount * 100;
-	}
-
-	private void updateTier() {
-		double winRate = getWinRate();
-		if (matchCount >= 20 && winRate >= 80) {
-			tier = MemberTier.GOLD;
-		} else if (matchCount >= 10 && matchCount < 20 && winRate >= 60) {
-			tier = MemberTier.SILVER;
-		} else {
-			tier = MemberTier.BRONZE;
-		}
-	}
-
 	public LeagueRecordEntity(ClubMemberEntity clubMember) {
 		this.clubMember = clubMember;
 		this.winCount = 0;
@@ -90,4 +54,23 @@ public class LeagueRecordEntity extends BaseTimeEntity {
 		this.tier = MemberTier.BRONZE;
 	}
 
+	public void updateWinCount(int winCount) {
+		this.winCount = winCount;
+	}
+
+	public void updateLoseCount(int loseCount) {
+		this.loseCount = loseCount;
+	}
+
+	public void updateDrawCount(int drawCount) {
+		this.drawCount = drawCount;
+	}
+
+	public void updateMatchCount(int matchCount) {
+		this.matchCount = matchCount;
+	}
+
+	public void updateTier(MemberTier tier) {
+		this.tier = tier;
+	}
 }

--- a/badminton-domain/src/main/java/org/badminton/domain/leaguerecord/entity/LeagueRecordEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/leaguerecord/entity/LeagueRecordEntity.java
@@ -1,0 +1,93 @@
+package org.badminton.domain.leaguerecord.entity;
+
+import org.badminton.domain.clubmember.entity.ClubMemberEntity;
+import org.badminton.domain.common.BaseTimeEntity;
+import org.badminton.domain.common.enums.MemberTier;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "league_record")
+public class LeagueRecordEntity extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long leagueRecordId;
+
+	private int winCount;
+
+	private int loseCount;
+
+	private int drawCount;
+
+	private int matchCount;
+
+	@Enumerated(EnumType.STRING)
+	private MemberTier tier;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "clubMemberId")
+	private ClubMemberEntity clubMember;
+
+	public void addWind() {
+		this.winCount++;
+		this.matchCount++;
+		updateTier();
+	}
+
+	public void addLose() {
+		this.loseCount++;
+		this.matchCount++;
+		updateTier();
+	}
+
+	public void addDraw() {
+		this.drawCount++;
+		this.matchCount++;
+		updateTier();
+	}
+
+	public double getWinRate() {
+		if (matchCount == 0) {
+			return 0.0;
+		}
+		return (double)winCount / matchCount * 100;
+	}
+
+	private void updateTier() {
+		double winRate = getWinRate();
+		if (matchCount >= 20 && winRate >= 80) {
+			tier = MemberTier.GOLD;
+		} else if (matchCount >= 10 && matchCount < 20 && winRate >= 60) {
+			tier = MemberTier.SILVER;
+		} else {
+			tier = MemberTier.BRONZE;
+		}
+	}
+
+	public LeagueRecordEntity(ClubMemberEntity clubMember) {
+		this.clubMember = clubMember;
+		this.winCount = 0;
+		this.loseCount = 0;
+		this.drawCount = 0;
+		this.matchCount = 0;
+		this.tier = MemberTier.BRONZE;
+	}
+
+}

--- a/badminton-domain/src/main/java/org/badminton/domain/leaguerecord/repository/LeagueRecordRepository.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/leaguerecord/repository/LeagueRecordRepository.java
@@ -1,0 +1,17 @@
+package org.badminton.domain.leaguerecord.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.badminton.domain.clubmember.entity.ClubMemberEntity;
+import org.badminton.domain.common.enums.MemberTier;
+import org.badminton.domain.leaguerecord.entity.LeagueRecordEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LeagueRecordRepository extends JpaRepository<LeagueRecordEntity, Long> {
+	Optional<LeagueRecordEntity> findByClubMember(ClubMemberEntity clubMember);
+
+	List<LeagueRecordEntity> findTop10ByOrderByWinCountDesc();
+
+	List<LeagueRecordEntity> findAllByTier(MemberTier tier);
+}

--- a/badminton-domain/src/main/java/org/badminton/domain/leaguerecord/repository/LeagueRecordRepository.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/leaguerecord/repository/LeagueRecordRepository.java
@@ -14,4 +14,6 @@ public interface LeagueRecordRepository extends JpaRepository<LeagueRecordEntity
 	List<LeagueRecordEntity> findTop10ByOrderByWinCountDesc();
 
 	List<LeagueRecordEntity> findAllByTier(MemberTier tier);
+
+	Optional<LeagueRecordEntity> findByClubMember_ClubMemberId(Long clubMemberId);
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍

### 경기횟수와 승률 기준으로 회원 등급 승급 기능 구현

#### 브론즈
- 가입 즉시
#### 실버
- 경기 횟수 10회 이상
승률 60% 이상(승리 횟수/총 경기수)
#### 골드
- 경기 횟수 20회 이상
- 승률 80% 이상(승리 횟수/총 경기수)

#### 회원 정보 마이페이지에 티어 정보, 전적 정보 추가

## 변경된 사항 📝

![image](https://github.com/user-attachments/assets/52b91cf3-09b0-48bb-a6dc-db6f2657800c)

## PR에서 중점적으로 확인되어야 하는 사항

### memberController의 승리 기록 추가, 패배 기록 추가 api는 테스트용으로 만들어두었습니다 추후 삭제할 예정입니다

### 경기결과 로직 만드실 때 LeagueRecordServiced의 `addWin`, `addLose`, `addDraw` 메서드 사용하시면 될것 같아요 😄 
