### PR TITLE
fix: ban된 동호회 회원 총 회원 수에 추가

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/club/controller/ClubController.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/controller/ClubController.java
@@ -70,7 +70,9 @@ public class ClubController {
 			3. 동호회 이미지 URL:
 			   - 호스트: badminton-team.s3.ap-northeast-2.amazonaws.com
 			   - 경로: /club-banner/로 시작
-			   - 파일 확장자: png, jpg, jpeg, gif 중 하나""",
+			   - 파일 확장자: png, jpg, jpeg, gif 중 하나
+			   - https://badminton-team.s3.ap-northeast-2.amazonaws.com/club-banner/85e45bf0-2f68-4566-b17d-0f08c8b2c333/banner.png
+			""",
 		tags = {"Club"})
 	public ResponseEntity<ClubCreateResponse> createClub(@Valid @RequestBody ClubCreateRequest clubCreateRequest,
 		@AuthenticationPrincipal CustomOAuth2Member member) {

--- a/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubDetailsResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubDetailsResponse.java
@@ -18,14 +18,14 @@ public record ClubDetailsResponse(
 ) {
 
 	public static ClubDetailsResponse fromClubEntityAndMemberCountByTier(ClubEntity clubEntity,
-		Map<MemberTier, Long> memberCountByTier, boolean isClubMember, int clubMembers) {
+		Map<MemberTier, Long> memberCountByTier, boolean isClubMember, int clubMembersCount) {
 		return new ClubDetailsResponse(
 			clubEntity.getClubId(),
 			clubEntity.getClubName(),
 			clubEntity.getClubDescription(),
 			clubEntity.getClubImage(),
 			ClubMemberCountByTier.ofClubMemberCountResponse(memberCountByTier),
-			clubMembers,
+			clubMembersCount,
 			clubEntity.getCreatedAt(),
 			isClubMember);
 	}

--- a/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubDetailsResponse.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/model/dto/ClubDetailsResponse.java
@@ -18,14 +18,14 @@ public record ClubDetailsResponse(
 ) {
 
 	public static ClubDetailsResponse fromClubEntityAndMemberCountByTier(ClubEntity clubEntity,
-		Map<MemberTier, Long> memberCountByTier, boolean isClubMember) {
+		Map<MemberTier, Long> memberCountByTier, boolean isClubMember, int clubMembers) {
 		return new ClubDetailsResponse(
 			clubEntity.getClubId(),
 			clubEntity.getClubName(),
 			clubEntity.getClubDescription(),
 			clubEntity.getClubImage(),
 			ClubMemberCountByTier.ofClubMemberCountResponse(memberCountByTier),
-			clubEntity.getClubMembers().size(),
+			clubMembers,
 			clubEntity.getCreatedAt(),
 			isClubMember);
 	}

--- a/badminton-api/src/main/java/org/badminton/api/club/service/ClubService.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/service/ClubService.java
@@ -51,9 +51,9 @@ public class ClubService {
 
 		boolean isClubMember = checkIfMemberBelongsToClub(memberId, clubId);
 
-		int clubMembers = clubMemberRepository.findAllByDeletedFalseAndClub_ClubId(
+		int clubMembersCount = clubMemberRepository.findAllByDeletedFalseAndClub_ClubId(
 			clubId).size();
-		return ClubDetailsResponse.fromClubEntityAndMemberCountByTier(club, memberCountByTier, isClubMember, clubMembers);
+		return ClubDetailsResponse.fromClubEntityAndMemberCountByTier(club, memberCountByTier, isClubMember, clubMembersCount);
 	}
 
 	private boolean checkIfMemberBelongsToClub(Long memberId, Long clubId) {

--- a/badminton-api/src/main/java/org/badminton/api/club/service/ClubService.java
+++ b/badminton-api/src/main/java/org/badminton/api/club/service/ClubService.java
@@ -51,7 +51,9 @@ public class ClubService {
 
 		boolean isClubMember = checkIfMemberBelongsToClub(memberId, clubId);
 
-		return ClubDetailsResponse.fromClubEntityAndMemberCountByTier(club, memberCountByTier, isClubMember);
+		int clubMembers = clubMemberRepository.findAllByDeletedFalseAndClub_ClubId(
+			clubId).size();
+		return ClubDetailsResponse.fromClubEntityAndMemberCountByTier(club, memberCountByTier, isClubMember, clubMembers);
 	}
 
 	private boolean checkIfMemberBelongsToClub(Long memberId, Long clubId) {

--- a/badminton-domain/src/main/java/org/badminton/domain/club/entity/ClubEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/club/entity/ClubEntity.java
@@ -69,7 +69,7 @@ public class ClubEntity extends BaseTimeEntity {
 
 		Map<MemberTier, Long> actualCounts = clubMembers.stream()
 			.filter(clubMember -> clubMember.getLeagueRecord() != null)
-			.filter(clubMember -> !clubMember.isDeleted() && !clubMember.isBanned())
+			.filter(clubMember -> !clubMember.isDeleted())
 			.collect(Collectors.groupingBy(
 				ClubMemberEntity::getTier,
 				Collectors.counting()

--- a/badminton-domain/src/main/java/org/badminton/domain/clubmember/repository/ClubMemberRepository.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/clubmember/repository/ClubMemberRepository.java
@@ -23,5 +23,7 @@ public interface ClubMemberRepository extends JpaRepository<ClubMemberEntity, Lo
 	boolean existsByMember_MemberIdAndClub_ClubId(Long memberId, Long clubId);
 
 	Optional<ClubMemberEntity> findByClubMemberId(Long clubMemberId);
+
+	List<ClubMemberEntity> findAllByDeletedFalseAndClub_ClubId(Long clubId);
 }
 


### PR DESCRIPTION
## PR에 대한 설명 🔍
- ban된 동호회 회원 총 회원 수에 추가
- expel 된 동호회 회원은 동호회 조회 시 인원 수에 포함되지 않고, ban된 회원은 포함됩니다.
- 동호회 추가 Swagger description에 예시 이미지 url 추가했습니다
