### PR TITLE
feat: 현재 사용자의 동호회 조회 로직 구현

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/club/controller/ClubController.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/controller/ClubController.java
@@ -1,7 +1,6 @@
 package org.badminton.api.club.controller;
 
 import java.util.List;
-
 import org.badminton.api.club.model.dto.ClubCreateRequest;
 import org.badminton.api.club.model.dto.ClubCreateResponse;
 import org.badminton.api.club.model.dto.ClubDeleteResponse;
@@ -11,11 +10,9 @@ import org.badminton.api.club.model.dto.ClubUpdateResponse;
 import org.badminton.api.club.model.dto.ClubsReadResponse;
 import org.badminton.api.club.service.ClubService;
 import org.badminton.api.member.oauth2.dto.CustomOAuth2Member;
-import org.springframework.http.HttpStatus;
+import org.badminton.domain.clubmember.repository.ClubMemberRepository;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -23,7 +20,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ClubController {
 
 	private final ClubService clubService;
+	private final ClubMemberRepository clubMemberRepository;
 
 	@GetMapping("/{clubId}")
 	@Operation(summary = "동호회 조회",
@@ -45,6 +42,13 @@ public class ClubController {
 		tags = {"Club"})
 	public ResponseEntity<ClubReadResponse> readClub(@PathVariable Long clubId) {
 		ClubReadResponse clubReadResponse = clubService.readClub(clubId);
+		return ResponseEntity.ok(clubReadResponse);
+	}
+
+	@GetMapping("/current")
+	@Operation(summary = "현재 로그인된 사용자의 동호회 조회", description = "현재 로그인되어 있는 사용자의 동호회를 조회합니다", tags = {"Club"})
+	public ResponseEntity<ClubReadResponse> readCurrentClub(@AuthenticationPrincipal CustomOAuth2Member member) {
+		ClubReadResponse clubReadResponse = clubService.readCurrentClub(member.getMemberId());
 		return ResponseEntity.ok(clubReadResponse);
 	}
 

--- a/badminton-api/src/main/java/org/badminton/api/club/controller/ClubController.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/controller/ClubController.java
@@ -45,7 +45,7 @@ public class ClubController {
 		return ResponseEntity.ok(clubReadResponse);
 	}
 
-	@GetMapping("/current")
+	@GetMapping("/me")
 	@Operation(summary = "현재 로그인된 사용자의 동호회 조회", description = "현재 로그인되어 있는 사용자의 동호회를 조회합니다", tags = {"Club"})
 	public ResponseEntity<ClubReadResponse> readCurrentClub(@AuthenticationPrincipal CustomOAuth2Member member) {
 		ClubReadResponse clubReadResponse = clubService.readCurrentClub(member.getMemberId());

--- a/badminton-api/src/main/java/org/badminton/api/club/service/ClubService.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/service/ClubService.java
@@ -2,6 +2,7 @@ package org.badminton.api.club.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.badminton.api.club.model.dto.ClubCreateRequest;
@@ -14,6 +15,7 @@ import org.badminton.api.club.model.dto.ClubsReadResponse;
 import org.badminton.api.common.exception.club.ClubNameDuplicateException;
 import org.badminton.api.common.exception.club.ClubNotExistException;
 import org.badminton.api.common.exception.member.MemberNotExistException;
+import org.badminton.api.common.exception.member.MemberNotJoinedClubException;
 import org.badminton.api.leaguerecord.service.LeagueRecordService;
 import org.badminton.domain.club.entity.ClubEntity;
 import org.badminton.domain.club.repository.ClubRepository;
@@ -45,6 +47,11 @@ public class ClubService {
 	public ClubReadResponse readClub(Long clubId) {
 		ClubEntity club = findClubByClubId(clubId);
 		return ClubReadResponse.clubEntityToClubReadResponse(club);
+	}
+
+	public ClubReadResponse readCurrentClub(Long memberId) {
+		ClubMemberEntity clubMember = findClubMemberByClubMemberId(memberId);
+		return ClubReadResponse.clubEntityToClubReadResponse(clubMember.getClub());
 	}
 
 	public List<ClubsReadResponse> readAllClub() {
@@ -115,6 +122,12 @@ public class ClubService {
 		return clubRepository.findByClubIdAndIsClubDeletedFalse(clubId)
 			.orElseThrow(
 				() -> new ClubNotExistException(clubId));
+	}
+
+	private ClubMemberEntity findClubMemberByClubMemberId(Long memberId) {
+		return clubMemberRepository.findByMember_MemberId(memberId)
+            .orElseThrow(
+                () -> new MemberNotJoinedClubException(memberId));
 	}
 
 }

--- a/badminton-api/src/main/java/org/badminton/api/common/error/ErrorCode.java
+++ b/badminton-api/src/main/java/org/badminton/api/common/error/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
 	LEAGUE_NOT_EXIST(404, "해당하는 경기 일정이 존재하지 않습니다."),
 	MATCH_NOT_EXIST(404, "해당하는 대진이 존재하지 않습니다."),
 	SET_NOT_EXIST(404, "해당하는 세트는 존재하지 않습니다."),
+	MEMBER_NOT_JOINED_CLUB(404, "해당하는 회원은 동호회에 가입하지 않았습니다."),
 	CLUB_MEMBER_NOT_EXIST(404, "해당하는 회원은 해당 동호회에 아직 가입하지 않았습니다."),
 
 	// 409 Errors

--- a/badminton-api/src/main/java/org/badminton/api/common/exception/member/MemberNotJoinedClubException.java
+++ b/badminton-api/src/main/java/org/badminton/api/common/exception/member/MemberNotJoinedClubException.java
@@ -1,0 +1,16 @@
+package org.badminton.api.common.exception.member;
+
+import org.badminton.api.common.error.ErrorCode;
+import org.badminton.api.common.exception.BadmintonException;
+
+public class MemberNotJoinedClubException extends BadmintonException {
+
+	public MemberNotJoinedClubException(Long memberId) {
+		super(ErrorCode.MEMBER_NOT_JOINED_CLUB, "[회원 아이디 : " + memberId + "]");
+	}
+
+	public MemberNotJoinedClubException(Long memberId, Exception e) {
+		super(ErrorCode.MEMBER_NOT_JOINED_CLUB, "[회원 아이디 : " + memberId + "]");
+	}
+
+}

--- a/badminton-api/src/main/java/org/badminton/api/config/security/SecurityConfig.java
+++ b/badminton-api/src/main/java/org/badminton/api/config/security/SecurityConfig.java
@@ -79,7 +79,7 @@ public class SecurityConfig {
 
 			.securityMatcher(
 				request -> request.getMethod().equals("POST") && request.getRequestURI().equals("/v1/clubs")
-					|| request.getRequestURI().startsWith("/v1/members") || request.getRequestURI().equals("/v1/clubs/current")
+					|| request.getRequestURI().startsWith("/v1/members") || request.getRequestURI().equals("/v1/clubs/me")
 			)
 			.csrf(AbstractHttpConfigurer::disable)
 			.cors(this::corsConfigurer)

--- a/badminton-api/src/main/java/org/badminton/api/config/security/SecurityConfig.java
+++ b/badminton-api/src/main/java/org/badminton/api/config/security/SecurityConfig.java
@@ -79,7 +79,7 @@ public class SecurityConfig {
 
 			.securityMatcher(
 				request -> request.getMethod().equals("POST") && request.getRequestURI().equals("/v1/clubs")
-					|| request.getRequestURI().startsWith("/v1/members")
+					|| request.getRequestURI().startsWith("/v1/members") || request.getRequestURI().equals("/v1/clubs/current")
 			)
 			.csrf(AbstractHttpConfigurer::disable)
 			.cors(this::corsConfigurer)


### PR DESCRIPTION
## PR에 대한 설명 🔍

### 기존 계획
> 동호회에 가입한 사람의 로그인 후 메인페이지는 본인이 가입한 동호회 페이지.
현재는 특정 동호회의 페이지의 정보를 조회하려면 동호회의 Id가 필요 -> 동호회 조회 API에서 clubId를 null 허용 -> clubId가 null 일때 현재 로그인 되어있는 사용자가 가입한 club Id로 조회 api 실행

### 현재 상태
> clubId를 null 로 두었을 때 현재 로그인된 사용자의 정보를 이용해 사용자가 가입되어 있는 동호회 조회 시도 -> "v1/clubs" 동호회 전체 조회와 충돌 발생 -> "v1/clubs/current" 로 api를 새로 생성

## 변경된 사항 📝

![image](https://github.com/user-attachments/assets/b3dfc5e3-c6ea-4547-bd4e-1c70119e08eb)


## PR에서 중점적으로 확인되어야 하는 사항

1. PathVariable이 null 일 때 현재 사용자가 가입되어 있는 club을 조회를 하려면 동호회 전체 조회할 때의 url을 수정해야합니다.
2. "v1/clubs/currnet" api를 새로 만들어서 현재 사용자가 가입되어 있는 clubId를 조회

위 두개의 방법 중 어떤 방법이 나은지 말씀해주시면 감사하겠습니다 저는 현재는 새로운 api를 생성하는 것이 더 나을 것 같아서 추가했습니다.

