### PR TITLE
feat: 로그아웃 시 oAuth 연결끊기 구현

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubsReadResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubsReadResponse.java
@@ -7,6 +7,7 @@ import org.badminton.domain.club.entity.ClubEntity;
 import org.badminton.domain.common.enums.MemberTier;
 
 public record ClubsReadResponse(
+	Long clubId,
 	String clubName,
 	String clubDescription,
 	String clubImage,
@@ -17,7 +18,7 @@ public record ClubsReadResponse(
 
 	public static ClubsReadResponse clubEntityToClubsReadResponse(ClubEntity clubEntity,
 		Map<MemberTier, Long> tierCounts) {
-		return new ClubsReadResponse(clubEntity.getClubName(), clubEntity.getClubDescription(),
+		return new ClubsReadResponse(clubEntity.getClubId(),clubEntity.getClubName(), clubEntity.getClubDescription(),
 			clubEntity.getClubImage(),
 			clubEntity.getCreatedAt(),
 			clubEntity.getModifiedAt(),

--- a/badminton-api/src/main/java/org/badminton/api/config/jpa/JpaConfig.java
+++ b/badminton-api/src/main/java/org/badminton/api/config/jpa/JpaConfig.java
@@ -1,13 +1,20 @@
 package org.badminton.api.config.jpa;
 
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 @EntityScan(basePackages = "org.badminton.domain")
 @EnableJpaRepositories(basePackages = "org.badminton.domain")
 @EnableJpaAuditing
 public class JpaConfig {
+
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
 }

--- a/badminton-api/src/main/java/org/badminton/api/filter/JwtAuthenticationFilter.java
+++ b/badminton-api/src/main/java/org/badminton/api/filter/JwtAuthenticationFilter.java
@@ -38,10 +38,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			List<ClubMemberEntity> clubMemberEntities = clubMemberService.findAllClubMembersByMemberId(
 				Long.valueOf(memberId));
 
+			String oAuthAccessToken = jwtUtil.getOAuthToken(token);
+
 			MemberResponse memberResponse = new MemberResponse(Long.valueOf(memberId),
 				MemberAuthorization.AUTHORIZATION_USER.toString());
 			CustomOAuth2Member customOAuth2Member = new CustomOAuth2Member(memberResponse,
-				jwtUtil.getRegistrationId(token));
+				jwtUtil.getRegistrationId(token), oAuthAccessToken);
 
 			for (ClubMemberEntity clubMember : clubMemberEntities) {
 				customOAuth2Member.addClubRole(clubMember.getClub().getClubId(), clubMember.getRole().name());

--- a/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtUtil.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtUtil.java
@@ -34,11 +34,13 @@ public class JwtUtil {
 			Jwts.SIG.HS256.key().build().getAlgorithm()); // 비밀 키 생성
 	}
 
-	public String createAccessToken(String memberId, List<String> roles, String registrationId) {
+	public String createAccessToken(String memberId, List<String> roles, String registrationId, String oAuthAccessToken) {
+
 		return Jwts.builder()
 			.claim("memberId", memberId)
 			.claim("roles", String.join(",", roles)) // List<String>을 String으로 변환하여 JWT에 추가
 			.claim("registrationId", registrationId)
+			.claim("oAuthAccessToken", oAuthAccessToken)
 			.issuedAt(new Date(System.currentTimeMillis())) // 토큰 발행 시각 설정
 			.expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRY)) // 만료 시각 설정 (현재 시각 + expiredMs)
 			.signWith(secretKey) // secretKey 로 서명
@@ -50,6 +52,7 @@ public class JwtUtil {
 			.claim("memberId", memberId)
 			.claim("roles", String.join(",", roles)) // List<String>을 String으로 변환하여 JWT에 추가
 			.claim("registrationId", registrationId)
+			// .claim("oAuthAccessToken", oAuthAccessToken)
 			.expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRY))
 			.signWith(secretKey)
 			.compact();
@@ -61,24 +64,24 @@ public class JwtUtil {
 
 	public void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
 		ResponseCookie cookie = ResponseCookie.from("refresh_token", refreshToken)
-			.httpOnly(true)
-			.secure(true)
+			// .httpOnly(true)
+			// .secure(true)
+			// .sameSite("None")
+			// .domain(domain)
 			.path("/")
 			.maxAge(REFRESH_TOKEN_EXPIRY) // 14일
-			.sameSite("None")
-			.domain(domain)
 			.build();
 		response.addHeader("Set-Cookie", cookie.toString());
 	}
 
 	public void setAccessTokenCookie(HttpServletResponse response, String accessToken) {
 		ResponseCookie cookie = ResponseCookie.from("access_token", accessToken)
-			.httpOnly(true)
-			.secure(true)
+			// .httpOnly(true)
+			// .secure(true)
+			// .sameSite("None")
+			// .domain(domain)
 			.path("/")
 			.maxAge(ACCESS_TOKEN_EXPIRY) // 14일
-			.sameSite("None")
-			.domain(domain)
 			.build();
 		response.addHeader("Set-Cookie", cookie.toString());
 	}
@@ -89,8 +92,12 @@ public class JwtUtil {
 
 	public String getRegistrationId(String token) {
 		return getDetail(token, "registrationId");
+
 	}
 
+	public String getOAuthToken(String token) {
+		return getDetail(token, "oAuthAccessToken");
+	}
 	public List<String> getRoles(String token) {
 		String rolesString = getDetail(token, "roles");
 		return (rolesString != null) ? List.of(rolesString.split(",")) : Collections.emptyList(); // 문자열을 List로 변환

--- a/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtUtil.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtUtil.java
@@ -64,10 +64,10 @@ public class JwtUtil {
 
 	public void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
 		ResponseCookie cookie = ResponseCookie.from("refresh_token", refreshToken)
-			// .httpOnly(true)
-			// .secure(true)
-			// .sameSite("None")
-			// .domain(domain)
+			.httpOnly(true)
+			.secure(true)
+			.sameSite("None")
+			.domain(domain)
 			.path("/")
 			.maxAge(REFRESH_TOKEN_EXPIRY) // 14일
 			.build();
@@ -76,10 +76,10 @@ public class JwtUtil {
 
 	public void setAccessTokenCookie(HttpServletResponse response, String accessToken) {
 		ResponseCookie cookie = ResponseCookie.from("access_token", accessToken)
-			// .httpOnly(true)
-			// .secure(true)
-			// .sameSite("None")
-			// .domain(domain)
+			.httpOnly(true)
+			.secure(true)
+			.sameSite("None")
+			.domain(domain)
 			.path("/")
 			.maxAge(ACCESS_TOKEN_EXPIRY) // 14일
 			.build();

--- a/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtUtil.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/jwt/JwtUtil.java
@@ -31,28 +31,27 @@ public class JwtUtil {
 
 	public JwtUtil(@Value("${spring.jwt.secret}") String secret) {
 		secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
-			Jwts.SIG.HS256.key().build().getAlgorithm()); // 비밀 키 생성
+			Jwts.SIG.HS256.key().build().getAlgorithm());
 	}
 
 	public String createAccessToken(String memberId, List<String> roles, String registrationId, String oAuthAccessToken) {
 
 		return Jwts.builder()
 			.claim("memberId", memberId)
-			.claim("roles", String.join(",", roles)) // List<String>을 String으로 변환하여 JWT에 추가
+			.claim("roles", String.join(",", roles))
 			.claim("registrationId", registrationId)
 			.claim("oAuthAccessToken", oAuthAccessToken)
-			.issuedAt(new Date(System.currentTimeMillis())) // 토큰 발행 시각 설정
-			.expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRY)) // 만료 시각 설정 (현재 시각 + expiredMs)
-			.signWith(secretKey) // secretKey 로 서명
-			.compact(); // Jwt 를 문자열로 변환
+			.issuedAt(new Date(System.currentTimeMillis()))
+			.expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRY))
+			.signWith(secretKey)
+			.compact();
 	}
 
 	public String createRefreshToken(String memberId, List<String> roles, String registrationId) {
 		return Jwts.builder()
 			.claim("memberId", memberId)
-			.claim("roles", String.join(",", roles)) // List<String>을 String으로 변환하여 JWT에 추가
+			.claim("roles", String.join(",", roles))
 			.claim("registrationId", registrationId)
-			// .claim("oAuthAccessToken", oAuthAccessToken)
 			.expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRY))
 			.signWith(secretKey)
 			.compact();

--- a/badminton-api/src/main/java/org/badminton/api/member/oauth2/CustomSuccessHandler.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/oauth2/CustomSuccessHandler.java
@@ -49,19 +49,20 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 		String registrationId = customUserDetails.getRegistrationId();
 
-		// ClubMemberEntity clubMemberEntity = clubMemberRepository.findByMember_MemberId(memberId)
-		// 	.orElse(null);
-		// String clubRole = (clubMemberEntity != null) ? clubMemberEntity.getRole().name() : "ROLE_NOUSER";
-		//
-		// customUserDetails.updateClubRole(clubRole);
+		String oAuthAccessToken = customUserDetails.getOAuthAccessToken();
 
 		List<String> roles = customUserDetails.getAuthorities().stream()
 			.map(GrantedAuthority::getAuthority)
 			.toList();
 
+
+
 		log.info("roles: {}", roles);
 
-		String accessToken = jwtUtil.createAccessToken(String.valueOf(memberId), roles, registrationId);
+		String accessToken = jwtUtil.createAccessToken(String.valueOf(memberId), roles, registrationId, oAuthAccessToken);
+
+		log.info("Extracted from JWT - registrationId: {}, oAuthAccessToken: {}",
+			jwtUtil.getRegistrationId(accessToken), jwtUtil.getOAuthToken(accessToken));
 
 		String refreshToken = jwtUtil.createRefreshToken(String.valueOf(memberId), roles, registrationId);
 

--- a/badminton-api/src/main/java/org/badminton/api/member/oauth2/dto/CustomOAuth2Member.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/oauth2/dto/CustomOAuth2Member.java
@@ -19,8 +19,15 @@ public class CustomOAuth2Member implements OAuth2User {
 
 	private final MemberResponse memberResponse;
 
+
 	@Getter
 	private final String registrationId;
+
+	private final String oAuthAccessToken;
+
+	public String getOAuthAccessToken() {
+		return this.oAuthAccessToken;
+	}
 
 	private Map<Long, String> clubRoles = new HashMap<>();
 

--- a/badminton-api/src/main/java/org/badminton/api/member/service/CustomOAuth2MemberService.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/service/CustomOAuth2MemberService.java
@@ -38,6 +38,7 @@ public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
 		String registrationId = userRequest.getClientRegistration().getRegistrationId();
 		log.info("registrationId: {}", registrationId);
 		OAuthResponse oAuth2Response = null;
+		String oAuthAccessToken = userRequest.getAccessToken().getTokenValue();
 
 		switch (registrationId) {
 			case "naver" -> oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
@@ -47,7 +48,6 @@ public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
 				return null;
 			}
 		}
-
 		String providerId = oAuth2Response.getProviderId();
 		MemberEntity memberEntity = memberRepository.findByProviderId(providerId).orElse(null);
 
@@ -66,7 +66,7 @@ public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
 		memberRepository.save(memberEntity);
 
 		MemberResponse memberResponse = memberEntityToResponse(memberEntity);
-		return new CustomOAuth2Member(memberResponse, registrationId);
+		return new CustomOAuth2Member(memberResponse, registrationId, oAuthAccessToken);
 
 	}
 }

--- a/badminton-api/src/main/resources/application.yaml
+++ b/badminton-api/src/main/resources/application.yaml
@@ -63,9 +63,9 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
       revoke-url:
-        naver: "https://nid.naver.com/oauth2.0/token?grant_type=delete&client_id={client_id}&client_secret={client_secret}&access_token={access_token}&service_provider=NAVER"
+        naver: "https://nid.naver.com/oauth2.0/token"
         kakao: "https://kapi.kakao.com/v1/user/unlink"
-        google: "https://accounts.google.com/o/oauth2/revoke?token={access_token}"
+        google: "https://accounts.google.com/o/oauth2/revoke"
   servlet:
     multipart:
       enabled: true


### PR DESCRIPTION
## PR에 대한 설명 🔍
회원탈퇴 시 oAuth 연결끊기 설정하여 다시 로그인 시 동의항목을 다시 받도록 수정
+ 동호회 전체 조회시 clubId 추가

## PR에서 중점적으로 확인되어야 하는 사항

추후 refreshToken 과 oAuthAccessToken 위치 수정 예정
