### PR TITLE
feat: 개발, 로컬 환경 로그 분리

### DIFF
--- a/.github/workflows/ci-cd-build.yml
+++ b/.github/workflows/ci-cd-build.yml
@@ -26,11 +26,25 @@ jobs:
           echo "${{ secrets.ENV }}" > ./.env
         shell: bash
 
+      - name: Generate logback.xml for badminton-api
+        run: |
+          cd ./badminton-api/src/main/resources
+          touch ./logback.xml
+          echo "${{ secrets.LOGBACK_API }}" > ./logback.xml
+        shell: bash
+
       - name: Set environment values badminton-batch
         run: |
           cd ./badminton-batch/src/main/resources
           touch ./.env
           echo "${{ secrets.ENV }}" > ./.env
+        shell: bash
+
+      - name: Generate logback.xml for badminton-batch
+        run: |
+          cd ./badminton-batch/src/main/resources
+          touch ./logback.xml
+          echo "${{ secrets.LOGBACK_BATCH }}" > ./logback.xml
         shell: bash
 
       - name: Set Gradle Wrapper Permissions

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ data/
 
 gradlew
 gradlew.bat
+
+logback-api.xml
+logback-batch.xml

--- a/badminton-api/build.gradle
+++ b/badminton-api/build.gradle
@@ -6,8 +6,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-    implementation group: 'me.paulschwarz', name: 'spring-dotenv', version: '4.0.0'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.5.RELEASE'
+
 
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'

--- a/badminton-api/src/main/resources/application.yaml
+++ b/badminton-api/src/main/resources/application.yaml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: ${ACTIVE_PROFILE}
   application:
     name: badminton
   jpa:
@@ -17,7 +19,7 @@ spring:
     basename: messages
   sql:
     init:
-      mode: always
+      mode: ${SQL_MODE}
   datasource:
     url: ${DATABASE_URL}
     username: ${DATABASE_USER_NAME}

--- a/badminton-api/src/main/resources/logback-spring.xml
+++ b/badminton-api/src/main/resources/logback-spring.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration packagingData="true">
+    <timestamp key="timestamp" datePattern="yyyy-MM-dd-HH-mm-ssSSS"/>
+    <timestamp key="timestamp_log" datePattern="yyyy-MM-dd"/>
+    <springProfile name="develop">
+        <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+            <layout>
+                <pattern>[%thread] [%date] [%level] [%logger{10}] [%file:%line] - %msg%n</pattern>
+            </layout>
+        </appender>
+
+        <!-- 파일로 로그 저장 -->
+        <appender name="local-log" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>logs/batch/badminton-batch.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <layout>
+                <pattern>[%thread] [%date] [%level] [%logger{10}] [%file:%line] - %msg%n</pattern>
+            </layout>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="console"/>
+            <appender-ref ref="local-log"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/badminton-batch/build.gradle
+++ b/badminton-batch/build.gradle
@@ -6,7 +6,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-    implementation group: 'me.paulschwarz', name: 'spring-dotenv', version: '4.0.0'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     testImplementation 'org.springframework.batch:spring-batch-test'
 

--- a/badminton-batch/src/main/resources/application.yaml
+++ b/badminton-batch/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 server:
   port: 9090
 spring:
+  profiles:
+    active: ${ACTIVE_PROFILE}
   application:
     name: badminton-batch
   jpa:

--- a/badminton-batch/src/main/resources/logback-spring.xml
+++ b/badminton-batch/src/main/resources/logback-spring.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration packagingData="true">
+    <timestamp key="timestamp" datePattern="yyyy-MM-dd-HH-mm-ssSSS"/>
+    <timestamp key="timestamp_log" datePattern="yyyy-MM-dd"/>
+    <springProfile name="develop">
+        <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+            <layout>
+                <pattern>[%thread] [%date] [%level] [%logger{10}] [%file:%line] - %msg%n</pattern>
+            </layout>
+        </appender>
+
+        <!-- 파일로 로그 저장 -->
+        <appender name="local-log" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>logs/batch/badminton-batch.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <layout>
+                <pattern>[%thread] [%date] [%level] [%logger{10}] [%file:%line] - %msg%n</pattern>
+            </layout>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="console"/>
+            <appender-ref ref="local-log"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,11 @@ allprojects {
     apply plugin: 'java-library'
 
     dependencies {
+        implementation "ca.pjer:logback-awslogs-appender:1.6.0"
+        implementation group: 'me.paulschwarz', name: 'spring-dotenv', version: '4.0.0'
+        implementation 'com.amazonaws:aws-java-sdk-logs:1.12.300'  // AWS CloudWatch Logs SDK
+        implementation 'net.logstash.logback:logstash-logback-encoder:7.2'
+
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'


### PR DESCRIPTION
## PR에 대한 설명 🔍
- PR의 내용에 대한 설명을 자세히 설명 
로컬과 프로덕션 환경에서의 로그 분리

## 변경된 사항 📝
로컬 환경과 프로덕션 환경에서의 로그를 분리했습니다. 
프로덕션 환경에서의 로그백 xml은 배포 시에 생성되는 것으로 변경하였습니다.

<img width="282" alt="image" src="https://github.com/user-attachments/assets/6c66ca9c-ee09-45f0-933a-4d38b0f072b9">
로그 그룹은 모듈별로 분리하였습니다.

<img width="338" alt="image" src="https://github.com/user-attachments/assets/d7b308cd-5590-498c-9120-d625ff354fd8">
각 로그 스트림은 날짜별로 생성되도록 하였습니다.


### After
로컬 환경에서의 로그는 파일로 생성합니다,
프로덕션 환경에서의 로그는 AWS를 통해 확인이 가능합니다.

## PR에서 중점적으로 확인되어야 하는 사항

