### PR TITLE
feat: S3 이미지 업로드 인터페이스, 회원 프로필 사진 수정 시 S3 연결

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/aws/s3/controller/ClubImageController.java
+++ b/badminton-api/src/main/java/org/badminton/api/aws/s3/controller/ClubImageController.java
@@ -1,6 +1,6 @@
 package org.badminton.api.aws.s3.controller;
 
-import org.badminton.api.aws.s3.model.dto.ClubImageUploadRequest;
+import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
 import org.badminton.api.aws.s3.service.ClubImageService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,15 +27,16 @@ public class ClubImageController {
 			required = true,
 			content = @Content(
 				mediaType = "multipart/form-data",
-				schema = @Schema(implementation = ClubImageUploadRequest.class)
+				schema = @Schema(implementation = ImageUploadRequest.class)
 			)
 		)
 	)
 	@PostMapping
 	public ResponseEntity<String> saveImage(@RequestPart("multipartFile") MultipartFile multipartFile) {
-		ClubImageUploadRequest request = new ClubImageUploadRequest(multipartFile);
+		ImageUploadRequest request = new ImageUploadRequest(multipartFile);
 		return ResponseEntity.ok(clubImageService.uploadFile(request));
 	}
 	//TODO : 임시 테이블을 만들어 저장하고 배치에서 동호회 url 을 조회 후 미사용 객체들을 모두 삭제
 
 }
+

