### PR TITLE
fix: 경기 조회 시 경기 참여 여부를 나타내는 필드가 항상 true로 나타나는 문제 해결

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/league/service/LeagueService.java
+++ b/badminton-api/src/main/java/org/badminton/api/league/service/LeagueService.java
@@ -58,7 +58,7 @@ public class LeagueService {
 		boolean isParticipatedInLeague = false;
 		if (memberId != null) {
 			isParticipatedInLeague = !leagueParticipantRepository
-				.findByMemberMemberIdAndCanceledFalse(memberId)
+				.findByMemberMemberIdAndLeagueLeagueIdAndCanceledFalse(memberId, leagueId)
 				.isEmpty();
 		}
 		ClubEntity club = provideClub(clubId);

--- a/badminton-domain/src/main/java/org/badminton/domain/league/repository/LeagueParticipantRepository.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/league/repository/LeagueParticipantRepository.java
@@ -11,7 +11,7 @@ public interface LeagueParticipantRepository extends JpaRepository<LeaguePartici
 	Optional<LeagueParticipantEntity> findByLeagueLeagueIdAndClubMemberClubMemberId(Long leagueId,
 		Long clubMemberId);
 
-	List<LeagueParticipantEntity> findByMemberMemberIdAndCanceledFalse(Long memberId);
+	List<LeagueParticipantEntity> findByMemberMemberIdAndLeagueLeagueIdAndCanceledFalse(Long memberId, Long leagueId);
 
 	List<LeagueParticipantEntity> findAllByLeagueLeagueIdAndCanceledFalse(Long leagueId);
 


### PR DESCRIPTION
## PR에 대한 설명 🔍

경기 조회 시 경기 참여 여부를 나타내는 필드가 항상 true로 나타나는 문제 해결

## 변경된 사항 📝

<!-- 이번 PR에서의 변경점 -->

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF, 글 -->

### Before

### After

## PR에서 중점적으로 확인되어야 하는 사항
