### PR TITLE
feat : 리그 중복 생성 방지

### DIFF
--- a/api/src/main/java/org/badminton/api/interfaces/league/controller/LeagueController.java
+++ b/api/src/main/java/org/badminton/api/interfaces/league/controller/LeagueController.java
@@ -82,7 +82,7 @@ public class LeagueController {
 		summary = "경기를 생성합니다.",
 		description = """
 			경기 생성하고를 데이터베이스에 저장합니다.
-			
+						
 			1. 경기 이름 2 ~ 20 글자
 			2. 경기 설명 2 ~ 1000 글자
 			3. 경기 장소 2 ~ 100 글자
@@ -93,7 +93,7 @@ public class LeagueController {
 				토너먼트 더블: 참가자 수/2 가 2의 제곱
 				프리 싱글: 2의 배수
 				프리 더블: 4의 배수
-			
+						
 			""",
 		tags = {"league"}
 	)
@@ -129,7 +129,7 @@ public class LeagueController {
 		summary = "경기의 세부 정보를 변경합니다.",
 		description = """
 			경기 이름, 설명, 참가자, 싱글/더블, 프리/토너먼트 변경
-			
+						
 			1. 경기 이름 2 ~ 20 글자
 			2. 경기 설명 2 ~ 1000 글자
 			3. 참가인원:
@@ -137,7 +137,7 @@ public class LeagueController {
 				토너먼트 더블: 참가자 수/2 가 2의 제곱
 				프리 싱글: 2의 배수
 				프리 더블: 4의 배수
-			
+						
 			""",
 		tags = {"league"}
 	)

