### PR TITLE
bug : 이메일 여러번 보내는 버그 해결

### DIFF
--- a/api/src/main/java/org/badminton/api/application/clubMember/ClubMemberFacade.java
+++ b/api/src/main/java/org/badminton/api/application/clubMember/ClubMemberFacade.java
@@ -32,7 +32,7 @@ public class ClubMemberFacade {
 	private final MailService mailService;
 
 	public ApplyClubInfo applyClub(String memberToken, String clubToken, ClubApplyCommand command) {
-		mailService.prepareClubApplyEmail(clubToken);
+		mailService.prepareClubApplyEmail(clubToken, memberToken);
 		return clubApplyService.applyClub(memberToken, clubToken, command.applyReason());
 
 	}

--- a/domain/src/main/java/org/badminton/domain/domain/mail/MailService.java
+++ b/domain/src/main/java/org/badminton/domain/domain/mail/MailService.java
@@ -1,7 +1,7 @@
 package org.badminton.domain.domain.mail;
 
 public interface MailService {
-	void prepareClubApplyEmail(String clubToken);
+	void prepareClubApplyEmail(String clubToken, String memberToken);
 
 	void prepareClubApplyResultEmail(Long clubApplyId, boolean isApproved);
 }

--- a/domain/src/main/java/org/badminton/domain/domain/mail/MailServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/mail/MailServiceImpl.java
@@ -28,7 +28,8 @@ public class MailServiceImpl implements MailService {
 	private final MailStore mailStore;
 
 	@Override
-	public void prepareClubApplyEmail(String clubToken) {
+	public void prepareClubApplyEmail(String clubToken, String memberToken) {
+		clubApplyReader.validateApply(clubToken, memberToken);
 		Club club = clubReader.readClub(clubToken);
 		ClubMember clubOwner = clubMemberReader.getClubOwner(clubToken);
 		String ownerEmail = clubOwner.getMember().getEmail();


### PR DESCRIPTION
## PR에 대한 설명 🔍 
- 메일이 여러번 보내지는 버그가 해결 


## 변경된 사항 📝
배치 문제가 아닌 mail 테이블에 똑같은 데이터가 여러번 들어가는 이슈가 발생 했었습니다.
해당 이슈는 clubApply 테이블의 상태를 이용해서 해결하였습니다.
pending 이냐 APPROVED 또는 REJECTED 인지에 따라서 
메일 테이블에 새롭게 데이터가 추가되고 Pending 상태의 데이터만 누적됩니다.


## PR에서 중점적으로 확인되어야 하는 사항
