### PR TITLE
fix: clubMember 조회 시 delete 한 clubMember 조회하지 못하게 수정

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/club/service/ClubService.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/service/ClubService.java
@@ -131,8 +131,8 @@ public class ClubService {
 	}
 
 	public void deleteAllClubMembers(Long clubId) {
-		List<ClubMemberEntity> allByClubClubId = clubMemberRepository.findAllByClub_ClubId(clubId);
-		allByClubClubId.forEach(clubMember -> {
+		List<ClubMemberEntity> clubMembers = clubMemberRepository.findAllByClub_ClubId(clubId);
+		clubMembers.forEach(clubMember -> {
 			clubMember.deleteClubMember();
 			clubMemberRepository.save(clubMember);
 		});
@@ -173,9 +173,6 @@ public class ClubService {
 
 	private void checkIfMemberAlreadyClubMember(Long memberId) {
 		clubMemberRepository.findByMember_MemberIdAndDeletedFalse(memberId).ifPresent(clubMember -> {
-			if (clubMember.getClub().isClubDeleted()) {
-				return;
-			}
 			throw new MemberAlreadyExistInClubException(memberId, clubMember.getClub().getClubId(),
 				clubMember.getRole());
 		});

--- a/badminton-api/src/main/java/org/badminton/api/filter/JwtAuthenticationFilter.java
+++ b/badminton-api/src/main/java/org/badminton/api/filter/JwtAuthenticationFilter.java
@@ -46,7 +46,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				jwtUtil.getRegistrationId(token), oAuthAccessToken);
 
 			for (ClubMemberEntity clubMember : clubMemberEntities) {
-				customOAuth2Member.addClubRole(clubMember.getClub().getClubId(), clubMember.getRole().name());
+				if (!clubMember.getClub().isClubDeleted()) {
+					customOAuth2Member.addClubRole(clubMember.getClub().getClubId(), clubMember.getRole().name());
+					break;
+				}
 			}
 
 			Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2Member, null,

--- a/badminton-api/src/main/java/org/badminton/api/member/controller/MemberController.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/controller/MemberController.java
@@ -52,7 +52,7 @@ public class MemberController {
 	@PostMapping("/win")
 	public ResponseEntity<String> addWin(@AuthenticationPrincipal CustomOAuth2Member member) {
 		Long memberId = member.getMemberId();
-		Long clubMemberId = clubMemberRepository.findByMember_MemberId(memberId).get().getClubMemberId();
+		Long clubMemberId = clubMemberRepository.findByMember_MemberIdAndDeletedFalse(memberId).get().getClubMemberId();
 		leagueRecordService.addWin(clubMemberId);
 		return ResponseEntity.ok("Win added successfully");
 	}
@@ -66,7 +66,7 @@ public class MemberController {
 	@PostMapping("/lose")
 	public ResponseEntity<String> addLose(@AuthenticationPrincipal CustomOAuth2Member member) {
 		Long memberId = member.getMemberId();
-		Long clubMemberId = clubMemberRepository.findByMember_MemberId(memberId).get().getClubMemberId();
+		Long clubMemberId = clubMemberRepository.findByMember_MemberIdAndDeletedFalse(memberId).get().getClubMemberId();
 		leagueRecordService.addLose(clubMemberId);
 		return ResponseEntity.ok("Loss added successfully");
 	}

--- a/badminton-api/src/main/java/org/badminton/api/member/oauth2/dto/CustomOAuth2Member.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/oauth2/dto/CustomOAuth2Member.java
@@ -32,6 +32,7 @@ public class CustomOAuth2Member implements OAuth2User {
 	private Map<Long, String> clubRoles = new HashMap<>();
 
 	public void addClubRole(Long clubId, String role) {
+		this.clubRoles.clear();
 		this.clubRoles.put(clubId, role);
 	}
 

--- a/badminton-api/src/main/java/org/badminton/api/member/service/MemberService.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/service/MemberService.java
@@ -64,7 +64,7 @@ public class MemberService {
 	public MemberIsClubMemberResponse getMemberIsClubMember(Long memberId) {
 		boolean isClubMember = clubMemberRepository.existsByMember_MemberId(memberId);
 		if (isClubMember) {
-			ClubMemberEntity clubMemberEntity = clubMemberRepository.findByMember_MemberId(memberId).get();
+			ClubMemberEntity clubMemberEntity = clubMemberRepository.findByMember_MemberIdAndDeletedFalse(memberId).get();
 			ClubMemberRole clubMemberRole = clubMemberEntity.getRole();
 			Long clubId = clubMemberEntity.getClub().getClubId();
 
@@ -75,7 +75,7 @@ public class MemberService {
 
 	public MemberMyPageResponse getMemberInfo(Long memberId) {
 		MemberEntity memberEntity = memberValidator.findMemberByMemberId(memberId);
-		ClubMemberEntity clubMemberEntity = clubMemberRepository.findByMember_MemberId(memberId).orElse(null);
+		ClubMemberEntity clubMemberEntity = clubMemberRepository.findByMember_MemberIdAndDeletedFalse(memberId).orElse(null);
 		LeagueRecordEntity leagueRecordEntity = null;
 
 		if (clubMemberEntity != null) {

--- a/badminton-domain/src/main/java/org/badminton/domain/clubmember/entity/ClubMemberEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/clubmember/entity/ClubMemberEntity.java
@@ -68,6 +68,10 @@ public class ClubMemberEntity extends BaseTimeEntity {
 		this.role = role;
 	}
 
+	public void deleteClubMember() {
+		this.deleted = true;
+	}
+
 	public void expel() {
 		this.deleted = true;
 		this.banned = true;

--- a/badminton-domain/src/main/java/org/badminton/domain/clubmember/repository/ClubMemberRepository.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/clubmember/repository/ClubMemberRepository.java
@@ -10,7 +10,7 @@ public interface ClubMemberRepository extends JpaRepository<ClubMemberEntity, Lo
 
 	List<ClubMemberEntity> findAllByClub_ClubId(Long clubId);
 
-	Optional<ClubMemberEntity> findByMember_MemberId(Long memberId);
+	Optional<ClubMemberEntity> findByMember_MemberIdAndDeletedFalse(Long memberId);
 
 	Optional<ClubMemberEntity> findByClub_ClubIdAndMember_MemberId(Long clubId, Long memberId);
 


### PR DESCRIPTION
## PR에 대한 설명 🔍

- 동호회 생성 -> 삭제 -> 생성 시 다른 로직을 사용할 때 에러 발생

> 동호회 삭제 시 해당 동호회에 가입되어있는 모든 회원 삭제 로직 추가


