### PR TITLE
fix: dtoMapper

### DIFF
--- a/api/src/main/java/org/badminton/api/interfaces/clubmember/ClubMemberDtoMapper.java
+++ b/api/src/main/java/org/badminton/api/interfaces/clubmember/ClubMemberDtoMapper.java
@@ -40,11 +40,12 @@ public interface ClubMemberDtoMapper {
 
 	default Map<String, List<ClubMemberResponse>> of(Map<ClubMember.ClubMemberRole, List<ClubMemberInfo>> infoMap) {
 		return infoMap.entrySet().stream()
-			.collect(Collectors.toMap(
+			.collect(Collectors.groupingBy(
 				entry -> entry.getKey().name(),
-				entry -> entry.getValue().stream()
-					.map(this::of)
-					.collect(Collectors.toList())
+				Collectors.flatMapping(
+					entry -> entry.getValue().stream().map(this::of),
+					Collectors.toList()
+				)
 			));
 	}
 

--- a/api/src/main/java/org/badminton/api/interfaces/clubmember/controller/ClubMemberController.java
+++ b/api/src/main/java/org/badminton/api/interfaces/clubmember/controller/ClubMemberController.java
@@ -69,10 +69,10 @@ public class ClubMemberController {
 			clubMemberInfoMap);
 
 		List<ClubMemberResponse> roleOwner = clubMemberRoleListMap.get("ROLE_OWNER");
-		List<ClubMemberResponse> roleMember = clubMemberRoleListMap.get("ROLE_MEMBER");
 		List<ClubMemberResponse> roleManager = clubMemberRoleListMap.get("ROLE_MANAGER");
+		List<ClubMemberResponse> roleUser = clubMemberRoleListMap.get("ROLE_USER");
 
-		ClubMemberRoleResponse response = new ClubMemberRoleResponse(roleOwner, roleMember, roleManager);
+		ClubMemberRoleResponse response = new ClubMemberRoleResponse(roleOwner, roleManager, roleUser);
 
 		return CommonResponse.success(response);
 	}

--- a/api/src/main/java/org/badminton/api/interfaces/clubmember/dto/ClubMemberRoleResponse.java
+++ b/api/src/main/java/org/badminton/api/interfaces/clubmember/dto/ClubMemberRoleResponse.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public record ClubMemberRoleResponse(
 	List<ClubMemberResponse> ROLE_OWNER,
-	List<ClubMemberResponse> ROLE_MEMBER,
-	List<ClubMemberResponse> ROLE_MANAGER
+	List<ClubMemberResponse> ROLE_MANAGER,
+	List<ClubMemberResponse> ROLE_USER
 ) {
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍

```
	default Map<String, List<ClubMemberResponse>> of(Map<ClubMember.ClubMemberRole, List<ClubMemberInfo>> infoMap) {
		return infoMap.entrySet().stream()
			.collect(Collectors.groupingBy(
				entry -> entry.getKey().name(),
				Collectors.flatMapping(
					entry -> entry.getValue().stream().map(this::of),
					Collectors.toList()
				)
			));
	}
```

Collectors.Mapping -> Collectors.groupingBy
Collectors.Mapping 사용 시 중복된 키가 나오면 에러 발생