### PR TITLE
feat: 프로덕션 환경을 위한 ci/cd 파일 수정

### DIFF
--- a/.github/workflows/ci-cd-build.yml
+++ b/.github/workflows/ci-cd-build.yml
@@ -29,8 +29,9 @@ jobs:
       - name: Generate logback.xml for badminton-api
         run: |
           cd ./badminton-api/src/main/resources
-          touch ./logback.xml
-          echo "${{ secrets.LOGBACK_API }}" > ./logback.xml
+          cat <<EOF > logback.xml
+          ${{ secrets.LOGBACK_API }}
+          EOF
         shell: bash
 
       - name: Set environment values badminton-batch
@@ -43,8 +44,9 @@ jobs:
       - name: Generate logback.xml for badminton-batch
         run: |
           cd ./badminton-batch/src/main/resources
-          touch ./logback.xml
-          echo "${{ secrets.LOGBACK_BATCH }}" > ./logback.xml
+          cat <<EOF > logback.xml
+          ${{ secrets.LOGBACK_BATCH  }}
+          EOF
         shell: bash
 
       - name: Set Gradle Wrapper Permissions


### PR DESCRIPTION
## PR에 대한 설명 🔍
- PR의 내용에 대한 설명을 자세히 설명 
프로덕션 환경을 위해 ci/cd를 파일 수정


## 변경된 사항 📝

### Before
logback.xml 파일 내에 프로덕션 로그가 들어있었습니다.

### After
<img width="868" alt="image" src="https://github.com/user-attachments/assets/6f2975e5-999d-46f0-8495-6fc7fcc716b8">
해당 파일을 깃 환경변수로 빼서 관리합니다. 