### PR TITLE
feat: 타임아웃 설정을 통한 리소스 절약

### DIFF
--- a/badminton-api/src/main/resources/application.yaml
+++ b/badminton-api/src/main/resources/application.yaml
@@ -25,6 +25,16 @@ spring:
     username: ${DATABASE_USER_NAME}
     password: ${DATABASE_USER_PASSWORD}
     driver-class-name: ${DATABASE_DRIVER}
+    hikari:
+      connection-timeout: 15000
+      idle-timeout: 300000
+      maximum-pool-size: 5
+      max-lifetime: 600000
+      validation-timeout: 3000
+  mvc:
+    async:
+      request-timeout: 20000
+
   jwt:
     secret: ${JWT_SECRET}
   security:

--- a/badminton-batch/src/main/resources/application.yaml
+++ b/badminton-batch/src/main/resources/application.yaml
@@ -27,3 +27,13 @@ spring:
     username: ${DATABASE_USER_NAME}
     password: ${DATABASE_USER_PASSWORD}
     driver-class-name: ${DATABASE_DRIVER}
+    hikari:
+      connection-timeout: 15000
+      idle-timeout: 300000
+      maximum-pool-size: 5
+      max-lifetime: 600000
+      validation-timeout: 3000
+  mvc:
+    async:
+      request-timeout: 20000
+


### PR DESCRIPTION
## PR에 대한 설명 🔍
- PR의 내용에 대한 설명을 자세히 설명 
```
spring:
  datasource:
    hikari:
      connection-timeout: 15000  # 커넥션 타임아웃 (15초)
      idle-timeout: 300000       # 유휴 커넥션 타임아웃 (5분)
      maximum-pool-size: 5       # 최대 커넥션 수 (5개)
      max-lifetime: 600000       # 커넥션 최대 수명 (10분)
      validation-timeout: 3000   # 커넥션 유효성 검사 타임아웃 (3초)
  
  mvc:
    async:
      request-timeout: 20000     # 소켓 타임아웃 (20초)
  
```

## 변경된 사항 📝

### Before

기본값

### After

리소스 절약을 위해 타임아웃 설정을 하였습니다. 
해당 파일을 적용할 때 빈번하게 응답실패가 발생하면 다시 롤백할 필요가 있습니다. 
충분히 사용 후 판단하면 될 듯합니다.
