### PR TITLE
fix: 경기 참여 신청과 취소를 반복적으로 수행했을 때 경기 조회 시 모집 인원 카운트에 발생하는 문제 해결

### DIFF
--- a/badminton-api/src/main/java/org/badminton/api/config/security/SecurityConfig.java
+++ b/badminton-api/src/main/java/org/badminton/api/config/security/SecurityConfig.java
@@ -113,7 +113,7 @@ public class SecurityConfig {
 				.access(hasClubRole("OWNER"))
 				.requestMatchers(HttpMethod.PATCH, "/v1/clubs/{clubId}")
 				.access(hasClubRole("OWNER", "MANAGER"))
-				.requestMatchers(HttpMethod.GET, "/v1/clubs/{clubId}/leagues/{leagueId}/**")
+				.requestMatchers(HttpMethod.GET, "/v1/clubs/{clubId}/leagues/{leagueId}")
 				.access(hasClubRole("OWNER", "MANAGER", "USER"))
 				.requestMatchers(HttpMethod.GET, "/v1/clubs/{clubId}/clubMembers")
 				.access(hasClubRole("OWNER", "MANAGER", "USER"))

--- a/badminton-api/src/main/java/org/badminton/api/league/model/dto/LeagueUpdateRequest.java
+++ b/badminton-api/src/main/java/org/badminton/api/league/model/dto/LeagueUpdateRequest.java
@@ -7,7 +7,6 @@ import org.badminton.domain.common.enums.MatchType;
 import org.badminton.domain.common.enums.MemberTier;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Pattern;
 
 public record LeagueUpdateRequest(
 
@@ -20,11 +19,9 @@ public record LeagueUpdateRequest(
 	@Schema(description = "경기 장소", example = "성동구 서울숲 체육센터")
 	String leagueLocation,
 
-	@Pattern(regexp = "GOLD|SILVER|BRONZE", message = "리그 상태 값이 올바르지 않습니다.")
 	@Schema(description = "최소 티어", example = "GOLD")
 	MemberTier tierLimit,
 
-	@Pattern(regexp = "SINGLE|DOUBLES", message = "경기 방식 값이 올바르지 않습니다.")
 	@Schema(description = "경기 방식", example = "SINGLES")
 	MatchType matchType,
 

--- a/badminton-api/src/main/java/org/badminton/api/league/service/LeagueParticipationService.java
+++ b/badminton-api/src/main/java/org/badminton/api/league/service/LeagueParticipationService.java
@@ -93,16 +93,11 @@ public class LeagueParticipationService {
 	}
 
 	private void checkIfClubMemberInLeague(Long leagueId, Long clubMemberId) {
-		LeagueParticipantEntity leagueParticipant = leagueParticipantRepository.findByLeagueLeagueIdAndClubMemberClubMemberId(
+		LeagueParticipantEntity leagueParticipant = leagueParticipantRepository.findByLeagueLeagueIdAndClubMemberClubMemberIdAndCanceledFalse(
 			leagueId, clubMemberId).orElse(null);
-		if (Objects.isNull(leagueParticipant)) {
-			return;
-		}
-		if (leagueParticipant.isCanceled()) {
-			leagueParticipant.reactiveParticipation();
-		} else
+		if (Objects.nonNull(leagueParticipant)) {
 			throw new LeagueParticipationDuplicateException(leagueId, clubMemberId);
-
+		}
 	}
 
 	private LeagueEntity provideLeagueIfClubMemberInLeague(Long clubId, Long leagueId) {
@@ -111,7 +106,8 @@ public class LeagueParticipationService {
 	}
 
 	private LeagueParticipantEntity provideLeagueParticipantIfClubMemberInLeague(Long leagueId, Long clubMemberId) {
-		return leagueParticipantRepository.findByLeagueLeagueIdAndClubMemberClubMemberId(leagueId, clubMemberId)
+		return leagueParticipantRepository.findByLeagueLeagueIdAndClubMemberClubMemberIdAndCanceledFalse(leagueId,
+				clubMemberId)
 			.orElseThrow(
 				() -> new LeagueParticipationNotExistException(leagueId, clubMemberId));
 	}

--- a/badminton-domain/src/main/java/org/badminton/domain/league/entity/LeagueParticipantEntity.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/league/entity/LeagueParticipantEntity.java
@@ -51,9 +51,5 @@ public class LeagueParticipantEntity extends BaseTimeEntity {
 	public void cancelLeagueParticipation() {
 		this.canceled = true;
 	}
-
-	public void reactiveParticipation() {
-		this.canceled = false;
-	}
-
+	
 }

--- a/badminton-domain/src/main/java/org/badminton/domain/league/repository/LeagueParticipantRepository.java
+++ b/badminton-domain/src/main/java/org/badminton/domain/league/repository/LeagueParticipantRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LeagueParticipantRepository extends JpaRepository<LeagueParticipantEntity, Long> {
 
-	Optional<LeagueParticipantEntity> findByLeagueLeagueIdAndClubMemberClubMemberId(Long leagueId,
+	Optional<LeagueParticipantEntity> findByLeagueLeagueIdAndClubMemberClubMemberIdAndCanceledFalse(Long leagueId,
 		Long clubMemberId);
 
 	List<LeagueParticipantEntity> findByMemberMemberIdAndLeagueLeagueIdAndCanceledFalse(Long memberId, Long leagueId);


### PR DESCRIPTION
## PR에 대한 설명 🔍

- [x] 모집 인원 카운트에 발생하는 문제 해결

경기 참여 Entity에 canceled 필드를 두어 경기 참여 신청과 취소를 관리하고 있습니다. 
문제가 된 지점은, 신청 후 취소, 그리고 재신청 시 canceled 필드를 true로 변경해주고 있기 때문이었습니다.

## 변경된 사항 📝

<!-- 이번 PR에서의 변경점 -->

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF, 글 -->

### Before

### After

## PR에서 중점적으로 확인되어야 하는 사항
