### PR TITLE
다형성을 이용해 중복 분기 제거

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/common/exception/match/MatchNotExistException.java
+++ b/badminton-api/src/main/java/org/badminton/api/common/exception/match/MatchNotExistException.java
@@ -5,10 +5,16 @@ import org.badminton.api.common.exception.BadmintonException;
 import org.badminton.domain.common.enums.MatchType;
 
 public class MatchNotExistException extends BadmintonException {
+	public MatchNotExistException(Long matchId, MatchType matchType) {
+		super(ErrorCode.MATCH_NOT_EXIST,
+				"[경기 일정 아이디 : " + matchId + " 대진 아이디 : " + matchId + " 경기 타입 : "
+						+ matchType.getDescription());
+	}
+
 	public MatchNotExistException(Long clubId, Long leagueId, Long matchId, MatchType matchType) {
 		super(ErrorCode.MATCH_NOT_EXIST,
-			"[동호회 아이디 : " + leagueId + " 경기 일정 아이디 : " + matchId + " 대진 아이디 : " + matchId + " 경기 타입 : "
-				+ matchType.getDescription());
+				"[동호회 아이디 : " + leagueId + " 경기 일정 아이디 : " + matchId + " 대진 아이디 : " + matchId + " 경기 타입 : "
+						+ matchType.getDescription());
 	}
 
 	public MatchNotExistException(Long clubId, Long leagueId, Long matchId, MatchType matchType, Exception e) {

--- a/badminton-api/src/main/java/org/badminton/api/match/DoublesMatchProgress.java
+++ b/badminton-api/src/main/java/org/badminton/api/match/DoublesMatchProgress.java
@@ -1,0 +1,58 @@
+package org.badminton.api.match;
+
+import lombok.AllArgsConstructor;
+import org.badminton.api.common.exception.match.MatchNotExistException;
+import org.badminton.api.match.model.dto.MatchDetailsResponse;
+import org.badminton.api.match.model.dto.SetScoreUpdateRequest;
+import org.badminton.api.match.model.dto.SetScoreUpdateResponse;
+import org.badminton.domain.common.enums.MatchType;
+import org.badminton.domain.match.model.entity.DoublesMatchEntity;
+import org.badminton.domain.match.model.entity.DoublesSetEntity;
+import org.badminton.domain.match.repository.DoublesMatchRepository;
+
+import java.util.List;
+
+@AllArgsConstructor
+public class DoublesMatchProgress implements MatchProgress {
+    private DoublesMatchRepository doublesMatchRepository;
+
+    @Override
+    public List<MatchDetailsResponse> initDetails(Long leagueId) {
+        List<DoublesMatchEntity> doublesMatchList = doublesMatchRepository.findAllByLeague_LeagueId(leagueId);
+
+        return doublesMatchList.stream()
+                .map(this::initDoublesMatch)
+                .map(MatchDetailsResponse::entityToDoublesMatchDetailsResponse).toList();
+    }
+
+    @Override
+    public SetScoreUpdateResponse updateSetScore(Long matchId, int setIndex, SetScoreUpdateRequest setScoreUpdateRequest) {
+        // DoublesSetEntity를 꺼내온다.
+
+        DoublesMatchEntity doublesMatch = doublesMatchRepository.findById(matchId).orElseThrow(
+                () -> new MatchNotExistException(matchId, MatchType.DOUBLES));
+
+        // 세트 스코어를 기록한다.
+        doublesMatch.getDoublesSets()
+                .get(setIndex - 1)
+                .saveSetScore(setScoreUpdateRequest.score1(), setScoreUpdateRequest.score2());
+        doublesMatchRepository.save(doublesMatch);
+        return SetScoreUpdateResponse.doublesSetEntityToSetScoreUpdateResponse(
+                doublesMatch.getDoublesSets().get(setIndex - 1));
+    }
+
+    private DoublesMatchEntity initDoublesMatch(DoublesMatchEntity doublesMatch) {
+        // 복식 게임 세트를 3개 생성
+        DoublesSetEntity set1 = new DoublesSetEntity(doublesMatch, 1);
+        DoublesSetEntity set2 = new DoublesSetEntity(doublesMatch, 2);
+        DoublesSetEntity set3 = new DoublesSetEntity(doublesMatch, 3);
+
+        // 복식 게임 결과를 생성
+        doublesMatch.addSet(set1);
+        doublesMatch.addSet(set2);
+        doublesMatch.addSet(set3);
+
+        doublesMatchRepository.save(doublesMatch);
+        return doublesMatch;
+    }
+}

--- a/badminton-api/src/main/java/org/badminton/api/match/MatchProgress.java
+++ b/badminton-api/src/main/java/org/badminton/api/match/MatchProgress.java
@@ -1,0 +1,12 @@
+package org.badminton.api.match;
+
+import org.badminton.api.match.model.dto.MatchDetailsResponse;
+import org.badminton.api.match.model.dto.SetScoreUpdateRequest;
+import org.badminton.api.match.model.dto.SetScoreUpdateResponse;
+
+import java.util.List;
+
+public interface MatchProgress {
+    List<MatchDetailsResponse> initDetails(Long leagueId);
+    SetScoreUpdateResponse updateSetScore(Long matchId, int setIndex, SetScoreUpdateRequest setScoreUpdateRequest);
+}

--- a/badminton-api/src/main/java/org/badminton/api/match/SinglesMatchProgress.java
+++ b/badminton-api/src/main/java/org/badminton/api/match/SinglesMatchProgress.java
@@ -1,0 +1,57 @@
+package org.badminton.api.match;
+
+import lombok.AllArgsConstructor;
+import org.badminton.api.common.exception.match.MatchNotExistException;
+import org.badminton.api.match.model.dto.MatchDetailsResponse;
+import org.badminton.api.match.model.dto.SetScoreUpdateRequest;
+import org.badminton.api.match.model.dto.SetScoreUpdateResponse;
+import org.badminton.domain.common.enums.MatchType;
+import org.badminton.domain.match.model.entity.SinglesMatchEntity;
+import org.badminton.domain.match.model.entity.SinglesSetEntity;
+import org.badminton.domain.match.repository.SinglesMatchRepository;
+
+import java.util.List;
+
+@AllArgsConstructor
+public class SinglesMatchProgress implements MatchProgress {
+    private SinglesMatchRepository singlesMatchRepository;
+
+    @Override
+    public List<MatchDetailsResponse> initDetails(Long leagueId) {
+        List<SinglesMatchEntity> singlesMatchList = singlesMatchRepository.findAllByLeague_LeagueId(leagueId);
+
+        return singlesMatchList.stream()
+                .map(this::initSinglesMatch)
+                .map(MatchDetailsResponse::entityToSinglesMatchDetailsResponse).toList();
+    }
+
+    @Override
+    public SetScoreUpdateResponse updateSetScore(Long matchId, int setIndex, SetScoreUpdateRequest setScoreUpdateRequest) {
+        // SinglesSetEntity를 꺼내온다.
+        SinglesMatchEntity singlesMatch = singlesMatchRepository.findById(matchId).orElseThrow(
+                () -> new MatchNotExistException(matchId, MatchType.SINGLE)
+        );
+
+        // 세트 스코어를 기록한다.
+        singlesMatch.getSinglesSets()
+                .get(setIndex - 1)
+                .saveSetScore(setScoreUpdateRequest.score1(), setScoreUpdateRequest.score2());
+        singlesMatchRepository.save(singlesMatch);
+        return SetScoreUpdateResponse.singlesSetentityToSetScoreUpdateResponse(
+                singlesMatch.getSinglesSets().get(setIndex - 1));
+    }
+
+    private SinglesMatchEntity initSinglesMatch(SinglesMatchEntity singlesMatch) {
+        //단식 게임 세트를 3개 생성
+        SinglesSetEntity set1 = new SinglesSetEntity(singlesMatch, 1);
+        SinglesSetEntity set2 = new SinglesSetEntity(singlesMatch, 2);
+        SinglesSetEntity set3 = new SinglesSetEntity(singlesMatch, 3);
+
+        singlesMatch.addSet(set1);
+        singlesMatch.addSet(set2);
+        singlesMatch.addSet(set3);
+
+        singlesMatchRepository.save(singlesMatch);
+        return singlesMatch;
+    }
+}

--- a/badminton-api/src/main/java/org/badminton/api/match/service/MatchProgressService.java
+++ b/badminton-api/src/main/java/org/badminton/api/match/service/MatchProgressService.java
@@ -6,6 +6,9 @@ import org.badminton.api.common.error.ErrorCode;
 import org.badminton.api.common.exception.BadmintonException;
 import org.badminton.api.common.exception.league.LeagueNotExistException;
 import org.badminton.api.common.exception.match.MatchNotExistException;
+import org.badminton.api.match.DoublesMatchProgress;
+import org.badminton.api.match.MatchProgress;
+import org.badminton.api.match.SinglesMatchProgress;
 import org.badminton.api.match.model.dto.MatchDetailsResponse;
 import org.badminton.api.match.model.dto.SetScoreUpdateRequest;
 import org.badminton.api.match.model.dto.SetScoreUpdateResponse;
@@ -25,107 +28,42 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class MatchProgressService {
-	private final SinglesMatchRepository singlesMatchRepository;
-	private final DoublesMatchRepository doublesMatchRepository;
+    private final SinglesMatchRepository singlesMatchRepository;
+    private final DoublesMatchRepository doublesMatchRepository;
 
-	private final LeagueRepository leagueRepository;
+    private final LeagueRepository leagueRepository;
 
-	public List<MatchDetailsResponse> initMatchDetails(Long clubId, Long leagueId) {
-		// 경기 일정이 있는지 확인하고 꺼내기
-		LeagueEntity league = leagueRepository.findById(leagueId)
-			.orElseThrow(() -> new LeagueNotExistException(clubId, leagueId));
+    public List<MatchDetailsResponse> initMatchDetails(Long clubId, Long leagueId) {
+        // 경기 일정이 있는지 확인하고 꺼내기
+        LeagueEntity league = leagueRepository.findById(leagueId)
+                .orElseThrow(() -> new LeagueNotExistException(clubId, leagueId));
 
-		// 경기 타입을 구분하여 처리하기 위해
-		MatchType matchType = league.getMatchType();
+        // 경기 타입을 구분하여 처리하기 위해
+        MatchType matchType = league.getMatchType();
 
-		if (matchType == MatchType.SINGLE) {
-			List<SinglesMatchEntity> singlesMatchList = singlesMatchRepository.findAllByLeague_LeagueId(leagueId);
+        MatchProgress matchProgress = createMatchProgress(matchType);
+        return matchProgress.initDetails(leagueId);
+    }
 
-			return singlesMatchList.stream()
-				.map(this::initSinglesMatch)
-				.map(MatchDetailsResponse::entityToSinglesMatchDetailsResponse).toList();
+    // 한 세트가 끝나고 세트 결과를 저장
+    public SetScoreUpdateResponse updateSetScore(Long clubId, Long leagueId, Long matchId, int setIndex,
+                                                 SetScoreUpdateRequest setScoreUpdateRequest) {
+        // 경기 일정이 있는지 확인하고 꺼내기
+        LeagueEntity league = leagueRepository.findById(leagueId)
+                .orElseThrow(() -> new LeagueNotExistException(clubId, leagueId));
 
-		} else if (matchType == MatchType.DOUBLES) {
-			List<DoublesMatchEntity> doublesMatchList = doublesMatchRepository.findAllByLeague_LeagueId(leagueId);
+        // 경기 타입을 구분하여 처리하기 위해
+        MatchType matchType = league.getMatchType();
 
-			return doublesMatchList.stream()
-				.map(this::initDoublesMatch)
-				.map(MatchDetailsResponse::entityToDoublesMatchDetailsResponse).toList();
-		}
-		throw new BadmintonException(ErrorCode.INVALID_PARAMETER, "적절하지 않은 경기 타입입니다.");
+        MatchProgress matchProgress = createMatchProgress(matchType);
+        return matchProgress.updateSetScore(matchId, setIndex, setScoreUpdateRequest);
+    }
 
-	}
-
-	private SinglesMatchEntity initSinglesMatch(SinglesMatchEntity singlesMatch) {
-		//단식 게임 세트를 3개 생성
-		SinglesSetEntity set1 = new SinglesSetEntity(singlesMatch, 1);
-		SinglesSetEntity set2 = new SinglesSetEntity(singlesMatch, 2);
-		SinglesSetEntity set3 = new SinglesSetEntity(singlesMatch, 3);
-
-		singlesMatch.addSet(set1);
-		singlesMatch.addSet(set2);
-		singlesMatch.addSet(set3);
-
-		singlesMatchRepository.save(singlesMatch);
-		return singlesMatch;
-	}
-
-	private DoublesMatchEntity initDoublesMatch(DoublesMatchEntity doublesMatch) {
-		// 복식 게임 세트를 3개 생성
-		DoublesSetEntity set1 = new DoublesSetEntity(doublesMatch, 1);
-		DoublesSetEntity set2 = new DoublesSetEntity(doublesMatch, 2);
-		DoublesSetEntity set3 = new DoublesSetEntity(doublesMatch, 3);
-
-		// 복식 게임 결과를 생성
-		doublesMatch.addSet(set1);
-		doublesMatch.addSet(set2);
-		doublesMatch.addSet(set3);
-
-		doublesMatchRepository.save(doublesMatch);
-		return doublesMatch;
-	}
-
-	// 한 세트가 끝나고 세트 결과를 저장
-	public SetScoreUpdateResponse updateSetScore(Long clubId, Long leagueId, Long matchId, int setIndex,
-		SetScoreUpdateRequest setScoreUpdateRequest) {
-		// 경기 일정이 있는지 확인하고 꺼내기
-		LeagueEntity league = leagueRepository.findById(leagueId)
-			.orElseThrow(() -> new LeagueNotExistException(clubId, leagueId));
-
-		// 경기 타입을 구분하여 처리하기 위해
-		MatchType matchType = league.getMatchType();
-
-		// 경기 타입이 단식이면,
-		if (matchType == MatchType.SINGLE) {
-			// SinglesSetEntity를 꺼내온다.
-			SinglesMatchEntity singlesMatch = singlesMatchRepository.findById(matchId).orElseThrow(
-				() -> new MatchNotExistException(clubId, leagueId, matchId, matchType)
-			);
-
-			// 세트 스코어를 기록한다.
-			singlesMatch.getSinglesSets()
-				.get(setIndex - 1)
-				.saveSetScore(setScoreUpdateRequest.score1(), setScoreUpdateRequest.score2());
-			singlesMatchRepository.save(singlesMatch);
-			return SetScoreUpdateResponse.singlesSetentityToSetScoreUpdateResponse(
-				singlesMatch.getSinglesSets().get(setIndex - 1));
-		} else if (matchType == MatchType.DOUBLES) {
-
-			// DoublesSetEntity를 꺼내온다.
-
-			DoublesMatchEntity doublesMatch = doublesMatchRepository.findById(matchId).orElseThrow(
-				() -> new MatchNotExistException(clubId, leagueId, matchId, matchType));
-
-			// 세트 스코어를 기록한다.
-			doublesMatch.getDoublesSets()
-				.get(setIndex - 1)
-				.saveSetScore(setScoreUpdateRequest.score1(), setScoreUpdateRequest.score2());
-			doublesMatchRepository.save(doublesMatch);
-			return SetScoreUpdateResponse.doublesSetEntityToSetScoreUpdateResponse(
-				doublesMatch.getDoublesSets().get(setIndex - 1));
-		}
-
-		throw new BadmintonException(ErrorCode.INVALID_PARAMETER, "적절하지 않은 경기 타입입니다.");
-	}
+    private MatchProgress createMatchProgress(MatchType matchType) {
+        return switch (matchType) {
+            case SINGLE -> new SinglesMatchProgress(singlesMatchRepository);
+            case DOUBLES -> new DoublesMatchProgress(doublesMatchRepository);
+        };
+    }
 
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍
- Service 내에서 메서드 마다 반복되던 분기문을 제거하는 내용입니다. 각 타입(single/double)에 따라 다르게 행동해야하기 때문에 `MatchProgress` 라는 인터페이스를 정의하고, 각 타입별로 이를 구현하도록 했습니다. 타입별로 달라지는 로직은 각 구현체 내에서 실행하며, 각 구현체를 만드는 시점에만 분기문이 사용되게 했습니다. 각 타입별로 변경되는 내용이 생긴다면 타입별 구현체 내에서만 수정해주면 되기 때문에 지속적으로 분기가 나오는걸 방지할 수 있을거라고 생각합니다. 구현체 내용은 기존 Service 내에 있던 로직을 그대로 가져왔기 때문에 로직은 달라지는 부분 없고, 인터페이스 분리만 참고해보시면 됩니다.

## 변경된 사항 📝

<!-- 이번 PR에서의 변경점 -->

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF, 글 -->

### Before

### After

## PR에서 중점적으로 확인되어야 하는 사항
