### PR TITLE
feat: get daily league schedule by date and month

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/league/controller/LeagueController.java
+++ b/badminton-api/src/main/java/org/badminton/api/league/controller/LeagueController.java
@@ -3,6 +3,7 @@ package org.badminton.api.league.controller;
 import java.util.List;
 
 import org.badminton.api.league.model.dto.LeagueAndParticipantResponse;
+import org.badminton.api.league.model.dto.LeagueByDateResponse;
 import org.badminton.api.league.model.dto.LeagueCreateRequest;
 import org.badminton.api.league.model.dto.LeagueCreateResponse;
 import org.badminton.api.league.model.dto.LeagueReadResponse;
@@ -34,19 +35,36 @@ public class LeagueController {
 	private final LeagueService leagueService;
 
 	@Operation(
-		summary = "해당 일자 기준으로 데이터를 조회합니다.",
-		description = "특정 클럽 ID에 대한 리그 데이터를 조회합니다. 검색 조건으로 날짜를 사용하며, 날짜는 'yyyy-MM' 형식으로 제공되어야 합니다.",
+		summary = "월별로 경기 일정을 조회합니다.",
+		description = "월별로 경기 일정을 리스트로 조회할 수 있습니다. 날짜는 'yyyy-MM' 형식으로 제공되어야 합니다.",
 		tags = {"league"},
 		parameters = {
 			@Parameter(name = "clubId", description = "조회할 클럽의 ID", required = true),
 			@Parameter(name = "date", description = "조회할 날짜, 'yyyy-MM' 형식으로 입력", required = true)
 		}
 	)
-	@GetMapping()
-	public ResponseEntity<List<LeagueReadResponse>> leagueReadByCondition(@PathVariable Long clubId,
+	@GetMapping("/month")
+	public ResponseEntity<List<LeagueReadResponse>> getLeagueByMonth(@PathVariable Long clubId,
 		@RequestParam
 		@DateTimeFormat(pattern = "yyyy-MM") String date) {
-		return ResponseEntity.ok(leagueService.getLeagues(clubId, date));
+		return ResponseEntity.ok(leagueService.getLeaguesByMonth(clubId, date));
+	}
+
+	@Operation(
+		summary = "일자별로 경기 일정을 조회합니다.",
+		description = "일별로 경기 일정을 리스트로 조회할 수 있습니다. 검색 조건으로 날짜를 사용하며, 날짜는 'yyyy-MM' 형식으로 제공되어야 합니다.",
+		tags = {"league"},
+		parameters = {
+			@Parameter(name = "clubId", description = "조회할 클럽의 ID", required = true),
+			@Parameter(name = "date", description = "조회할 날짜, 'yyyy-MM-dd' 형식으로 입력", required = true)
+		}
+	)
+
+	@GetMapping("/date")
+	public ResponseEntity<List<LeagueByDateResponse>> getLeagueByDate(@PathVariable Long clubId,
+		@RequestParam
+		@DateTimeFormat(pattern = "yyyy-MM-dd") String date) {
+		return ResponseEntity.ok(leagueService.getLeaguesByDate(clubId, date));
 	}
 
 	@Operation(

--- a/badminton-api/src/main/java/org/badminton/api/league/model/dto/LeagueByDateResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/league/model/dto/LeagueByDateResponse.java
@@ -1,0 +1,28 @@
+package org.badminton.api.league.model.dto;
+
+import java.time.LocalDateTime;
+
+import org.badminton.domain.common.enums.MatchType;
+import org.badminton.domain.common.enums.MemberTier;
+import org.badminton.domain.league.entity.LeagueEntity;
+
+public record LeagueByDateResponse(
+	Long leagueId,
+	LocalDateTime leagueAt,
+	String leagueName,
+	MatchType matchType,
+	MemberTier requiredTier,
+	LocalDateTime closedAt,
+	int playerLimitCount,
+	int recruitedMemberCount
+) {
+
+	public static LeagueByDateResponse fromLeagueEntity(LeagueEntity league, int recruitedMemberCount) {
+		return new LeagueByDateResponse(
+			league.getLeagueId(), league.getLeagueAt(), league.getLeagueName(),
+			league.getMatchType(), league.getRequiredTier(), league.getClosedAt(),
+			league.getPlayerLimitCount(), recruitedMemberCount
+		);
+	}
+
+}


### PR DESCRIPTION
## PR에 대한 설명 🔍

- [x] 일별 조회 구현

## 변경된 사항 📝

- [x] 월별 조회와 일별 조회 구분 -> Path Variable로 구분했는데 적절하지 않다면 추후 수정 예정입니다. 
- [ ] 월별 조회에서 날짜를 yyyy-MM 형식의 String 타입으로 받고 있어 이를 똑같이 구현했습니다. 추후 더 적절한 타입으로 수정 예정입니다. 


### Before

### After

![image](https://github.com/user-attachments/assets/94bc0287-9651-40a7-87e9-c808c4cd9692)


## PR에서 중점적으로 확인되어야 하는 사항
