### PR TITLE
feat: 프론트 로그인 세션 확인용 API

### DIFF
--- a/api/src/main/java/org/badminton/api/application/member/MemberFacade.java
+++ b/api/src/main/java/org/badminton/api/application/member/MemberFacade.java
@@ -10,6 +10,7 @@ import org.badminton.domain.domain.league.info.LeagueRecordInfo;
 import org.badminton.domain.domain.league.service.LeagueRecordService;
 import org.badminton.domain.domain.member.info.MemberMyPageInfo;
 import org.badminton.domain.domain.member.info.MemberUpdateInfo;
+import org.badminton.domain.domain.member.info.SimpleMemberInfo;
 import org.badminton.domain.domain.member.service.MemberService;
 import org.springframework.stereotype.Service;
 
@@ -30,6 +31,10 @@ public class MemberFacade {
 		LeagueRecord leagueRecord = leagueRecordService.getLeagueRecord(memberToken);
 		LeagueRecordInfo leagueRecordInfo = LeagueRecordInfo.from(leagueRecord);
 		return memberService.getMemberInfo(memberToken, leagueRecordInfo, clubMemberMyPageInfos);
+	}
+
+	public SimpleMemberInfo getSimpleMember(String memberToken) {
+		return memberService.getSimpleMember(memberToken);
 	}
 
 	public List<ClubMemberMyPageInfo> getClubMembers(String memberToken) {

--- a/api/src/main/java/org/badminton/api/interfaces/member/MemberDtoMapper.java
+++ b/api/src/main/java/org/badminton/api/interfaces/member/MemberDtoMapper.java
@@ -3,7 +3,9 @@ package org.badminton.api.interfaces.member;
 import java.util.List;
 
 import org.badminton.api.interfaces.club.dto.ClubCardResponse;
+import org.badminton.api.interfaces.member.dto.SimpleMemberResponse;
 import org.badminton.domain.domain.club.info.ClubCardInfo;
+import org.badminton.domain.domain.member.info.SimpleMemberInfo;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
@@ -17,4 +19,5 @@ public interface MemberDtoMapper {
 
 	List<ClubCardResponse> of(List<ClubCardInfo> clubCardInfoList);
 
+	SimpleMemberResponse of(SimpleMemberInfo simpleMemberInfo);
 }

--- a/api/src/main/java/org/badminton/api/interfaces/member/controller/MemberController.java
+++ b/api/src/main/java/org/badminton/api/interfaces/member/controller/MemberController.java
@@ -17,11 +17,13 @@ import org.badminton.api.interfaces.match.dto.MatchResultResponse;
 import org.badminton.api.interfaces.member.MemberDtoMapper;
 import org.badminton.api.interfaces.member.dto.MemberMyPageResponse;
 import org.badminton.api.interfaces.member.dto.MemberUpdateRequest;
+import org.badminton.api.interfaces.member.dto.SimpleMemberResponse;
 import org.badminton.domain.domain.club.info.ClubCardInfo;
 import org.badminton.domain.domain.clubmember.info.ClubMemberMyPageInfo;
 import org.badminton.domain.domain.match.info.MatchResultInfo;
 import org.badminton.domain.domain.member.info.MemberMyPageInfo;
 import org.badminton.domain.domain.member.info.MemberUpdateInfo;
+import org.badminton.domain.domain.member.info.SimpleMemberInfo;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -54,7 +56,7 @@ public class MemberController {
 		summary = "프로필 사진을 수정합니다",
 		description = """
 			프로필 사진을 수정합니다. 다음 조건을 만족해야 합니다:
-			
+						
 			1. 프로필 이미지 URL:
 			   - 호스트: badminton-team.s3.ap-northeast-2.amazonaws.com
 			   - 경로: /member-profile/로 시작
@@ -79,6 +81,19 @@ public class MemberController {
 		MemberMyPageInfo memberMyPageInfo = memberFacade.getMemberMyPageInfo(member.getMemberToken());
 		MemberMyPageResponse memberMyPageResponse = MemberMyPageResponse.toMemberMyPageResponse(memberMyPageInfo);
 		return CommonResponse.success(memberMyPageResponse);
+	}
+
+	@Operation(
+		summary = "로그인 세션을 확인합니다.",
+		description = "로그인 세션을 확인하여 로그인 여부를 판단할 때 사용합니다.",
+		tags = {"Member"}
+	)
+	@GetMapping("/session")
+	public CommonResponse<SimpleMemberResponse> getMySummaryInfo(@AuthenticationPrincipal CustomOAuth2Member member
+	) {
+		SimpleMemberInfo simpleMemberInfo = memberFacade.getSimpleMember(member.getMemberToken());
+		SimpleMemberResponse simpleMemberResponse = memberDtoMapper.of(simpleMemberInfo);
+		return CommonResponse.success(simpleMemberResponse);
 	}
 
 	@GetMapping("/matchesRecord")

--- a/api/src/main/java/org/badminton/api/interfaces/member/dto/SimpleMemberResponse.java
+++ b/api/src/main/java/org/badminton/api/interfaces/member/dto/SimpleMemberResponse.java
@@ -1,0 +1,28 @@
+package org.badminton.api.interfaces.member.dto;
+
+import org.badminton.domain.domain.member.entity.Member;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "로그인 세션 확인 Dto")
+public record SimpleMemberResponse(
+
+	@Schema(description = "회원 이름", example = "이선우")
+	String name,
+
+	@Schema(description = "oAuth 로그인 이메일", example = "qosle@naver.com")
+	String email,
+
+	@Schema(description = "oAuth 제공 ID", example = "1070449979547641023123")
+	Member.MemberTier memberTier,
+
+	@Schema(description = "회원 역할", example = "AUTHORIZATION_USER")
+	String authorization,
+
+	@Schema(description = "oAuth 제공 이미지", example = "1070449979547641023123")
+	String profileImage
+) {
+
+}
+
+

--- a/domain/src/main/java/org/badminton/domain/domain/member/info/SimpleMemberInfo.java
+++ b/domain/src/main/java/org/badminton/domain/domain/member/info/SimpleMemberInfo.java
@@ -1,0 +1,22 @@
+package org.badminton.domain.domain.member.info;
+
+import org.badminton.domain.domain.member.entity.Member;
+
+public record SimpleMemberInfo(
+
+	String authorization,
+
+	String name,
+
+	String email,
+
+	Member.MemberTier memberTier,
+
+	String profileImage
+) {
+	public static SimpleMemberInfo from(Member member) {
+		return new SimpleMemberInfo(member.getAuthorization(), member.getName(),
+			member.getEmail(), member.getTier(), member.getProfileImage());
+	}
+
+}

--- a/domain/src/main/java/org/badminton/domain/domain/member/service/MemberService.java
+++ b/domain/src/main/java/org/badminton/domain/domain/member/service/MemberService.java
@@ -6,6 +6,7 @@ import org.badminton.domain.domain.clubmember.info.ClubMemberMyPageInfo;
 import org.badminton.domain.domain.league.info.LeagueRecordInfo;
 import org.badminton.domain.domain.member.info.MemberMyPageInfo;
 import org.badminton.domain.domain.member.info.MemberUpdateInfo;
+import org.badminton.domain.domain.member.info.SimpleMemberInfo;
 
 public interface MemberService {
 
@@ -13,4 +14,6 @@ public interface MemberService {
 		List<ClubMemberMyPageInfo> clubMemberMyPageInfos);
 
 	MemberUpdateInfo updateProfileImage(String memberToken, String imageUrl);
+
+	SimpleMemberInfo getSimpleMember(String memberToken);
 }

--- a/domain/src/main/java/org/badminton/domain/domain/member/service/MemberServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/member/service/MemberServiceImpl.java
@@ -9,6 +9,7 @@ import org.badminton.domain.domain.member.MemberStore;
 import org.badminton.domain.domain.member.entity.Member;
 import org.badminton.domain.domain.member.info.MemberMyPageInfo;
 import org.badminton.domain.domain.member.info.MemberUpdateInfo;
+import org.badminton.domain.domain.member.info.SimpleMemberInfo;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,24 +24,17 @@ public class MemberServiceImpl implements MemberService {
 	private final MemberReader memberReader;
 	private final MemberStore memberStore;
 
-	// @Override
-	// public MemberIsClubMemberInfo getMemberIsClubMember(String memberToken,
-	// 	List<ClubMemberMyPageInfo> clubMemberMyPageInfos) {
-	//
-	// 	if (clubMemberMyPageInfos == null) {
-	// 		return new MemberIsClubMemberInfo(false, null, null);
-	// 	} else {
-	// 		ClubMember.ClubMemberRole clubMemberRole = clubMemberMyPageInfo.role();
-	// 		Long clubId = clubMemberMyPageInfo.clubId();
-	// 		return new MemberIsClubMemberInfo(true, clubMemberRole, clubId);
-	// 	}
-	// }
-
 	@Override
 	public MemberMyPageInfo getMemberInfo(String memberToken, LeagueRecordInfo leagueRecordInfo,
 		List<ClubMemberMyPageInfo> clubMemberMyPageInfos) {
 		Member member = memberReader.getMember(memberToken);
 		return createMemberMyPageInfo(member, clubMemberMyPageInfos, leagueRecordInfo);
+	}
+
+	@Override
+	public SimpleMemberInfo getSimpleMember(String memberToken) {
+		Member member = memberReader.getMember(memberToken);
+		return SimpleMemberInfo.from(member);
 	}
 
 	private MemberMyPageInfo createMemberMyPageInfo(Member member, List<ClubMemberMyPageInfo> clubMemberMyPageInfos,
@@ -64,5 +58,4 @@ public class MemberServiceImpl implements MemberService {
 		memberStore.store(member);
 		return MemberUpdateInfo.fromMemberEntity(member);
 	}
-
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍
- PR의 내용에 대한 설명을 자세히 설명 
프론트 엔드에서 로그인 세션을 확인하기 위한 API 호출입니다. 
API 에는 프론트에서 요청한 최소한의 정보만 담고 있습니다.
페이지 이동 간 또는 주기적인 로그인 확인 요청은 아래의 API로 호출 됩니다.

```java
/v1/members/session
```


## 변경된 사항 📝


<!-- 개발 기능을 보여줄 수 있는 이미지, GIF, 글 -->

<img width="794" alt="image" src="https://github.com/user-attachments/assets/87c83241-23f7-4312-a544-2d56fefbaba1">



## PR에서 중점적으로 확인되어야 하는 사항
