### PR TITLE
feat: 이미지 webp, avif 로 컨버팅

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -8,7 +8,9 @@ dependencies {
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.5.RELEASE'
-
+    implementation "com.sksamuel.scrimage:scrimage-core:4.0.32"
+    implementation "com.sksamuel.scrimage:scrimage-webp:4.0.32"
+    
     implementation 'org.mapstruct:mapstruct:1.4.2.Final'
     annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: '3.3.4'

--- a/api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
@@ -35,7 +35,7 @@ public abstract class AbstractFileUploadService implements ImageService {
 	public String uploadFile(ImageUploadRequest file) {
 		MultipartFile uploadFile = file.multipartFile();
 		if (uploadFile.getSize() > MAX_FILE_SIZE) {
-			throw new FileSizeOverException();
+			throw new FileSizeOverException(uploadFile.getSize());
 		}
 
 		// 파일이 비어있거나 파일 이름이 없는 경우 체크

--- a/api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
@@ -1,10 +1,12 @@
 package org.badminton.api.aws.s3.service;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Objects;
 
 import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
 import org.badminton.api.common.exception.EmptyFileException;
+import org.badminton.api.common.exception.FileSizeOverException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,32 +19,72 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public abstract class AbstractFileUploadService implements ImageService {
+	private static final long MAX_FILE_SIZE = 2548576; // 1.5MB
 
 	@Value("${cloud.aws.s3.bucket}")
 	private String bucket;
 
 	private final AmazonS3 s3Client;
+	private final ImageConversionService imageConversionService;
 	private static final String S3_URL_PREFIX = "https://badminton-team.s3.ap-northeast-2.amazonaws.com";
 	private static final String CLOUDFRONT_URL_PREFIX = "https://d36om9pjoifd2y.cloudfront.net";
 
 	public String uploadFile(ImageUploadRequest file) {
 		MultipartFile uploadFile = file.multipartFile();
-		if (uploadFile.isEmpty() || Objects.isNull(uploadFile.getOriginalFilename())) {
+
+		try {
+			if (uploadFile.getSize() > MAX_FILE_SIZE) {
+				throw new FileSizeOverException();
+			}
+
+			// 파일이 비어있거나 파일 이름이 없는 경우 체크
+			if (uploadFile.isEmpty() || Objects.isNull(uploadFile.getOriginalFilename())) {
+				throw new EmptyFileException();
+			}
+
+			// 파일 형식이 WebP인지 체크
+			byte[] fileBytes = uploadFile.getBytes();
+			String fileExtension = getFileExtension(uploadFile.getOriginalFilename());
+
+			byte[] processedImage;
+			String newFileExtension;
+
+			if ("webp".equalsIgnoreCase(fileExtension)) {
+				processedImage = fileBytes;
+				newFileExtension = "webp";
+			} else if ("avif".equalsIgnoreCase(fileExtension)) {
+				processedImage = fileBytes;
+				newFileExtension = "avif";
+			} else {
+				processedImage = imageConversionService.convertToWebP(uploadFile);
+				newFileExtension = "webp";
+			}
+
+			String fileName = makeFileName(newFileExtension);
+
+			ObjectMetadata objectMetadata = new ObjectMetadata();
+			objectMetadata.setContentLength(processedImage.length);
+			objectMetadata.setContentType("image/webp");
+
+			// S3에 파일 업로드
+			s3Client.putObject(new PutObjectRequest(bucket, fileName,
+				new ByteArrayInputStream(processedImage), objectMetadata)
+				.withCannedAcl(CannedAccessControlList.PublicRead));
+
+			// 업로드 후 CloudFront URL 반환
+			return toCloudFrontUrl(s3Client.getUrl(bucket, fileName).toString());
+
+		} catch (IOException e) {
 			throw new EmptyFileException();
 		}
-		String fileName = makeFileName(uploadFile.getOriginalFilename());
+	}
 
-		ObjectMetadata objectMetadata = new ObjectMetadata();
-		objectMetadata.setContentLength(uploadFile.getSize());
-		objectMetadata.setContentType(uploadFile.getContentType());
-		try {
-			s3Client.putObject(new PutObjectRequest(bucket, fileName,
-				uploadFile.getInputStream(), objectMetadata)
-				.withCannedAcl(CannedAccessControlList.PublicRead));
-			return toCloudFrontUrl(s3Client.getUrl(bucket, fileName).toString());
-		} catch (IOException exception) {
-			throw new EmptyFileException(exception);
+	private String getFileExtension(String filename) {
+		int dotIndex = filename.lastIndexOf(".");
+		if (dotIndex == -1) {
+			return "";
 		}
+		return filename.substring(dotIndex + 1);
 	}
 
 	private String toCloudFrontUrl(String originUrl) {
@@ -54,7 +96,5 @@ public abstract class AbstractFileUploadService implements ImageService {
 	}
 
 	@Override
-	public abstract String makeFileName(String originalFilename);
-
+	public abstract String makeFileName(String newFileExtension);
 }
-

--- a/api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
@@ -20,6 +20,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public abstract class AbstractFileUploadService implements ImageService {
 	private static final long MAX_FILE_SIZE = 2548576; // 1.5MB
+	private static final String WEBP = "webp";
+	private static final String AVIF = "avif";
+	private static final String CONTENT_TYPE = "image/webp";
 
 	@Value("${cloud.aws.s3.bucket}")
 	private String bucket;
@@ -49,22 +52,22 @@ public abstract class AbstractFileUploadService implements ImageService {
 			byte[] processedImage;
 			String newFileExtension;
 
-			if ("webp".equalsIgnoreCase(fileExtension)) {
+			if (WEBP.equalsIgnoreCase(fileExtension)) {
 				processedImage = fileBytes;
-				newFileExtension = "webp";
-			} else if ("avif".equalsIgnoreCase(fileExtension)) {
+				newFileExtension = WEBP;
+			} else if (AVIF.equalsIgnoreCase(fileExtension)) {
 				processedImage = fileBytes;
-				newFileExtension = "avif";
+				newFileExtension = AVIF;
 			} else {
 				processedImage = imageConversionService.convertToWebP(uploadFile);
-				newFileExtension = "webp";
+				newFileExtension = WEBP;
 			}
 
 			String fileName = makeFileName(newFileExtension);
 
 			ObjectMetadata objectMetadata = new ObjectMetadata();
 			objectMetadata.setContentLength(processedImage.length);
-			objectMetadata.setContentType("image/webp");
+			objectMetadata.setContentType(CONTENT_TYPE);
 
 			// S3에 파일 업로드
 			s3Client.putObject(new PutObjectRequest(bucket, fileName,

--- a/api/src/main/java/org/badminton/api/aws/s3/service/ClubImageService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/ClubImageService.java
@@ -10,8 +10,8 @@ import com.amazonaws.services.s3.AmazonS3;
 @Service
 public class ClubImageService extends AbstractFileUploadService {
 
-	public ClubImageService(AmazonS3 s3Client) {
-		super(s3Client);
+	public ClubImageService(AmazonS3 s3Client, ImageConversionService imageConversionService) {
+		super(s3Client, imageConversionService);
 	}
 
 	@Override
@@ -20,10 +20,8 @@ public class ClubImageService extends AbstractFileUploadService {
 	}
 
 	@Override
-	public String makeFileName(String originalFilename) {
-		String[] originFile = originalFilename.split("\\.");
-		String extension = originFile[originFile.length - 1];
-		return "club-banner/" + UUID.randomUUID() + "." + extension;
+	public String makeFileName(String newFileExtension) {
+		return "club-banner/" + UUID.randomUUID() + "." + newFileExtension;
 	}
 }
 

--- a/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
@@ -1,6 +1,7 @@
 package org.badminton.api.aws.s3.service;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 import org.badminton.api.common.exception.EmptyFileException;
 import org.springframework.stereotype.Service;
@@ -20,8 +21,8 @@ public class ImageConversionService {
 			WebpWriter writer = WebpWriter.DEFAULT;
 			writer.write(image, ImageMetadata.fromStream(file.getInputStream()), outputStream);
 			return outputStream.toByteArray();
-		} catch (Exception e) {
-			throw new EmptyFileException(e);
+		} catch (IOException exception) {
+			throw new EmptyFileException(exception);
 		}
 
 	}

--- a/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
@@ -1,0 +1,28 @@
+package org.badminton.api.aws.s3.service;
+
+import java.io.ByteArrayOutputStream;
+
+import org.badminton.api.common.exception.EmptyFileException;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.sksamuel.scrimage.ImmutableImage;
+import com.sksamuel.scrimage.metadata.ImageMetadata;
+import com.sksamuel.scrimage.webp.WebpWriter;
+
+@Service
+public class ImageConversionService {
+
+	public byte[] convertToWebP(MultipartFile file) {
+		try {
+			ImmutableImage image = ImmutableImage.loader().fromStream(file.getInputStream());
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			WebpWriter writer = WebpWriter.DEFAULT;
+			writer.write(image, ImageMetadata.fromStream(file.getInputStream()), outputStream);
+			return outputStream.toByteArray();
+		} catch (Exception e) {
+			throw new EmptyFileException(e);
+		}
+
+	}
+}

--- a/api/src/main/java/org/badminton/api/aws/s3/service/ImageService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/ImageService.java
@@ -1,4 +1,3 @@
-
 package org.badminton.api.aws.s3.service;
 
 import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
@@ -6,6 +5,6 @@ import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
 public interface ImageService {
 	String uploadFile(ImageUploadRequest file);
 
-	String makeFileName(String originalFilename);
+	String makeFileName(String newFileExtension);
 }
 

--- a/api/src/main/java/org/badminton/api/aws/s3/service/MemberProfileImageService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/MemberProfileImageService.java
@@ -3,6 +3,7 @@ package org.badminton.api.aws.s3.service;
 import java.util.UUID;
 
 import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
+import org.badminton.api.common.exception.member.MemberNotExistException;
 import org.badminton.domain.domain.member.service.MemberService;
 import org.springframework.stereotype.Service;
 
@@ -27,7 +28,7 @@ public class MemberProfileImageService extends AbstractFileUploadService {
 	@Override
 	public String makeFileName(String originalFilename) {
 		if (this.currentMemberToken == null) {
-			throw new IllegalStateException("Member ID is not set. Make sure to call uploadFile method first.");
+			throw new MemberNotExistException("멤버 토큰이 없습니다. 로그인을 먼저 해주세요.");
 		}
 		return "member-profile/" + UUID.randomUUID() + ".webp";
 	}

--- a/api/src/main/java/org/badminton/api/aws/s3/service/MemberProfileImageService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/MemberProfileImageService.java
@@ -11,25 +11,24 @@ import com.amazonaws.services.s3.AmazonS3;
 @Service
 public class MemberProfileImageService extends AbstractFileUploadService {
 
-    private String currentMemberToken;
+	private String currentMemberToken;
 
-    public MemberProfileImageService(AmazonS3 s3Client, MemberService memberService) {
-        super(s3Client);
-    }
+	public MemberProfileImageService(AmazonS3 s3Client, MemberService memberService,
+		ImageConversionService imageConversionService) {
+		super(s3Client, imageConversionService);
+	}
 
-    public String uploadFile(ImageUploadRequest file, String memberToken) {
-        this.currentMemberToken = memberToken;
-        return super.uploadFile(file);
+	public String uploadFile(ImageUploadRequest file, String memberToken) {
+		this.currentMemberToken = memberToken;
+		return super.uploadFile(file);
 
-    }
+	}
 
-    @Override
-    public String makeFileName(String originalFilename) {
-        if (this.currentMemberToken == null) {
-            throw new IllegalStateException("Member ID is not set. Make sure to call uploadFile method first.");
-        }
-        String[] originFile = originalFilename.split("\\.");
-        String extension = originFile[originFile.length - 1];
-        return "member-profile/" + UUID.randomUUID() + "." + extension;
-    }
+	@Override
+	public String makeFileName(String originalFilename) {
+		if (this.currentMemberToken == null) {
+			throw new IllegalStateException("Member ID is not set. Make sure to call uploadFile method first.");
+		}
+		return "member-profile/" + UUID.randomUUID() + ".webp";
+	}
 }

--- a/api/src/main/java/org/badminton/api/common/exception/EmptyFileException.java
+++ b/api/src/main/java/org/badminton/api/common/exception/EmptyFileException.java
@@ -4,11 +4,11 @@ import org.badminton.domain.common.error.ErrorCode;
 import org.badminton.domain.common.exception.BadmintonException;
 
 public class EmptyFileException extends BadmintonException {
-    public EmptyFileException() {
-        super(ErrorCode.FILE_NOT_EXIST);
-    }
+	public EmptyFileException() {
+		super(ErrorCode.FILE_NOT_EXIST);
+	}
 
-    public EmptyFileException(Exception exception) {
-        super(ErrorCode.FILE_NOT_EXIST, exception);
-    }
+	public EmptyFileException(Exception exception) {
+		super(ErrorCode.FILE_NOT_EXIST, exception);
+	}
 }

--- a/api/src/main/java/org/badminton/api/common/exception/FileSizeOverException.java
+++ b/api/src/main/java/org/badminton/api/common/exception/FileSizeOverException.java
@@ -1,0 +1,14 @@
+package org.badminton.api.common.exception;
+
+import org.badminton.domain.common.error.ErrorCode;
+import org.badminton.domain.common.exception.BadmintonException;
+
+public class FileSizeOverException extends BadmintonException {
+	public FileSizeOverException() {
+		super(ErrorCode.FILE_SIZE_OVER);
+	}
+
+	public FileSizeOverException(Exception exception) {
+		super(ErrorCode.FILE_SIZE_OVER, exception);
+	}
+}

--- a/api/src/main/java/org/badminton/api/common/exception/FileSizeOverException.java
+++ b/api/src/main/java/org/badminton/api/common/exception/FileSizeOverException.java
@@ -4,8 +4,8 @@ import org.badminton.domain.common.error.ErrorCode;
 import org.badminton.domain.common.exception.BadmintonException;
 
 public class FileSizeOverException extends BadmintonException {
-	public FileSizeOverException() {
-		super(ErrorCode.FILE_SIZE_OVER);
+	public FileSizeOverException(long fileSize) {
+		super(ErrorCode.FILE_SIZE_OVER, "[입력한 파일 사이즈 : " + fileSize + ", 최대 파일 사이즈 : 2.5MB]");
 	}
 
 	public FileSizeOverException(Exception exception) {

--- a/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
+++ b/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
 	LIMIT_EXCEEDED(400, "파라미터 또는 리소스 속성값이 제한을 초과했습니다."),
 	OUT_OF_RANGE(400, "파라미터 또는 리소스 속성값이 범위를 벗어났습니다."),
 	FILE_NOT_EXIST(400, "파일이 존재하지 않거나 잘못된 파일입니다."),
+	FILE_SIZE_OVER(400, "파일의 크기는 2.5MB 이내야 됩니다."),
 	VALIDATION_ERROR(400, "입력값 검증에 실패했습니다"),
 
 	// 401 Errors


### PR DESCRIPTION
## PR에 대한 설명 🔍
- 이미지를 webp와 avif 로 컨버팅 로직 추가입니다. 

## 변경된 사항 📝
- 이미지 최적화를 위한 작업 중 하나입니다. 
- 현재는 비동기 처리하지 않아 약간의 시간이 걸립니다 + 200m/s

webp와 avif 를 사용하는 이유는 다음과 같습니다. 
  -  이미지 압축률 향상으로 이미지 로드 시간 단축
  -  제가 확인하였을 때 이미지 크기는 이미지 타입에 따라 대략 25% ~ 많게는 75% 압축되는 것을 확인했습니다.
     (2.5MB --> 500kb) 

  -   S3 버킷 공간 절약 

### Before
- 모든 이미지가 해당되는 이미지 파일로 올라갑니다.

### After
- 모든 이미지를 webp와 avif 로 올라갑니다. 


