### PR TITLE
feat: 특정 년, 월을 통한 조회 기능 추가

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/common/exception/league/InvalidDateTimeException.java
+++ b/badminton-api/src/main/java/org/badminton/api/common/exception/league/InvalidDateTimeException.java
@@ -1,0 +1,14 @@
+package org.badminton.api.common.exception.league;
+
+import org.badminton.api.common.error.ErrorCode;
+import org.badminton.api.common.exception.BadmintonException;
+
+public class InvalidDateTimeException extends BadmintonException {
+	public InvalidDateTimeException(int year, int month) {
+		super(ErrorCode.INVALID_RESOURCE, "[유효하지 않은 날짜 : " + year + "년 " + month + "월]");
+	}
+
+	public InvalidDateTimeException(int year, int month, Exception exception) {
+		super(ErrorCode.INVALID_RESOURCE, "[유효하지 않은 날짜 : " + year + "년 " + month + "월]", exception);
+	}
+}

--- a/badminton-api/src/main/java/org/badminton/api/league/controller/LeagueController.java
+++ b/badminton-api/src/main/java/org/badminton/api/league/controller/LeagueController.java
@@ -1,5 +1,7 @@
 package org.badminton.api.league.controller;
 
+import java.util.List;
+
 import org.badminton.api.league.model.dto.LeagueCreateRequest;
 import org.badminton.api.league.model.dto.LeagueCreateResponse;
 import org.badminton.api.league.model.dto.LeagueReadResponse;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,6 +29,18 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/v1/clubs/{clubId}/leagues")
 public class LeagueController {
 	private final LeagueService leagueService;
+
+	@Operation(
+		summary = "년, 월별로 검색합니다.",
+		description = "검색조건에 따라 경기를 검색합니다.",
+		tags = {"league"}
+	)
+	@GetMapping()
+	public ResponseEntity<List<LeagueReadResponse>> leagueReadByCondition(@PathVariable Long clubId,
+		@RequestParam Integer year,
+		@RequestParam Integer month) {
+		return ResponseEntity.ok(leagueService.getLeagues(clubId, year, month));
+	}
 
 	@Operation(
 		summary = "경기를 생성합니다.",

--- a/badminton-domain/src/main/java/org/badminton/domain/league/repository/LeagueRepository.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/league/repository/LeagueRepository.java
@@ -1,5 +1,7 @@
 package org.badminton.domain.league.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.badminton.domain.league.entity.LeagueEntity;
@@ -8,6 +10,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface LeagueRepository extends JpaRepository<LeagueEntity, Long> {
 
 	Optional<LeagueEntity> findByClubClubIdAndLeagueId(Long clubId, Long leagueId);
+
+	List<LeagueEntity> findAllByClubClubIdAndLeagueAtBetween(Long clubId, LocalDateTime startOfMonth,
+		LocalDateTime endOfMonth);
 
 	void deleteByLeagueId(Long leagueId);
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍
- PR의 내용에 대한 설명을 자세히 설명 
특정 년, 월을 통해 조회하는 기능입니다.
년 월을 통해 조회하는 기능이라 쿼리파라미터를 통해 조회하도록 하였습니다. 
명시적으로 ?year=2024&month=1 과 같이 사용하면 좀 더 직관적으로 데이터를 조회할 수 있을 것 같아서 쿼리파라미터로 요청하도록 하였습니다. 

## 변경된 사항 📝

<!-- 이번 PR에서의 변경점 -->
<img width="841" alt="image" src="https://github.com/user-attachments/assets/41ad8216-0160-47f4-9e5b-95fcb487cd17">

리스트 타입으로 경기를 조회하고 있습니다.
그리고 다시 LeagueReadResponse 타입으로 변경하고 List<LeagueReadResponse> 으로 리턴 하고 있습니다.

## PR에서 중점적으로 확인되어야 하는 사항
쿼리로 검색 한 리스트 -> 별개의 데이터 ->  LeagueReadResponse 타입 변환 -> 리스트에 저장-> 반환 순으로 로직이 작성되어 있습니다. 
이렇게 작성하니 응답시간이 다소 느린 것을 확인했습니다. 
어떻게 하면 응답시간을 줄일 수 있을 까요?

```java
public List<LeagueReadResponse> getLeagues(Long clubId, Integer year, Integer month) {
		if (!validateDate(year, month)) {
			throw new InvalidDateTimeException(year, month);
		}

		LocalDateTime startOfMonth = LocalDateTime.of(LocalDate.of(year, month, START_MONTH), LocalTime.MIN);

		LocalDateTime endOfMonth = LocalDateTime.of(
			LocalDate.of(year, month, startOfMonth.toLocalDate().lengthOfMonth()), LocalTime.MAX);

		List<LeagueEntity> result = leagueRepository.findAllByClubClubIdAndLeagueAtBetween(clubId, startOfMonth,
			endOfMonth);

		return result.stream()
			.map(LeagueReadResponse::leagueReadEntityToResponse)
			.collect(
				Collectors.toList());
	}

	private boolean validateDate(Integer year, Integer month) {
		int yearsPrevCompare = LocalDate.now().minusYears(20).getYear();
		int yearsNextCompare = LocalDate.now().plusYears(20).getYear();
		if (yearsPrevCompare > year || yearsNextCompare < year) {
			return false;
		}
		return month >= JANUARY && month <= DECEMBER;
	}
```

