### PR TITLE
fix: 동호회 생성, 삭제 후 회원이 동호회에 가입되어있는지 확인 로직 에러 수정

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/clubmember/service/ClubMemberService.java
+++ b/badminton-api/src/main/java/org/badminton/api/clubmember/service/ClubMemberService.java
@@ -57,7 +57,7 @@ public class ClubMemberService {
 		MemberEntity memberEntity = memberRepository.findByMemberId(memberId)
 			.orElseThrow(() -> new MemberNotExistException(memberId));
 
-		if (clubMemberRepository.existsByMember_MemberId(memberId)) {
+		if (clubMemberRepository.existsByMember_MemberIdAndDeletedFalse(memberId)) {
 			throw new ClubMemberDuplicateException(clubId, memberId);
 		}
 

--- a/badminton-api/src/main/java/org/badminton/api/member/service/MemberService.java
+++ b/badminton-api/src/main/java/org/badminton/api/member/service/MemberService.java
@@ -62,7 +62,7 @@ public class MemberService {
 	private String naverClientSecret;
 
 	public MemberIsClubMemberResponse getMemberIsClubMember(Long memberId) {
-		boolean isClubMember = clubMemberRepository.existsByMember_MemberId(memberId);
+		boolean isClubMember = clubMemberRepository.existsByMember_MemberIdAndDeletedFalse(memberId);
 		if (isClubMember) {
 			ClubMemberEntity clubMemberEntity = clubMemberRepository.findByMember_MemberIdAndDeletedFalse(memberId).get();
 			ClubMemberRole clubMemberRole = clubMemberEntity.getRole();

--- a/badminton-domain/src/main/java/org/badminton/domain/clubmember/repository/ClubMemberRepository.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/clubmember/repository/ClubMemberRepository.java
@@ -14,7 +14,7 @@ public interface ClubMemberRepository extends JpaRepository<ClubMemberEntity, Lo
 
 	Optional<ClubMemberEntity> findByClub_ClubIdAndMember_MemberId(Long clubId, Long memberId);
 
-	boolean existsByMember_MemberId(Long memberId);
+	boolean existsByMember_MemberIdAndDeletedFalse(Long memberId);
 
 	List<ClubMemberEntity> findAllByMember_MemberId(Long memberId);
 


### PR DESCRIPTION
## PR에 대한 설명 🔍
동호회 생성, 삭제 후 회원이 동호회에 가입되어있는지 확인 로직 에러 수정
```	
boolean existsByMember_MemberIdAndDeletedFalse(Long memberId);
``` 
로 수정
