### PR TITLE
refactor: 회원 프로필 사진 등록, 변경 api 분리

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/aws/s3/service/MemberProfileImageService.java
+++ b/badminton-api/src/main/java/org/badminton/api/aws/s3/service/MemberProfileImageService.java
@@ -20,9 +20,8 @@ public class MemberProfileImageService extends AbstractFileUploadService {
 
 	public String uploadFile(ImageUploadRequest file, Long memberId) {
 		this.currentMemberId = memberId;
-		String fileUrl = super.uploadFile(file);
-		memberService.updateProfileImage(memberId, fileUrl);
-		return fileUrl;
+		return super.uploadFile(file);
+
 	}
 
 	@Override

--- a/badminton-api/src/main/java/org/badminton/api/config/security/SecurityConfig.java
+++ b/badminton-api/src/main/java/org/badminton/api/config/security/SecurityConfig.java
@@ -80,6 +80,7 @@ public class SecurityConfig {
 			.securityMatcher(
 				request -> request.getMethod().equals("POST") && request.getRequestURI().equals("/v1/clubs")
 					|| request.getRequestURI().startsWith("/v1/members") || request.getRequestURI().equals("/v1/clubs/me") || request.getRequestURI().equals("/v1/clubs/search")
+				|| request.getRequestURI().equals("/v1/members/profileImage")
 			)
 			.csrf(AbstractHttpConfigurer::disable)
 			.cors(this::corsConfigurer)

--- a/badminton-api/src/main/java/org/badminton/api/member/controller/MemberController.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import org.badminton.api.aws.s3.service.MemberProfileImageService;
 import org.badminton.api.leaguerecord.service.LeagueRecordService;
 import org.badminton.api.member.model.dto.MemberDeleteResponse;
 import org.badminton.api.member.model.dto.MemberMyPageResponse;
+import org.badminton.api.member.model.dto.MemberResponse;
 import org.badminton.api.member.oauth2.dto.CustomOAuth2Member;
 import org.badminton.api.member.service.MemberService;
 import org.badminton.domain.clubmember.repository.ClubMemberRepository;
@@ -13,9 +14,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -91,8 +93,8 @@ public class MemberController {
 	}
 
 	@Operation(
-		summary = "프로필 사진을 수정합니다",
-		description = "프로필 사진을 수정합니다",
+		summary = "프로필 사진을 S3에 업로드 합니다",
+		description = "프로필 사진을 S3에 업로드합니다",
 		tags = {"Member"},
 		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
 			required = true,
@@ -102,13 +104,26 @@ public class MemberController {
 			)
 		)
 	)
-	@PatchMapping
-	public ResponseEntity<String> updateProfileImage(
-		@RequestPart(value = "multipartFile", required = true) MultipartFile multipartFile,
+	@PostMapping("/profileImage")
+	public ResponseEntity<String> uploadProfileImage(
+		@RequestPart(value = "multipartFile") MultipartFile multipartFile,
 		@AuthenticationPrincipal CustomOAuth2Member member) {
 		ImageUploadRequest request = new ImageUploadRequest(multipartFile);
 		return ResponseEntity.ok(memberProfileImageService.uploadFile(request, member.getMemberId()));
 	}
+
+	@Operation(
+		summary = "프로필 사진을 수정합니다",
+		description = "프로필 사진을 수정합니다",
+		tags = {"Member"}
+	)
+	@PutMapping("/profileImage")
+	public ResponseEntity<MemberResponse> updateProfileImage(
+		@RequestParam String imageUrl,
+		@AuthenticationPrincipal CustomOAuth2Member member) {
+		return ResponseEntity.ok(memberService.updateProfileImage(member.getMemberId(), imageUrl));
+	}
+
 
 	@Operation(
 		summary = "회원 탈퇴를 합니다",

--- a/badminton-api/src/main/java/org/badminton/api/member/service/MemberService.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/service/MemberService.java
@@ -7,6 +7,7 @@ import org.badminton.api.member.jwt.JwtUtil;
 import org.badminton.api.member.model.dto.MemberDeleteResponse;
 import org.badminton.api.member.model.dto.MemberMyPageResponse;
 
+import org.badminton.api.member.model.dto.MemberResponse;
 import org.badminton.api.member.oauth2.dto.CustomOAuth2Member;
 import org.badminton.api.member.validator.MemberValidator;
 import org.badminton.domain.clubmember.entity.ClubMemberEntity;
@@ -73,10 +74,11 @@ public class MemberService {
 	}
 
 	@Transactional
-	public void updateProfileImage(Long memberId, String profileImageUrl) {
+	public MemberResponse updateProfileImage(Long memberId, String imageUrl) {
 		MemberEntity memberEntity = memberValidator.findMemberByMemberId(memberId);
-		memberEntity.updateMember(profileImageUrl);
+		memberEntity.updateMember(imageUrl);
 		memberRepository.save(memberEntity);
+		return MemberResponse.memberEntityToResponse(memberEntity);
 	}
 
 	public void logoutMember(Long memberId, HttpServletResponse response) {

--- a/badminton-domain/src/main/java/org/badminton/domain/member/entity/MemberEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/member/entity/MemberEntity.java
@@ -51,8 +51,8 @@ public class MemberEntity extends BaseTimeEntity {
 		this.refreshToken = refreshToken;
 	}
 
-	public void updateMember(String profileImage) {
-		this.profileImage = profileImage;
+	public void updateMember(String imageUrl) {
+		this.profileImage = imageUrl;
 	}
 
 	public void deleteMember() {


### PR DESCRIPTION
## PR에 대한 설명 🔍

>  회원의 현재 프로필 사진을 변경할 때 하나의 api에 사진을 S3에 업로드하고 회원의 프로필 사진을 변경하는 로직이 함께 있어 변경완료를 누르지 않고, 사진만 변경을 해도 회원의 프로필 이미지가 변경되는 이슈 발생

 프로필 사진을 S3에 업로드하는 로직과 회원의 프로필 사진을 변경하는 로직 두 개의 API로 변경

## 변경된 사항 📝

<img width="1412" alt="image" src="https://github.com/user-attachments/assets/181749ef-cf12-44cb-9c9b-4724b13b3409">

## PR에서 중점적으로 확인되어야 하는 사항

POST `"/v1/members/profileImage"` 의 response 값인 URL을 PUT `"/v1/members/profileImage"` 의 RequestParam 값으로 넣어 회원의 이미지를 변경해야합니다.