--- a/badminton-api/src/main/java/org/badminton/api/aws/s3/model/dto/ImageUploadRequest.java
+++ b/badminton-api/src/main/java/org/badminton/api/aws/s3/model/dto/ImageUploadRequest.java
@@ -8,8 +8,9 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(PropertyNamingStrategies.LowerCamelCaseStrategy.class)
-public record ClubImageUploadRequest(
+public record ImageUploadRequest(
 	@Schema(description = "업로드할 이미지 파일", type = "string", format = "binary")
 	MultipartFile multipartFile
 ) {
 }
+

--- a/badminton-api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
+++ b/badminton-api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
@@ -1,4 +1,52 @@
+
 package org.badminton.api.aws.s3.service;
 
-public class AbstractFileUploadService {
+import java.io.IOException;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
+import org.badminton.api.common.exception.EmptyFileException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public abstract class AbstractFileUploadService implements ImageService {
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	private final AmazonS3 s3Client;
+
+	public String uploadFile(ImageUploadRequest file) {
+		MultipartFile uploadFile = file.multipartFile();
+		if (uploadFile.isEmpty() || Objects.isNull(uploadFile.getOriginalFilename())) {
+			throw new EmptyFileException();
+		}
+		String fileName = makeFileName(uploadFile.getOriginalFilename());
+
+		ObjectMetadata objectMetadata = new ObjectMetadata();
+		objectMetadata.setContentLength(uploadFile.getSize());
+		objectMetadata.setContentType(uploadFile.getContentType());
+		try {
+			s3Client.putObject(new PutObjectRequest(bucket, fileName,
+				uploadFile.getInputStream(), objectMetadata)
+				.withCannedAcl(CannedAccessControlList.PublicRead));
+			return s3Client.getUrl(bucket, fileName).toString();
+		} catch (IOException exception) {
+			throw new EmptyFileException(exception);
+		}
+	}
+
+	@Override
+	public abstract String makeFileName(String originalFilename);
+
 }
+

--- a/badminton-api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
+++ b/badminton-api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
@@ -1,0 +1,4 @@
+package org.badminton.api.aws.s3.service;
+
+public class AbstractFileUploadService {
+}

--- a/badminton-api/src/main/java/org/badminton/api/aws/s3/service/ClubImageService.java
+++ b/badminton-api/src/main/java/org/badminton/api/aws/s3/service/ClubImageService.java
@@ -1,55 +1,31 @@
+
+
 package org.badminton.api.aws.s3.service;
 
-import java.io.IOException;
-import java.util.Objects;
 import java.util.UUID;
 
-import org.badminton.api.aws.s3.model.dto.ClubImageUploadRequest;
-import org.badminton.api.common.exception.EmptyFileException;
-import org.springframework.beans.factory.annotation.Value;
+import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-
-import lombok.RequiredArgsConstructor;
 
 @Service
-@RequiredArgsConstructor
-public class ClubImageService {
-	@Value("${cloud.aws.s3.bucket}")
-	private String bucket;
+public class ClubImageService extends AbstractFileUploadService {
 
-	private final AmazonS3 s3Client;
-
-	public String uploadFile(ClubImageUploadRequest file) {
-		MultipartFile uploadFile = file.multipartFile();
-		if (uploadFile.isEmpty() || Objects.isNull(uploadFile.getOriginalFilename())) {
-			throw new EmptyFileException();
-		}
-		String fileName = makeFileName(uploadFile.getOriginalFilename());
-
-		ObjectMetadata objectMetadata = new ObjectMetadata();
-		objectMetadata.setContentLength(uploadFile.getSize());
-		objectMetadata.setContentType(uploadFile.getContentType());
-
-		try {
-			s3Client.putObject(new PutObjectRequest(bucket, fileName,
-				uploadFile.getInputStream(), objectMetadata)
-				.withCannedAcl(CannedAccessControlList.PublicRead));
-			return s3Client.getUrl(bucket, fileName).toString();
-		} catch (IOException exception) {
-			throw new EmptyFileException(exception);
-		}
-
+	public ClubImageService(AmazonS3 s3Client) {
+		super(s3Client);
 	}
 
-	private String makeFileName(String originalFilename) {
+	@Override
+	public String uploadFile(ImageUploadRequest file) {
+		return super.uploadFile(file);
+	}
+
+	@Override
+	public String makeFileName(String originalFilename) {
 		String[] originFile = originalFilename.split("\\.");
 		String extension = originFile[originFile.length - 1];
 		return "club-banner/" + UUID.randomUUID() + "/" + "banner." + extension;
 	}
 }
+

--- a/badminton-api/src/main/java/org/badminton/api/aws/s3/service/ImageService.java
+++ b/badminton-api/src/main/java/org/badminton/api/aws/s3/service/ImageService.java
@@ -1,0 +1,4 @@
+package org.badminton.api.aws.s3.service;
+
+public class ImageService {
+}

--- a/badminton-api/src/main/java/org/badminton/api/aws/s3/service/ImageService.java
+++ b/badminton-api/src/main/java/org/badminton/api/aws/s3/service/ImageService.java
@@ -1,4 +1,11 @@
+
 package org.badminton.api.aws.s3.service;
 
-public class ImageService {
+import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
+
+public interface ImageService {
+	String uploadFile(ImageUploadRequest file);
+
+	String makeFileName(String originalFilename);
 }
+

--- a/badminton-api/src/main/java/org/badminton/api/aws/s3/service/MemberProfileImageService.java
+++ b/badminton-api/src/main/java/org/badminton/api/aws/s3/service/MemberProfileImageService.java
@@ -1,4 +1,37 @@
+
 package org.badminton.api.aws.s3.service;
 
-public class MemberProfileImageService {
+import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
+import org.badminton.api.member.service.MemberService;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.s3.AmazonS3;
+
+@Service
+public class MemberProfileImageService extends AbstractFileUploadService {
+
+	private final MemberService memberService;
+	private Long currentMemberId;
+
+	public MemberProfileImageService(AmazonS3 s3Client, MemberService memberService) {
+		super(s3Client);
+		this.memberService = memberService;
+	}
+
+	public String uploadFile(ImageUploadRequest file, Long memberId) {
+		this.currentMemberId = memberId;
+		String fileUrl = super.uploadFile(file);
+		memberService.updateProfileImage(memberId, fileUrl);
+		return fileUrl;
+	}
+
+	@Override
+	public String makeFileName(String originalFilename) {
+		if (this.currentMemberId == null) {
+			throw new IllegalStateException("Member ID is not set. Make sure to call uploadFile method first.");
+		}
+		String[] originFile = originalFilename.split("\\.");
+		String extension = originFile[originFile.length - 1];
+		return "member-profile/" + this.currentMemberId + "/" + "image." + extension;
+	}
 }

--- a/badminton-api/src/main/java/org/badminton/api/aws/s3/service/MemberProfileImageService.java
+++ b/badminton-api/src/main/java/org/badminton/api/aws/s3/service/MemberProfileImageService.java
@@ -1,0 +1,4 @@
+package org.badminton.api.aws.s3.service;
+
+public class MemberProfileImageService {
+}

--- a/badminton-api/src/main/java/org/badminton/api/league/model/dto/LeagueCreateRequest.java
+++ b/badminton-api/src/main/java/org/badminton/api/league/model/dto/LeagueCreateRequest.java
@@ -1,3 +1,4 @@
+
 package org.badminton.api.league.model.dto;
 
 import java.time.LocalDateTime;
@@ -23,7 +24,7 @@ public record LeagueCreateRequest(
 
 	//TODO: DTO 마다 검증 로직을 두지 않는 방법 알아보기
 	@Pattern(regexp = "GOLD|SILVER|BRONZE", message = "리그 상태 값이 올바르지 않습니다.")
-	@Schema(description = "최소 티어", example = "GOLD")
+	@Schema(description = "최소 티어", example = "GOLD || SILVER || BRONZE")
 	MemberTier tierLimit,
 
 	@Pattern(regexp = "OPEN|CLOSED", message = "리그 상태 값이 올바르지 않습니다.")
@@ -50,3 +51,4 @@ public record LeagueCreateRequest(
 ) {
 
 }
+

--- a/badminton-api/src/main/java/org/badminton/api/member/controller/MemberController.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/controller/MemberController.java
@@ -1,26 +1,28 @@
+
 package org.badminton.api.member.controller;
 
+import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
+import org.badminton.api.aws.s3.service.MemberProfileImageService;
 import org.badminton.api.leaguerecord.service.LeagueRecordService;
-import org.badminton.api.member.jwt.JwtUtil;
 import org.badminton.api.member.model.dto.MemberDeleteResponse;
 import org.badminton.api.member.model.dto.MemberMyPageResponse;
-import org.badminton.api.member.model.dto.MemberUpdateRequest;
-import org.badminton.api.member.model.dto.MemberUpdateResponse;
 import org.badminton.api.member.oauth2.dto.CustomOAuth2Member;
 import org.badminton.api.member.service.MemberService;
 import org.badminton.domain.clubmember.repository.ClubMemberRepository;
-import org.badminton.domain.leaguerecord.repository.LeagueRecordRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +37,7 @@ public class MemberController {
 	private final MemberService memberService;
 	private final ClubMemberRepository clubMemberRepository;
 	private final LeagueRecordService leagueRecordService;
+	private final MemberProfileImageService memberProfileImageService;
 
 	//TODO: 티어 정상 작동 테스트용, 지울예정입니다
 	@Operation(
@@ -90,12 +93,21 @@ public class MemberController {
 	@Operation(
 		summary = "프로필 사진을 수정합니다",
 		description = "프로필 사진을 수정합니다",
-		tags = {"Member"}
+		tags = {"Member"},
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+			required = true,
+			content = @Content(
+				mediaType = "multipart/form-data",
+				schema = @Schema(implementation = ImageUploadRequest.class)
+			)
+		)
 	)
 	@PatchMapping
-	public ResponseEntity<MemberUpdateResponse> update(
-		@RequestBody MemberUpdateRequest updateRequest, @AuthenticationPrincipal CustomOAuth2Member member) {
-		return ResponseEntity.ok(memberService.updateMember(member.getMemberId(), updateRequest));
+	public ResponseEntity<String> updateProfileImage(
+		@RequestPart(value = "multipartFile", required = true) MultipartFile multipartFile,
+		@AuthenticationPrincipal CustomOAuth2Member member) {
+		ImageUploadRequest request = new ImageUploadRequest(multipartFile);
+		return ResponseEntity.ok(memberProfileImageService.uploadFile(request, member.getMemberId()));
 	}
 
 	@Operation(
@@ -121,3 +133,4 @@ public class MemberController {
 	}
 
 }
+


### PR DESCRIPTION
## PR에 대한 설명 🔍

멤버 이미지 수정 시 S3를 사용해서 수정

## 변경된 사항 📝

<!-- 이번 PR에서의 변경점 -->

- S3 업로드 인터페이스 구현
- 클럽 이미지 업로드 수정
- 멤버 프로필 이미지 S3 업로드 구현

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF, 글 -->

![image](https://github.com/user-attachments/assets/44e8feeb-cfd1-4b14-88e0-2639bb74a767)


## PR에서 중점적으로 확인되어야 하는 사항

수정하거나 업로드한 이미지는 S3 에서 확인하면 됩니다.
멤버 프로필 이미지 : member-profile/{memberId}/image.jpeg
클럽 배너 이미지 : club-banner/UUID/banner.jpg
