### PR TITLE
feat : 경기 상태별, 지역별 조회

### DIFF
--- a/domain/src/main/java/org/badminton/domain/domain/league/LeagueReader.java
+++ b/domain/src/main/java/org/badminton/domain/domain/league/LeagueReader.java
@@ -20,8 +20,29 @@ public interface LeagueReader {
 
 	List<League> readLeagueByDate(String clubToken, LocalDateTime startOfMonth, LocalDateTime endOfMonth);
 
-	Page<League> readOngoingAndUpcomingLeagueByDate(AllowedLeagueStatus leagueStatus, Region region, LocalDate date,
-		Pageable pageable);
+	Page<League> readLeagueStatusIsNotAllAndRegionIsNotAll(
+		AllowedLeagueStatus leagueStatus,
+		Region region,
+		LocalDate date,
+		Pageable pageable
+	);
+
+	Page<League> readLeagueStatusIsAllAndRegionIsNotAll(
+		Region region,
+		LocalDate date,
+		Pageable pageable
+	);
+
+	Page<League> readLeagueStatusIsNotAllAndRegionIsAll(
+		AllowedLeagueStatus leagueStatus,
+		LocalDate date,
+		Pageable pageable
+	);
+
+	Page<League> readLeagueStatusIsAllAndRegionIsAll(
+		LocalDate date,
+		Pageable pageable
+	);
 
 	Integer getCountByClubId(Long clubId);
 

--- a/domain/src/main/java/org/badminton/domain/domain/league/LeagueServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/league/LeagueServiceImpl.java
@@ -23,6 +23,7 @@ import org.badminton.domain.domain.league.info.LeagueReadInfo;
 import org.badminton.domain.domain.league.info.LeagueSummaryInfo;
 import org.badminton.domain.domain.league.info.LeagueUpdateInfo;
 import org.badminton.domain.domain.league.info.OngoingAndUpcomingLeagueInfo;
+import org.badminton.domain.domain.league.vo.LeagueSearchStrategy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -40,6 +41,7 @@ public class LeagueServiceImpl implements LeagueService {
 	private final LeagueStore leagueStore;
 	private final LeagueParticipantReader leagueParticipantReader;
 	private final ClubReader clubReader;
+	private final LeagueSearchStrategy leagueSearchStrategy;
 
 	@Override
 	@Transactional
@@ -106,14 +108,16 @@ public class LeagueServiceImpl implements LeagueService {
 	}
 
 	@Override
-	public Page<OngoingAndUpcomingLeagueInfo> getOngoingAndUpcomingLeaguesByDate(AllowedLeagueStatus leagueStatus,
-		Region region, LocalDate date, Pageable pageable) {
+	public Page<OngoingAndUpcomingLeagueInfo> getOngoingAndUpcomingLeaguesByDate(
+		AllowedLeagueStatus leagueStatus,
+		Region region,
+		LocalDate date,
+		Pageable pageable
+	) {
 		if (date.isBefore(LocalDate.now())) {
 			throw new OngoingAndUpcomingLeagueCanNotBePastException(date, LocalDate.now());
 		}
-
-		Page<League> leagues = leagueReader.readOngoingAndUpcomingLeagueByDate(leagueStatus, region, date, pageable);
-
+		Page<League> leagues = leagueSearchStrategy.getStrategy(leagueStatus, region, date, pageable);
 		return leagues.map(league -> OngoingAndUpcomingLeagueInfo.from(
 			league, leagueParticipantReader.countParticipantMember(league.getLeagueId())));
 	}

--- a/domain/src/main/java/org/badminton/domain/domain/league/enums/Region.java
+++ b/domain/src/main/java/org/badminton/domain/domain/league/enums/Region.java
@@ -1,28 +1,41 @@
 package org.badminton.domain.domain.league.enums;
 
+import java.util.Arrays;
+
+import lombok.Getter;
+
+@Getter
 public enum Region {
-    ALL("전체"),
-    SEOUL("서울"),
-    GYEONGGI("경기"),
-    INCHEON("인천"),
-    GANGWON("강원"),
-    DAEJEON("대전"),
-    SEJONG("세종"),
-    CHUNGNAM("충남"),
-    CHUNGBUK("충북"),
-    DAEGU("대구"),
-    GYEONGBUK("경북"),
-    BUSAN("부산"),
-    ULSAN("울산"),
-    GYEONGNAM("경남"),
-    GWANGJU("광주"),
-    JEONNAM("전남"),
-    JEONBUK("전북"),
-    JEJU("제주");
+	ALL("전체"),
+	SEOUL("서울"),
+	GYEONGGI("경기"),
+	INCHEON("인천"),
+	GANGWON("강원"),
+	DAEJEON("대전"),
+	SEJONG("세종"),
+	CHUNGNAM("충남"),
+	CHUNGBUK("충북"),
+	DAEGU("대구"),
+	GYEONGBUK("경북"),
+	BUSAN("부산"),
+	ULSAN("울산"),
+	GYEONGNAM("경남"),
+	GWANGJU("광주"),
+	JEONNAM("전남"),
+	JEONBUK("전북"),
+	JEJU("제주");
 
-    private final String name;
+	private final String name;
 
-    Region(String name) {
-        this.name = name;
-    }
+	Region(String name) {
+		this.name = name;
+	}
+
+	public static String getNameByCode(String code) {
+		return Arrays.stream(Region.values())
+			.filter(region -> region.name().equalsIgnoreCase(code))
+			.findFirst()
+			.map(Region::getName)
+			.orElse(null); // 없는 코드명일 경우 null 반환
+	}
 }

--- a/domain/src/main/java/org/badminton/domain/domain/league/vo/LeagueSearchStrategy.java
+++ b/domain/src/main/java/org/badminton/domain/domain/league/vo/LeagueSearchStrategy.java
@@ -1,0 +1,37 @@
+package org.badminton.domain.domain.league.vo;
+
+import java.time.LocalDate;
+
+import org.badminton.domain.domain.league.LeagueReader;
+import org.badminton.domain.domain.league.entity.League;
+import org.badminton.domain.domain.league.enums.AllowedLeagueStatus;
+import org.badminton.domain.domain.league.enums.LeagueStatus;
+import org.badminton.domain.domain.league.enums.Region;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LeagueSearchStrategy {
+	private final LeagueReader leagueReader;
+
+	public Page<League> getStrategy(
+		AllowedLeagueStatus leagueStatus,
+		Region region,
+		LocalDate date,
+		Pageable pageable
+	) {
+		if (leagueStatus.name().equals(LeagueStatus.ALL.name())) {
+			return region.name().equals(Region.ALL.name())
+				? leagueReader.readLeagueStatusIsAllAndRegionIsAll(date, pageable)
+				: leagueReader.readLeagueStatusIsAllAndRegionIsNotAll(region, date, pageable);
+		} else {
+			return region.name().equals(Region.ALL.name())
+				? leagueReader.readLeagueStatusIsNotAllAndRegionIsAll(leagueStatus, date, pageable)
+				: leagueReader.readLeagueStatusIsNotAllAndRegionIsNotAll(leagueStatus, region, date, pageable);
+		}
+	}
+}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/league/LeagueReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/league/LeagueReaderImpl.java
@@ -3,7 +3,6 @@ package org.badminton.infrastructure.league;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Arrays;
 import java.util.List;
 
 import org.badminton.domain.common.enums.MatchGenerationType;
@@ -60,18 +59,54 @@ public class LeagueReaderImpl implements LeagueReader {
 		);
 	}
 
-	// TODO: 지역 필터링 기능 구현
 	@Override
-	public Page<League> readOngoingAndUpcomingLeagueByDate(AllowedLeagueStatus leagueStatus, Region region,
+	public Page<League> readLeagueStatusIsNotAllAndRegionIsNotAll(AllowedLeagueStatus leagueStatus, Region region,
 		LocalDate date, Pageable pageable) {
 		LocalDateTime startOfDay = date.atStartOfDay();
 		LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
 
-		if (leagueStatus.getStatus() == LeagueStatus.PLAYING || leagueStatus.getStatus() == LeagueStatus.RECRUITING) {
-			return leagueRepository.findAllByLeagueAtBetweenAndLeagueStatus(startOfDay, endOfDay,
-				leagueStatus.getStatus(), pageable);
-		}
-		return leagueRepository.findAllByLeagueAtBetweenAndLeagueStatusNotIn(startOfDay, endOfDay, Arrays.asList(
-			LeagueStatus.CANCELED, LeagueStatus.FINISHED), pageable);
+		return leagueRepository.findAllByLeagueAtBetweenAndLeagueStatusAndAddressRegion(
+			startOfDay,
+			endOfDay,
+			leagueStatus.getStatus(),
+			Region.getNameByCode(region.name()),
+			pageable
+		);
+	}
+
+	@Override
+	public Page<League> readLeagueStatusIsAllAndRegionIsNotAll(Region region, LocalDate date, Pageable pageable) {
+		LocalDateTime startOfDay = date.atStartOfDay();
+		LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+		return leagueRepository.findAllByLeagueAtBetweenAndAddressRegion(
+			startOfDay,
+			endOfDay,
+			Region.getNameByCode(region.name()),
+			pageable
+		);
+	}
+
+	@Override
+	public Page<League> readLeagueStatusIsNotAllAndRegionIsAll(AllowedLeagueStatus leagueStatus, LocalDate date,
+		Pageable pageable) {
+		LocalDateTime startOfDay = date.atStartOfDay();
+		LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+		return leagueRepository.findAllByLeagueAtBetweenAndLeagueStatus(
+			startOfDay,
+			endOfDay,
+			leagueStatus.getStatus(),
+			pageable
+		);
+	}
+
+	@Override
+	public Page<League> readLeagueStatusIsAllAndRegionIsAll(LocalDate date, Pageable pageable) {
+		LocalDateTime startOfDay = date.atStartOfDay();
+		LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+		return leagueRepository.findAllByLeagueAtBetween(
+			startOfDay,
+			endOfDay,
+			pageable
+		);
 	}
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/league/LeagueRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/league/LeagueRepository.java
@@ -20,13 +20,7 @@ public interface LeagueRepository extends JpaRepository<League, Long> {
 	List<League> findAllByClubClubTokenAndLeagueAtBetween(String clubToken, LocalDateTime startOfMonth,
 		LocalDateTime endOfMonth);
 
-	Page<League> findAllByLeagueAtBetweenAndLeagueStatusNotIn(LocalDateTime startOfDay, LocalDateTime endOfDay,
-		List<LeagueStatus> excludedLeagueStatusList, Pageable pageable);
-
 	Integer countByClubClubIdAndLeagueStatus(Long clubId, LeagueStatus leagueStatus);
-
-	Page<League> findAllByLeagueAtBetweenAndLeagueStatus(LocalDateTime startOfDay, LocalDateTime endOfDay,
-		LeagueStatus leagueStatus, Pageable pageable);
 
 	@Query("SELECT l.matchGenerationType FROM League l WHERE l.leagueId = :leagueId")
 	Optional<MatchGenerationType> getMatchGenerationTypeByLeagueId(@Param("leagueId") Long leagueId);
@@ -35,4 +29,32 @@ public interface LeagueRepository extends JpaRepository<League, Long> {
 	boolean existsByClubIdAndCreatedAtToday(@Param("clubId") Long clubId);
 
 	List<League> findByLeagueStatus(LeagueStatus leagueStatus);
+
+	Page<League> findAllByLeagueAtBetweenAndLeagueStatusAndAddressRegion(
+		LocalDateTime leagueAt,
+		LocalDateTime endOfDay,
+		LeagueStatus leagueStatus,
+		String addressRegion,
+		Pageable pageable
+	);
+
+	Page<League> findAllByLeagueAtBetweenAndAddressRegion(
+		LocalDateTime startOfDay,
+		LocalDateTime endOfDay,
+		String nameByCode,
+		Pageable pageable
+	);
+
+	Page<League> findAllByLeagueAtBetweenAndLeagueStatus(
+		LocalDateTime startOfDay,
+		LocalDateTime endOfDay,
+		LeagueStatus status,
+		Pageable pageable
+	);
+
+	Page<League> findAllByLeagueAtBetween(
+		LocalDateTime startOfDay,
+		LocalDateTime endOfDay,
+		Pageable pageable
+	);
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍
- PR의 내용에 대한 설명을 자세히 설명 
- 경기 상태별 지역별 조회 기능 추가입니다. 

## 변경된 사항 📝
상태 별 또는 지역 별로 조회할 수 있는 기능입니다.  
```java
Page<League> leagues = leagueSearchStrategy.getStrategy(leagueStatus, region, date, pageable);
```
위 메소드로 접근하면 전략 패턴으로 실행되는 리더를 분기 처리하였습니다.
분기되는 조건은 다음과 같습니다. 
- LeagueStatus가 ALL 이고 Region이 ALL 이 아닐 경우
- LeagueStatus가 ALL 이고 Region이 ALL 일 경우
- LeagueStatus가 ALL 이 아니고 Region이 ALL 이 아닐 경우
- LeagueStatus가 ALL 이 아니고 Region이 ALL 일 경우

```java
if (leagueStatus.name().equals(LeagueStatus.ALL.name())) {
			return region.name().equals(Region.ALL.name())
				? leagueReader.readLeagueStatusIsAllAndRegionIsAll(date, pageable)
				: leagueReader.readLeagueStatusIsAllAndRegionIsNotAll(region, date, pageable);
		} else {
			return region.name().equals(Region.ALL.name())
				? leagueReader.readLeagueStatusIsNotAllAndRegionIsAll(leagueStatus, date, pageable)
				: leagueReader.readLeagueStatusIsNotAllAndRegionIsNotAll(leagueStatus, region, date, pageable);
		}
```
위와 같이 처리하여 늘어나는 Reader 인터페이스는 다음과 같습니다. 
```java

	Page<League> readLeagueStatusIsNotAllAndRegionIsNotAll(
		AllowedLeagueStatus leagueStatus,
		Region region,
		LocalDate date,
		Pageable pageable
	);

	Page<League> readLeagueStatusIsAllAndRegionIsNotAll(
		Region region,
		LocalDate date,
		Pageable pageable
	);

	Page<League> readLeagueStatusIsNotAllAndRegionIsAll(
		AllowedLeagueStatus leagueStatus,
		LocalDate date,
		Pageable pageable
	);

	Page<League> readLeagueStatusIsAllAndRegionIsAll(
		LocalDate date,
		Pageable pageable
	);

```

사실 이렇게 나누니 엔드포인트에 따라 처리해도 될 것 같은 생각이 듭니다. 
편의상 분기 지점 클래스를 만들어 처리하였습니다. 


