### PR TITLE
feat : 클럽 오너를 보호하는 로직 추가

### DIFF
--- a/api/src/main/java/org/badminton/api/interfaces/clubmember/controller/ClubMemberController.java
+++ b/api/src/main/java/org/badminton/api/interfaces/clubmember/controller/ClubMemberController.java
@@ -80,9 +80,9 @@ public class ClubMemberController {
 	@Operation(summary = "동호회 가입 신청",
 		description = """
 			동호회에 가입을 신청합니다.
-			
+						
 			1. 가입 신청 글 2 ~ 20자
-			
+						
 			""",
 		tags = {"ClubMember"})
 	@PostMapping
@@ -122,7 +122,7 @@ public class ClubMemberController {
 		summary = "동호회원 역할 변경시키기",
 		description = """
 			동호회원의 역할을 변경시킵니다. 다음 제약 사항과 정보를 반드시 확인해야 합니다:
-			
+						
 			1. 회원 역할:
 			   - 탈퇴 대상 회원의 현재 역할을 나타냅니다.
 			   - 다음 중 하나여야 합니다:
@@ -148,19 +148,22 @@ public class ClubMemberController {
 		summary = "동호회원 강제 탈퇴시키기",
 		description = """
 			동호회원을 강제로 탈퇴시킵니다. 다음 제약 사항을 반드시 준수해야 합니다:
-			
+						
 			1. 회원 제제 사유:
 			   - 필수 입력 항목입니다.
 			   - 최소 2자 이상이어야 합니다.
 			   - 최대 100자 이하여야 합니다.
-			
+			2. 자기자신은 탈퇴 시킬 수 없습니다.
+						
 			""",
 		tags = {"ClubMember"}
 	)
 	@PatchMapping("/expel")
-	public CommonResponse<ClubMemberBanRecordResponse> expelClubMember(@RequestParam Long clubMemberId,
-		@PathVariable String clubToken, @Valid @RequestBody
-	ClubMemberExpelRequest request) {
+	public CommonResponse<ClubMemberBanRecordResponse> expelClubMember(
+		@RequestParam Long clubMemberId,
+		@PathVariable String clubToken,
+		@Valid @RequestBody ClubMemberExpelRequest request
+	) {
 		ClubMemberExpelCommand clubMemberExpelCommand = request.of();
 
 		ClubMemberBanRecordInfo clubMemberBanRecordInfo = clubMemberFacade.expelClubMember(clubMemberExpelCommand,
@@ -173,7 +176,7 @@ public class ClubMemberController {
 		summary = "동호회원 정지시키기",
 		description = """
 			동호회원을 정지시킵니다. 다음 제약 사항을 반드시 준수해야 합니다:
-			
+						
 			1. 회원 제제 사유:
 			   - 필수 입력 항목입니다.
 			   - 최소 2자 이상이어야 합니다.
@@ -184,7 +187,7 @@ public class ClubMemberController {
 			     THREE_DAYS: 3일 정지
 			     SEVEN_DAYS: 7일 정지
 			     TWO_WEEKS: 14일 정지
-			
+						
 			""",
 		tags = {"ClubMember"}
 	)

--- a/api/src/main/java/org/badminton/api/interfaces/clubmember/dto/ClubMemberExpelRequest.java
+++ b/api/src/main/java/org/badminton/api/interfaces/clubmember/dto/ClubMemberExpelRequest.java
@@ -4,10 +4,11 @@ import org.badminton.api.interfaces.clubmember.validation.ReasonValidator;
 import org.badminton.domain.domain.clubmember.command.ClubMemberExpelCommand;
 
 public record ClubMemberExpelRequest(
-        @ReasonValidator
-        String expelReason
+
+	@ReasonValidator
+	String expelReason
 ) {
-        public ClubMemberExpelCommand of() {
-                return new ClubMemberExpelCommand(this.expelReason);
-        }
+	public ClubMemberExpelCommand of() {
+		return new ClubMemberExpelCommand(this.expelReason);
+	}
 }

--- a/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
+++ b/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
@@ -64,6 +64,7 @@ public enum ErrorCode {
 	CLUB_MEMBER_ALREADY_BANNED(409, "해당 회원은 이미 제제를 받은 상태입니다"),
 	LEAGUE_ALREADY_CANCELED(409, "해당하는 경기는 이미 취소된 경기입니다."),
 	LEAGUE_AT_LESS_THAN_THREE_HOUR_INTERVAL(409, "3시간 이후에 경기를 생성할 수 있습니다."),
+	CLUB_MEMBER_OWNER_PROTECT(409, "동호회 회장의 리소스는 보호되어야 합니다."),
 
 	// 410 Errors
 	DELETED(410, "요청한 리소스가 삭제되었습니다."),

--- a/domain/src/main/java/org/badminton/domain/common/exception/clubmember/ClubMemberOwnerException.java
+++ b/domain/src/main/java/org/badminton/domain/common/exception/clubmember/ClubMemberOwnerException.java
@@ -1,0 +1,15 @@
+package org.badminton.domain.common.exception.clubmember;
+
+import org.badminton.domain.common.error.ErrorCode;
+import org.badminton.domain.common.exception.BadmintonException;
+
+public class ClubMemberOwnerException extends BadmintonException {
+
+	public ClubMemberOwnerException(String clubToken) {
+		super(ErrorCode.CLUB_MEMBER_OWNER_PROTECT, "[" + clubToken + "의 회장입니다.]");
+	}
+
+	public ClubMemberOwnerException(String clubToken, Exception e) {
+		super(ErrorCode.CLUB_MEMBER_OWNER_PROTECT, "[" + clubToken + "의 회장입니다.]");
+	}
+}

--- a/domain/src/main/java/org/badminton/domain/domain/clubmember/service/ClubMemberServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/clubmember/service/ClubMemberServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.badminton.domain.common.exception.clubmember.ClubMemberOwnerException;
 import org.badminton.domain.domain.club.entity.Club;
 import org.badminton.domain.domain.club.info.ClubCardInfo;
 import org.badminton.domain.domain.club.info.ClubCreateInfo;
@@ -49,6 +50,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 	public ClubMemberInfo updateClubMemberRole(ClubMemberRoleUpdateCommand command, Long clubMemberId) {
 		ClubMember clubMember = clubMemberReader.getClubMember(clubMemberId);
 		clubMember.updateClubMemberRole(command.role());
+		clubOwnerProtect(clubMember);
 		clubMemberStore.store(clubMember);
 		return ClubMemberInfo.valueOf(clubMember);
 	}
@@ -62,7 +64,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 			clubMemberReader.getAllClubMemberByClubId(clubToken);
 
 		clubMembers.stream()
-			.map(ClubMemberInfo::valueOf) // 멤버를 응답 객체로 변환
+			.map(ClubMemberInfo::valueOf)
 			.forEach(clubMemberResponse -> {
 				ClubMember.ClubMemberRole role = clubMemberResponse.role();
 				responseMap.computeIfAbsent(role, clubMember -> new ArrayList<>()).add(clubMemberResponse);
@@ -81,15 +83,14 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 	@Override
 	public ClubMemberInfo getClubMember(String memberToken, String clubToken) {
 		ClubMember clubMember = clubMemberReader.getClubMemberByMemberTokenAndClubToken(clubToken, memberToken);
-
 		return ClubMemberInfo.valueOf(clubMember);
 	}
 
 	@Override
 	public ClubMemberBanRecordInfo expelClubMember(ClubMemberExpelCommand command, Long clubMemberId) {
 		ExpelStrategy expelStrategy = new ExpelStrategy(clubMemberStore);
-
 		ClubMember clubMember = getClubMember(clubMemberId);
+		clubOwnerProtect(clubMember);
 		return expelStrategy.execute(clubMember, command);
 	}
 
@@ -97,6 +98,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 	public ClubMemberBanRecordInfo banClubMember(ClubMemberBanCommand command, Long clubMemberId) {
 		BanStrategy banStrategy = new BanStrategy(clubMemberStore);
 		ClubMember clubMember = getClubMember(clubMemberId);
+		clubOwnerProtect(clubMember);
 		return banStrategy.execute(clubMember, command);
 	}
 
@@ -161,6 +163,12 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 
 	private ClubMember getClubMember(Long clubMemberId) {
 		return clubMemberReader.getClubMember(clubMemberId);
+	}
+
+	private void clubOwnerProtect(ClubMember clubMember) {
+		if (clubMember.getRole().equals(ClubMember.ClubMemberRole.ROLE_OWNER)) {
+			throw new ClubMemberOwnerException(clubMember.getClub().getClubToken());
+		}
 	}
 
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍
- 클럽오너는 정지, 강제탈퇴, 역할 변경이 되어서는 안됩니다. 

## 변경된 사항 📝

### Before
동호회 회장에 대한 정보 변경 가능

### After
동호회 회장에 대한 정보 변경 보호

