### PR TITLE
feat: 배포서버에 대한 스웨거 접속 방지

### DIFF
--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -119,6 +119,9 @@ spring:
       on-profile: production
   jpa:
     show-sql: false
+springdoc:
+  swagger-ui:
+    enabled: false
 ---
 spring:
   config:


### PR DESCRIPTION
## PR에 대한 설명 🔍
- 현재 스웨거는 모두가 볼 수 있습니다. 스웨거 관련 url 을 제한 해야됩니다.

## 변경된 사항 📝
```yaml
---
spring:
  config:
    activate:
      on-profile: production
  jpa:
    show-sql: false
springdoc:
  swagger-ui:
    enabled: false
```
production 환경에서 스웨거 접속 방지

apit 를 사용하는 곳에서는 profile을 develop 으로 사용하고 api는 production으로 세팅하면됩니다.
.env 일부 발췌
```env

#ACTIVE_PROFILE="production"
ACTIVE_PROFILE="develop"

```


## PR에서 중점적으로 확인되어야 하는 사항
