### PR TITLE
feat: 조회수 증가 시 이벤트 리스너를 사용하여 비동기 처리

### DIFF
--- a/api/src/main/java/org/badminton/api/application/club/ClubFacade.java
+++ b/api/src/main/java/org/badminton/api/application/club/ClubFacade.java
@@ -14,7 +14,9 @@ import org.badminton.domain.domain.club.info.ClubDetailsInfo;
 import org.badminton.domain.domain.club.info.ClubUpdateInfo;
 import org.badminton.domain.domain.clubmember.service.ClubMemberService;
 import org.badminton.domain.domain.member.entity.Member;
-import org.badminton.domain.domain.statistics.ClubStatisticsService;
+import org.badminton.domain.domain.statistics.event.CreateClubEvent;
+import org.badminton.domain.domain.statistics.event.ReadClubEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -31,7 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ClubFacade {
 	private final ClubService clubService;
 	private final ClubMemberService clubMemberService;
-	private final ClubStatisticsService clubStatisticsService;
+	private final ApplicationEventPublisher eventPublisher;
 
 	@Transactional(readOnly = true)
 	public Page<ClubCardInfo> readAllClubs(int page, int size, String sort) {
@@ -42,10 +44,9 @@ public class ClubFacade {
 	@Transactional
 	public ClubDetailsInfo readClub(String clubToken) {
 		var club = clubService.readClub(clubToken);
+		eventPublisher.publishEvent(new ReadClubEvent(clubToken));
 		Map<Member.MemberTier, Long> memberCountByTier = club.getClubMemberCountByTier();
-
 		int clubMembersCount = clubMemberService.countExistingClub(clubToken);
-		clubStatisticsService.increaseVisitedClubCount(clubToken);
 		return ClubDetailsInfo.from(club, memberCountByTier,
 			clubMembersCount);
 	}
@@ -58,9 +59,9 @@ public class ClubFacade {
 
 	@Transactional
 	public ClubCreateInfo createClub(ClubCreateCommand createCommand, String memberToken) {
-		var clubCreateInfo = clubService.createClub(createCommand);
+		ClubCreateInfo clubCreateInfo = clubService.createClub(createCommand);
 		clubMemberService.clubMemberOwner(memberToken, clubCreateInfo);
-		clubStatisticsService.createStatistic(clubCreateInfo);
+		eventPublisher.publishEvent(new CreateClubEvent(clubCreateInfo));
 		return clubCreateInfo;
 	}
 

--- a/api/src/main/java/org/badminton/api/application/club/ClubFacade.java
+++ b/api/src/main/java/org/badminton/api/application/club/ClubFacade.java
@@ -44,9 +44,9 @@ public class ClubFacade {
 	@Transactional
 	public ClubDetailsInfo readClub(String clubToken) {
 		var club = clubService.readClub(clubToken);
-		eventPublisher.publishEvent(new ReadClubEvent(clubToken));
 		Map<Member.MemberTier, Long> memberCountByTier = club.getClubMemberCountByTier();
 		int clubMembersCount = clubMemberService.countExistingClub(clubToken);
+		eventPublisher.publishEvent(new ReadClubEvent(clubToken));
 		return ClubDetailsInfo.from(club, memberCountByTier,
 			clubMembersCount);
 	}

--- a/api/src/test/java/org/badminton/api/application/club/ClubFacadeTest.java
+++ b/api/src/test/java/org/badminton/api/application/club/ClubFacadeTest.java
@@ -19,13 +19,14 @@ import org.badminton.domain.domain.club.info.ClubSummaryInfo;
 import org.badminton.domain.domain.club.info.ClubUpdateInfo;
 import org.badminton.domain.domain.clubmember.service.ClubMemberService;
 import org.badminton.domain.domain.member.entity.Member;
-import org.badminton.domain.domain.statistics.ClubStatisticsService;
+import org.badminton.domain.domain.statistics.event.CreateClubEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -43,7 +44,7 @@ class ClubFacadeTest {
 	private ClubMemberService clubMemberService;
 
 	@Mock
-	private ClubStatisticsService clubStatisticsService;
+	private ApplicationEventPublisher eventPublisher;
 
 	@BeforeEach
 	void setUp() {
@@ -145,7 +146,7 @@ class ClubFacadeTest {
 		assertNotNull(result);
 		verify(clubService, times(1)).createClub(createCommand);
 		verify(clubMemberService, times(1)).clubMemberOwner(memberToken, mockClubCreateInfo);
-		verify(clubStatisticsService, times(1)).createStatistic(mockClubCreateInfo);
+		verify(eventPublisher, times(1)).publishEvent(any(CreateClubEvent.class));
 	}
 
 	@Test

--- a/domain/src/main/java/org/badminton/domain/domain/statistics/event/CreateClubEvent.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/event/CreateClubEvent.java
@@ -1,0 +1,12 @@
+package org.badminton.domain.domain.statistics.event;
+
+import org.badminton.domain.domain.club.info.ClubCreateInfo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateClubEvent {
+	private final ClubCreateInfo clubCreateInfo;
+}

--- a/domain/src/main/java/org/badminton/domain/domain/statistics/event/CreateClubEventHandler.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/event/CreateClubEventHandler.java
@@ -1,0 +1,18 @@
+package org.badminton.domain.domain.statistics.event;
+
+import org.badminton.domain.domain.statistics.ClubStatisticsService;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CreateClubEventHandler {
+	private final ClubStatisticsService clubStatisticsService;
+
+	@TransactionalEventListener
+	public void createClubEventListener(CreateClubEvent event) {
+		clubStatisticsService.createStatistic(event.getClubCreateInfo());
+	}
+}

--- a/domain/src/main/java/org/badminton/domain/domain/statistics/event/ReadClubEvent.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/event/ReadClubEvent.java
@@ -1,0 +1,11 @@
+package org.badminton.domain.domain.statistics.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ReadClubEvent {
+
+	private final String clubToken;
+}

--- a/domain/src/main/java/org/badminton/domain/domain/statistics/event/ReadClubEventHandler.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/event/ReadClubEventHandler.java
@@ -1,0 +1,19 @@
+package org.badminton.domain.domain.statistics.event;
+
+import org.badminton.domain.domain.statistics.ClubStatisticsService;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReadClubEventHandler {
+
+	private final ClubStatisticsService clubStatisticsService;
+
+	@TransactionalEventListener
+	public void readClubEventListener(ReadClubEvent event) {
+		clubStatisticsService.increaseVisitedClubCount(event.getClubToken());
+	}
+}


### PR DESCRIPTION
## PR에 대한 설명 🔍

동호회를 조회할 때 조회수를 증가합니다. 이때 GET 요청이 있을 때마다 DB에 count를 +1 씩 증가합니다. 이벤트 리스너를 통해 비동기적으로 처리하려고 합니다. 
또 지금은 DB에 바로 update를 하고 있지만, Redis에 우선 저장 후 특정 주기로 DB에 update를 하는 방향으로 개선하려고 합니다. 

## 변경된 사항 📝

ClubFacade에서 ClubStatistics에 의존하지 않고, 이벤트 리스너를 통해 이벤트를 발행합니다.

### Before

```java
@Transactional
	public ClubDetailsInfo readClub(String clubToken) {
		var club = clubService.readClub(clubToken);
		Map<Member.MemberTier, Long> memberCountByTier = club.getClubMemberCountByTier();
		int clubMembersCount = club.clubMembers().size();
		clubStatisticsService.increaseVisitedClubCount(clubToken);
		return ClubDetailsInfo.from(club, memberCountByTier,
			clubMembersCount);
	}
```

### After

```java
@Transactional
	public ClubDetailsInfo readClub(String clubToken) {
		var club = clubService.readClub(clubToken);
		eventPublisher.publishEvent(new ReadClubEvent(clubToken));
		Map<Member.MemberTier, Long> memberCountByTier = club.getClubMemberCountByTier();
		int clubMembersCount = clubMemberService.countExistingClub(clubToken);
		return ClubDetailsInfo.from(club, memberCountByTier,
			clubMembersCount);
	}
```

## PR에서 중점적으로 확인되어야 하는 사항

이벤트 리스너를 올바르게 사용했는지, 더 개선할 부분이 있을지 검토해주세요.