### PR TITLE
bug: 배치 에러 수정

### DIFF
--- a/batch/src/main/java/springproject/badmintonbatch/batch/config/EmailBatchConfig.java
+++ b/batch/src/main/java/springproject/badmintonbatch/batch/config/EmailBatchConfig.java
@@ -40,7 +40,7 @@ public class EmailBatchConfig {
 			.build();
 	}
 
-	@Bean
+	@Bean(name = "emailTransactionManager")
 	public PlatformTransactionManager emailTransactionManager(EntityManagerFactory entityManagerFactory) {
 		return new JpaTransactionManager(entityManagerFactory);
 	}

--- a/batch/src/main/java/springproject/badmintonbatch/batch/config/LeagueBatchConfig.java
+++ b/batch/src/main/java/springproject/badmintonbatch/batch/config/LeagueBatchConfig.java
@@ -45,7 +45,7 @@ public class LeagueBatchConfig {
 			.build();
 	}
 
-	@Bean
+	@Bean(name = "leagueTransactionManager")
 	public PlatformTransactionManager leagueTransactionManager(EntityManagerFactory entityManagerFactory) {
 		return new JpaTransactionManager(entityManagerFactory);
 	}

--- a/batch/src/main/java/springproject/badmintonbatch/batch/config/LeagueStatusBatchConfig.java
+++ b/batch/src/main/java/springproject/badmintonbatch/batch/config/LeagueStatusBatchConfig.java
@@ -41,7 +41,7 @@ public class LeagueStatusBatchConfig {
 			.build();
 	}
 
-	@Bean
+	@Bean(name = "leagueStatusTransactionManager")
 	PlatformTransactionManager leagueStatusTransactionManager(EntityManagerFactory entityManagerFactory) {
 		return new JpaTransactionManager(entityManagerFactory);
 	}


### PR DESCRIPTION
## PR에 대한 설명 🔍
- PR의 내용에 대한 설명을 자세히 설명 
- 테스트 서버에서의 배치가 멈추는 현상이 발생 
- 발생 일시 : 25일 17시 51분 

## 변경된 사항 📝
![image](https://github.com/user-attachments/assets/7a237ca2-bef9-448c-9419-1ff7f8c9eb3d)
다음과 같은 현상이 발생했습니다. 
트랜잭션 중복 현상
각 Job에는 다른 트랜잭션 매니저가 동작해야하는데 같은 매니저가 동작하여 발생한 에러 인것 같습니다.
트랜잭션 메니져 마다 이름을 설정하였습니다. 

에러 메시지 
```bash
08:51:43.235 [main] [ WARN] o.s.b.w.s.c.AnnotationConfigServletWebServerApplicationContext[refresh:633] Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.support.BeanDefinitionOverrideException: Invalid bean definition with name 'leagueStatusTransactionManager' defined in class path resource [springproject/badmintonbatch/batch/config/MemberLiftBatchConfig.class]: Cannot register bean definition [Root bean: class [null]; scope=; abstract=false; lazyInit=null; autowireMode=3; dependencyCheck=0; autowireCandidate=true; primary=false; factoryBeanName=memberLiftBatchConfig; factoryMethodName=leagueStatusTransactionManager; initMethodNames=null; destroyMethodNames=[(inferred)]; defined in class path resource [springproject/badmintonbatch/batch/config/MemberLiftBatchConfig.class]] for bean 'leagueStatusTransactionManager' since there is already [Root bean: class [null]; scope=; abstract=false; lazyInit=null; autowireMode=3; dependencyCheck=0; autowireCandidate=true; primary=false; factoryBeanName=leagueStatusBatchConfig; factoryMethodName=leagueStatusTransactionManager; initMethodNames=null; destroyMethodNames=[(inferred)]; defined in class path resource [springproject/badmintonbatch/batch/config/LeagueStatusBatchConfig.class]] bound.

08:51:43.306 [main] [ INFO] o.s.b.a.l.ConditionEvaluationReportLogger[logMessage:82] 

Error starting ApplicationContext. To display the condition evaluation report re-run your application with 'debug' enabled.

08:51:43.474 [main] [ERROR] o.s.b.d.LoggingFailureAnalysisReporter[report:40] 

***************************
APPLICATION FAILED TO START
***************************

Description:

The bean 'leagueStatusTransactionManager', defined in class path resource [springproject/badmintonbatch/batch/config/MemberLiftBatchConfig.class], could not be registered. A bean with that name has already been defined in class path resource [springproject/badmintonbatch/batch/config/LeagueStatusBatchConfig.class] and overriding is disabled.

Action:

Consider renaming one of the beans or enabling overriding by setting spring.main.allow-bean-definition-overriding=true



```


## PR에서 중점적으로 확인되어야 하는 사항
- 트랜잭션 이름 중복 확인 ❗️