### PR TITLE
feat: 동호회 중복 가입 방지

### DIFF
--- a/domain/src/main/java/org/badminton/domain/domain/club/ClubApplyReader.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/ClubApplyReader.java
@@ -11,6 +11,8 @@ public interface ClubApplyReader {
 
 	void validateApply(String clubToken, String memberToken);
 
+	void validateEmailApply(String clubToken, String memberToken);
+
 	List<ClubApplicantInfo> getClubApplyByClubToken(String clubToken, ClubApply.ApplyStatus applyStatus);
 
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubApplyReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubApplyReaderImpl.java
@@ -24,6 +24,13 @@ public class ClubApplyReaderImpl implements ClubApplyReader {
 
 	@Override
 	public void validateApply(String clubToken, String memberToken) {
+		if (clubApplyRepository.existsByClubClubTokenAndMemberMemberToken(clubToken, memberToken)) {
+			throw new MemberAlreadyApplyClubException(memberToken, clubToken);
+		}
+	}
+
+	@Override
+	public void validateEmailApply(String clubToken, String memberToken) {
 		if (clubApplyRepository.existsByClubClubTokenAndMemberMemberTokenAndStatus(clubToken, memberToken,
 			ClubApply.ApplyStatus.PENDING)) {
 			throw new MemberAlreadyApplyClubException(memberToken, clubToken);
@@ -34,7 +41,7 @@ public class ClubApplyReaderImpl implements ClubApplyReader {
 	public List<ClubApplicantInfo> getClubApplyByClubToken(String clubToken, ClubApply.ApplyStatus applyStatus) {
 		List<ClubApply> clubApplicants = clubApplyRepository.findAllByClubClubTokenAndStatus(clubToken,
 			applyStatus);
-		
+
 		return clubApplicants.stream()
 			.map(ClubApplicantInfo::from)
 			.toList();

--- a/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubApplyRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubApplyRepository.java
@@ -13,4 +13,6 @@ public interface ClubApplyRepository extends JpaRepository<ClubApply, Long> {
 		ClubApply.ApplyStatus status);
 
 	List<ClubApply> findAllByClubClubTokenAndStatus(String clubToken, ClubApply.ApplyStatus status);
+
+	boolean existsByClubClubTokenAndMemberMemberToken(String clubToken, String memberToken);
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍
- 동호회 가입 신청 후 새로고침 없이 동호회 회장이 가입 승인하면 다시 가입 신청이 되었습니다.


## 변경된 사항 📝

### Before
- 동호회 가입 신청 후 새로고침 없이 동호회 회장이 가입 승인하면 다시 가입 신청이 되었습니다.

### After
- 동호회 한번만 가입하면 이후 가입 신청 에러 메시지가 나오도록 수정하였습니다.
![image](https://github.com/user-attachments/assets/8e88398c-92de-4778-8d60-e6712f55a1b9)


## PR에서 중점적으로 확인되어야 하는 사항