--- a/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
+++ b/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
@@ -63,6 +63,7 @@ public enum ErrorCode {
 	LEAGUE_PARTICIPATION_ALREADY_CANCELED(409, "이미 참여 신청을 취소한 경기 일정입니다."),
 	CLUB_MEMBER_ALREADY_BANNED(409, "해당 회원은 이미 제제를 받은 상태입니다"),
 	LEAGUE_ALREADY_CANCELED(409, "해당하는 경기는 이미 취소된 경기입니다."),
+	LEAGUE_NOT_ALLOW_CREATE(409, "3시간 이후에 경기를 생성할 수 있습니다."),
 
 	// 410 Errors
 	DELETED(410, "요청한 리소스가 삭제되었습니다."),

--- a/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
+++ b/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
@@ -63,7 +63,7 @@ public enum ErrorCode {
 	LEAGUE_PARTICIPATION_ALREADY_CANCELED(409, "이미 참여 신청을 취소한 경기 일정입니다."),
 	CLUB_MEMBER_ALREADY_BANNED(409, "해당 회원은 이미 제제를 받은 상태입니다"),
 	LEAGUE_ALREADY_CANCELED(409, "해당하는 경기는 이미 취소된 경기입니다."),
-	LEAGUE_NOT_ALLOW_CREATE(409, "3시간 이후에 경기를 생성할 수 있습니다."),
+	LEAGUE_AT_LESS_THAN_THREE_HOUR_INTERVAL(409, "3시간 이후에 경기를 생성할 수 있습니다."),
 
 	// 410 Errors
 	DELETED(410, "요청한 리소스가 삭제되었습니다."),

--- a/domain/src/main/java/org/badminton/domain/common/exception/league/LeagueCreationWithin3HoursException.java
+++ b/domain/src/main/java/org/badminton/domain/common/exception/league/LeagueCreationWithin3HoursException.java
@@ -1,0 +1,12 @@
+package org.badminton.domain.common.exception.league;
+
+import java.time.LocalDateTime;
+
+import org.badminton.domain.common.error.ErrorCode;
+import org.badminton.domain.common.exception.BadmintonException;
+
+public class LeagueCreationWithin3HoursException extends BadmintonException {
+	public LeagueCreationWithin3HoursException(LocalDateTime localDateTime) {
+		super(ErrorCode.LEAGUE_NOT_ALLOW_CREATE, "[경기 일정 : " + localDateTime + "]");
+	}
+}

--- a/domain/src/main/java/org/badminton/domain/common/exception/league/LeagueCreationWithin3HoursException.java
+++ b/domain/src/main/java/org/badminton/domain/common/exception/league/LeagueCreationWithin3HoursException.java
@@ -7,6 +7,6 @@ import org.badminton.domain.common.exception.BadmintonException;
 
 public class LeagueCreationWithin3HoursException extends BadmintonException {
 	public LeagueCreationWithin3HoursException(LocalDateTime localDateTime) {
-		super(ErrorCode.LEAGUE_NOT_ALLOW_CREATE, "[경기 일정 : " + localDateTime + "]");
+		super(ErrorCode.LEAGUE_AT_LESS_THAN_THREE_HOUR_INTERVAL, "[경기 일정 : " + localDateTime + "]");
 	}
 }

--- a/domain/src/main/java/org/badminton/domain/domain/league/LeagueReader.java
+++ b/domain/src/main/java/org/badminton/domain/domain/league/LeagueReader.java
@@ -3,6 +3,7 @@ package org.badminton.domain.domain.league;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+
 import org.badminton.domain.common.enums.MatchGenerationType;
 import org.badminton.domain.domain.league.entity.League;
 import org.badminton.domain.domain.league.enums.AllowedLeagueStatus;
@@ -11,41 +12,43 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface LeagueReader {
-    League readLeague(String clubToken, Long leagueId);
+	League readLeague(String clubToken, Long leagueId);
 
-    League readLeagueNotCanceled(Long leagueId);
+	League readLeagueNotCanceled(Long leagueId);
 
-    League readLeagueById(Long leagueId);
+	League readLeagueById(Long leagueId);
 
-    List<League> readLeagueByMonth(String clubToken, LocalDateTime startOfMonth, LocalDateTime endOfMonth);
+	List<League> readLeagueByMonth(String clubToken, LocalDateTime startOfMonth, LocalDateTime endOfMonth);
 
-    List<League> readLeagueByDate(String clubToken, LocalDateTime startOfMonth, LocalDateTime endOfMonth);
+	List<League> readLeagueByDate(String clubToken, LocalDateTime startOfMonth, LocalDateTime endOfMonth);
 
-    Page<League> readLeagueStatusIsNotAllAndRegionIsNotAll(
-            AllowedLeagueStatus leagueStatus,
-            Region region,
-            LocalDate date,
-            Pageable pageable
-    );
+	Page<League> readLeagueStatusIsNotAllAndRegionIsNotAll(
+		AllowedLeagueStatus leagueStatus,
+		Region region,
+		LocalDate date,
+		Pageable pageable
+	);
 
-    Page<League> readLeagueStatusIsAllAndRegionIsNotAll(
-            Region region,
-            LocalDate date,
-            Pageable pageable
-    );
+	Page<League> readLeagueStatusIsAllAndRegionIsNotAll(
+		Region region,
+		LocalDate date,
+		Pageable pageable
+	);
 
-    Page<League> readLeagueStatusIsNotAllAndRegionIsAll(
-            AllowedLeagueStatus leagueStatus,
-            LocalDate date,
-            Pageable pageable
-    );
+	Page<League> readLeagueStatusIsNotAllAndRegionIsAll(
+		AllowedLeagueStatus leagueStatus,
+		LocalDate date,
+		Pageable pageable
+	);
 
-    Page<League> readLeagueStatusIsAllAndRegionIsAll(
-            LocalDate date,
-            Pageable pageable
-    );
+	Page<League> readLeagueStatusIsAllAndRegionIsAll(
+		LocalDate date,
+		Pageable pageable
+	);
 
-    Integer getCountByClubId(Long clubId);
+	Integer getCountByClubId(Long clubId);
 
-    MatchGenerationType getMatchGenerationTypeByLeagueId(Long leagueId);
+	MatchGenerationType getMatchGenerationTypeByLeagueId(Long leagueId);
+
+	void checkLeagueExistIn3Hours(String memberToken, LocalDateTime leagueAt);
 }

--- a/domain/src/main/java/org/badminton/domain/domain/league/LeagueServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/league/LeagueServiceImpl.java
@@ -1,12 +1,10 @@
 package org.badminton.domain.domain.league;
 
-import jakarta.transaction.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.badminton.domain.common.exception.league.LeagueAlreadyCanceledException;
 import org.badminton.domain.common.exception.league.OngoingAndUpcomingLeagueCanNotBePastException;
 import org.badminton.domain.domain.club.ClubReader;
@@ -32,140 +30,145 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class LeagueServiceImpl implements LeagueService {
 
-    private final LeagueReader leagueReader;
-    private final LeagueStore leagueStore;
-    private final LeagueParticipantReader leagueParticipantReader;
-    private final ClubReader clubReader;
-    private final LeagueSearchStrategy leagueSearchStrategy;
+	private final LeagueReader leagueReader;
+	private final LeagueStore leagueStore;
+	private final LeagueParticipantReader leagueParticipantReader;
+	private final ClubReader clubReader;
+	private final LeagueSearchStrategy leagueSearchStrategy;
 
-    @Override
-    @Transactional
-    public LeagueCreateInfo createLeague(String memberToken, String clubToken,
-                                         LeagueCreateNoIncludeClubCommand leagueCreateNoIncludeClubCommand) {
-        var club = clubReader.readClub(clubToken);
-        var createdLeague = LeagueCreateCommand.build(leagueCreateNoIncludeClubCommand, memberToken, club).toEntity();
-        leagueStore.store(createdLeague);
-        return LeagueCreateInfo.from(createdLeague);
-    }
+	@Override
+	@Transactional
+	public LeagueCreateInfo createLeague(String memberToken, String clubToken,
+		LeagueCreateNoIncludeClubCommand leagueCreateNoIncludeClubCommand) {
+		var club = clubReader.readClub(clubToken);
+		var createdLeague = LeagueCreateCommand.build(leagueCreateNoIncludeClubCommand, memberToken, club).toEntity();
+		leagueReader.checkLeagueExistIn3Hours(memberToken, createdLeague.getLeagueAt());
+		leagueStore.store(createdLeague);
+		return LeagueCreateInfo.from(createdLeague);
+	}
 
-    @Override
-    @Transactional
-    public LeagueSummaryInfo getLeague(String clubToken, Long leagueId) {
-        var league = leagueReader.readLeague(clubToken, leagueId);
-        return LeagueSummaryInfo.from(league);
-    }
+	@Override
+	@Transactional
+	public LeagueSummaryInfo getLeague(String clubToken, Long leagueId) {
+		var league = leagueReader.readLeague(clubToken, leagueId);
+		return LeagueSummaryInfo.from(league);
+	}
 
-    @Override
-    @Transactional
-    public LeagueDetailInfo getLeagueDetail(String clubToken, Long leagueId) {
-        var league = leagueReader.readLeague(clubToken, leagueId);
-        return LeagueDetailInfo.from(league);
-    }
+	@Override
+	@Transactional
+	public LeagueDetailInfo getLeagueDetail(String clubToken, Long leagueId) {
+		var league = leagueReader.readLeague(clubToken, leagueId);
+		return LeagueDetailInfo.from(league);
+	}
 
-    @Override
-    public Integer getLeagueCountByClubId(Long clubId) {
-        return leagueReader.getCountByClubId(clubId);
-    }
+	@Override
+	public Integer getLeagueCountByClubId(Long clubId) {
+		return leagueReader.getCountByClubId(clubId);
+	}
 
-    @Override
-    public LeagueUpdateInfo updateLeague(String clubToken, Long leagueId, LeagueUpdateCommand leagueUpdateCommand) {
-        League league = leagueReader.readLeague(clubToken, leagueId);
-        if (league.getLeagueStatus() == LeagueStatus.CANCELED) {
-            throw new LeagueAlreadyCanceledException(leagueId);
-        }
-        league.updateLeague(leagueUpdateCommand.leagueName(), leagueUpdateCommand.description(),
-                leagueUpdateCommand.playerLimitCount(), leagueUpdateCommand.matchType(),
-                leagueUpdateCommand.matchGenerationType());
-        return LeagueUpdateInfo.from(leagueStore.store(league));
-    }
+	@Override
+	public LeagueUpdateInfo updateLeague(String clubToken, Long leagueId, LeagueUpdateCommand leagueUpdateCommand) {
+		League league = leagueReader.readLeague(clubToken, leagueId);
+		if (league.getLeagueStatus() == LeagueStatus.CANCELED) {
+			throw new LeagueAlreadyCanceledException(leagueId);
+		}
+		league.updateLeague(leagueUpdateCommand.leagueName(), leagueUpdateCommand.description(),
+			leagueUpdateCommand.playerLimitCount(), leagueUpdateCommand.matchType(),
+			leagueUpdateCommand.matchGenerationType());
+		return LeagueUpdateInfo.from(leagueStore.store(league));
+	}
 
-    @Override
-    public List<LeagueReadInfo> getLeaguesByMonth(String clubToken, String date) {
-        LocalDate parsedDate = parseDateByMonth(date);
-        LocalDateTime startOfMonth = getStartOfMonth(parsedDate);
-        LocalDateTime endOfMonth = getEndOfMonth(parsedDate);
-        List<League> result =
-                leagueReader.readLeagueByMonth(clubToken, startOfMonth, endOfMonth);
-        return result.stream()
-                .map(LeagueReadInfo::leagueReadEntityToInfo)
-                .collect(
-                        Collectors.toList());
-    }
+	@Override
+	public List<LeagueReadInfo> getLeaguesByMonth(String clubToken, String date) {
+		LocalDate parsedDate = parseDateByMonth(date);
+		LocalDateTime startOfMonth = getStartOfMonth(parsedDate);
+		LocalDateTime endOfMonth = getEndOfMonth(parsedDate);
+		List<League> result =
+			leagueReader.readLeagueByMonth(clubToken, startOfMonth, endOfMonth);
+		return result.stream()
+			.map(LeagueReadInfo::leagueReadEntityToInfo)
+			.collect(
+				Collectors.toList());
+	}
 
-    @Override
-    public List<LeagueByDateInfo> getLeaguesByDate(String clubToken, String date) {
-        LocalDate parsedDate = parseDate(date);
-        LocalDateTime startOfDay = getStartOfDay(parsedDate);
-        LocalDateTime endOfMDay = getEndOfDay(parsedDate);
-        List<League> result =
-                leagueReader.readLeagueByDate(clubToken, startOfDay, endOfMDay);
-        return result.stream()
-                .map(LeagueByDateInfo::leagueByDateEntityToInfo)
-                .collect(
-                        Collectors.toList());
-    }
+	@Override
+	public List<LeagueByDateInfo> getLeaguesByDate(String clubToken, String date) {
+		LocalDate parsedDate = parseDate(date);
+		LocalDateTime startOfDay = getStartOfDay(parsedDate);
+		LocalDateTime endOfMDay = getEndOfDay(parsedDate);
+		List<League> result =
+			leagueReader.readLeagueByDate(clubToken, startOfDay, endOfMDay);
+		return result.stream()
+			.map(LeagueByDateInfo::leagueByDateEntityToInfo)
+			.collect(
+				Collectors.toList());
+	}
 
-    @Override
-    public Page<OngoingAndUpcomingLeagueInfo> getOngoingAndUpcomingLeaguesByDate(
-            AllowedLeagueStatus leagueStatus,
-            Region region,
-            LocalDate date,
-            Pageable pageable
-    ) {
-        if (date.isBefore(LocalDate.now())) {
-            throw new OngoingAndUpcomingLeagueCanNotBePastException(date, LocalDate.now());
-        }
-        Page<League> leagues = leagueSearchStrategy.getStrategy(leagueStatus, region, date, pageable);
-        return leagues.map(league -> OngoingAndUpcomingLeagueInfo.from(
-                league, leagueParticipantReader.countParticipantMember(league.getLeagueId())));
-    }
+	@Override
+	public Page<OngoingAndUpcomingLeagueInfo> getOngoingAndUpcomingLeaguesByDate(
+		AllowedLeagueStatus leagueStatus,
+		Region region,
+		LocalDate date,
+		Pageable pageable
+	) {
+		if (date.isBefore(LocalDate.now())) {
+			throw new OngoingAndUpcomingLeagueCanNotBePastException(date, LocalDate.now());
+		}
+		Page<League> leagues = leagueSearchStrategy.getStrategy(leagueStatus, region, date, pageable);
+		return leagues.map(league -> OngoingAndUpcomingLeagueInfo.from(
+			league, leagueParticipantReader.countParticipantMember(league.getLeagueId())));
+	}
 
-    @Override
-    public LeagueCancelInfo cancelLeague(String clubToken, Long leagueId) {
-        var league = leagueReader.readLeague(clubToken, leagueId);
-        league.cancelLeague();
-        leagueStore.store(league);
-        return LeagueCancelInfo.from(league);
-    }
+	@Override
+	public LeagueCancelInfo cancelLeague(String clubToken, Long leagueId) {
+		var league = leagueReader.readLeague(clubToken, leagueId);
+		league.cancelLeague();
+		leagueStore.store(league);
+		return LeagueCancelInfo.from(league);
+	}
 
-    private LocalDate parseDateByMonth(String date) {
-        String[] parts = date.split("-");
-        int year = Integer.parseInt(parts[0]);
-        int month = Integer.parseInt(parts[1]);
-        return LocalDate.of(year, month, StartDateType.START_DAY.getDescription()); // 첫 번째 날로 초기화
-    }
+	private LocalDate parseDateByMonth(String date) {
+		String[] parts = date.split("-");
+		int year = Integer.parseInt(parts[0]);
+		int month = Integer.parseInt(parts[1]);
+		return LocalDate.of(year, month, StartDateType.START_DAY.getDescription()); // 첫 번째 날로 초기화
+	}
 
-    private LocalDateTime getStartOfMonth(LocalDate date) {
-        return LocalDateTime.of(date.getYear(), date.getMonthValue(), StartDateType.START_DAY.getDescription(),
-                StartDateType.START_HOUR.getDescription(), StartDateType.START_MINUTE.getDescription());
-    }
+	private LocalDateTime getStartOfMonth(LocalDate date) {
+		return LocalDateTime.of(date.getYear(), date.getMonthValue(), StartDateType.START_DAY.getDescription(),
+			StartDateType.START_HOUR.getDescription(), StartDateType.START_MINUTE.getDescription());
+	}
 
-    private LocalDateTime getEndOfMonth(LocalDate date) {
-        return LocalDateTime.of(date.getYear(), date.getMonthValue(),
-                date.lengthOfMonth(), EndDateType.END_HOUR.getDescription(), EndDateType.END_MINUTE.getDescription());
-    }
+	private LocalDateTime getEndOfMonth(LocalDate date) {
+		return LocalDateTime.of(date.getYear(), date.getMonthValue(),
+			date.lengthOfMonth(), EndDateType.END_HOUR.getDescription(), EndDateType.END_MINUTE.getDescription());
+	}
 
-    private LocalDate parseDate(String date) {
-        String[] parts = date.split("-");
-        int year = Integer.parseInt(parts[0]);
-        int month = Integer.parseInt(parts[1]);
-        int day = Integer.parseInt(parts[2]);
-        return LocalDate.of(year, month, day); // 첫 번째 날로 초기화
-    }
+	private LocalDate parseDate(String date) {
+		String[] parts = date.split("-");
+		int year = Integer.parseInt(parts[0]);
+		int month = Integer.parseInt(parts[1]);
+		int day = Integer.parseInt(parts[2]);
+		return LocalDate.of(year, month, day); // 첫 번째 날로 초기화
+	}
 
-    private LocalDateTime getStartOfDay(LocalDate date) {
-        return LocalDateTime.of(date.getYear(), date.getMonthValue(), date.getDayOfMonth(),
-                StartDateType.START_HOUR.getDescription(), StartDateType.START_MINUTE.getDescription());
-    }
+	private LocalDateTime getStartOfDay(LocalDate date) {
+		return LocalDateTime.of(date.getYear(), date.getMonthValue(), date.getDayOfMonth(),
+			StartDateType.START_HOUR.getDescription(), StartDateType.START_MINUTE.getDescription());
+	}
 
-    private LocalDateTime getEndOfDay(LocalDate date) {
-        return LocalDateTime.of(date.getYear(), date.getMonthValue(),
-                date.getDayOfMonth(), EndDateType.END_HOUR.getDescription(), EndDateType.END_MINUTE.getDescription());
-    }
+	private LocalDateTime getEndOfDay(LocalDate date) {
+		return LocalDateTime.of(date.getYear(), date.getMonthValue(),
+			date.getDayOfMonth(), EndDateType.END_HOUR.getDescription(), EndDateType.END_MINUTE.getDescription());
+	}
 
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/league/LeagueRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/league/LeagueRepository.java
@@ -57,4 +57,10 @@ public interface LeagueRepository extends JpaRepository<League, Long> {
 
 	@Query("SELECT league FROM League league WHERE league.leagueAt < :yesterday")
 	List<League> findAllByLeagueAtBefore(@Param("yesterday") LocalDateTime yesterday);
+
+	boolean existsByLeagueOwnerMemberTokenAndLeagueAtBetween(
+		String memberToken,
+		LocalDateTime startTime,
+		LocalDateTime endTime
+	);
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍
-리그 중복 생성 방지입니다. 



## 변경된 사항 📝

<!-- 이번 PR에서의 변경점 -->

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF, 글 -->

### Before

### After
![image](https://github.com/user-attachments/assets/6f8ef687-0908-4b97-b375-6a589ebafb5b)

## PR에서 중점적으로 확인되어야 하는 사항
- 리그 중복 방지에 2가지 방안을 고민했습니다.
### 2가지 방법
- memberOwenerToken 으로 중복생성을 방지 할 것인지
  - 이 방식을 적용하면 생성자가 같은 경우 다른 동호회라도 경기 생성은 3시간 단위로 할 수 있습니다.   
- clubId 로 방지 할 것인지 
  - 이 방식을 적용하면 같은 동호회 내에서 경기는 3시간 단위로 생성됩니다.

### 적용안 
- 1안으로 결정하여 적용하였습니다.
  - 2안으로 결정할 시에는 경기 방식이 다르면 시간을 중복해서 생성 가능하도록 해야 되기 때문에 1안이 적합하다고 생각합니다.   
