### PR TITLE
refactor: 경기 취소 시 현재 시각이 경기 시작 시간 이후라면 예외 발생

### DIFF
--- a/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
+++ b/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
@@ -83,6 +83,7 @@ public enum ErrorCode {
 	LEAGUE_OWNER_CANNOT_CANCEL_LEAGUE_PARTICIPATION(412, "경기를 생성한 사람은 경기 참여를 취소할 수 없습니다."),
 	INVALID_LEAGUE_STATUS_TO_CANCEL_LEAGUE_PARTICIPATION(412, "경기 중이거나, 취소되거나, 종료된 경기에 대해 경기 참여를 취소할 수 없습니다."),
 	INVALID_TIME_TO_CANCEL_LEAGUE_PARTICIPATION(412, "모집 마감 시간이 지나면 경기 참여를 취소할 수 없습니다."),
+	INVALID_TIME_TO_CANCEL_LEAGUE(412, "경기 시작 시간이 지난 경기는 취소할 수 없습니다."),
 	LEAGUE_PARTICIPANT_POWER_OF_TWO(412, "토너먼트 경기에서는 경기 참여 인원이 2의 제곱이어야 합니다"),
 	LEAGUE_PARTICIPANTS_NOT_EXISTS(412, "해당 매치의 참여자가 아직 정해지지 않았습니다"),
 	SET_FINISHED(412, "Set 의 상태가 FINISHED 입니다"),

--- a/domain/src/main/java/org/badminton/domain/common/exception/league/LeagueCannotBeCanceled.java
+++ b/domain/src/main/java/org/badminton/domain/common/exception/league/LeagueCannotBeCanceled.java
@@ -1,0 +1,17 @@
+package org.badminton.domain.common.exception.league;
+
+import java.time.LocalDateTime;
+
+import org.badminton.domain.common.error.ErrorCode;
+import org.badminton.domain.common.exception.BadmintonException;
+
+public class LeagueCannotBeCanceled extends BadmintonException {
+
+	public LeagueCannotBeCanceled(Long leagueId, LocalDateTime leagueAt) {
+		super(ErrorCode.INVALID_TIME_TO_CANCEL_LEAGUE, "[경기 아이디 : " + leagueId + " 경기 시간 : " + leagueAt + "]");
+	}
+
+	public LeagueCannotBeCanceled(Long leagueId, LocalDateTime leagueAt, Exception e) {
+		super(ErrorCode.INVALID_TIME_TO_CANCEL_LEAGUE, "[경기 아이디 : " + leagueId + " 경기 시간 : " + leagueAt + "]", e);
+	}
+}

--- a/domain/src/main/java/org/badminton/domain/common/exception/league/LeagueParticipationCannotBeCanceledException.java
+++ b/domain/src/main/java/org/badminton/domain/common/exception/league/LeagueParticipationCannotBeCanceledException.java
@@ -6,18 +6,18 @@ import org.badminton.domain.common.error.ErrorCode;
 import org.badminton.domain.common.exception.BadmintonException;
 import org.badminton.domain.domain.league.enums.LeagueStatus;
 
-public class LeagueCannotBeCanceledException extends BadmintonException {
-	public LeagueCannotBeCanceledException(Long leagueId, LeagueStatus leagueStatus) {
+public class LeagueParticipationCannotBeCanceledException extends BadmintonException {
+	public LeagueParticipationCannotBeCanceledException(Long leagueId, LeagueStatus leagueStatus) {
 		super(ErrorCode.INVALID_LEAGUE_STATUS_TO_CANCEL_LEAGUE_PARTICIPATION,
 			"[경기 일정 아이디 : " + leagueId + " 경기 상태 : " + leagueStatus.getDescription() + "]");
 	}
 
-	public LeagueCannotBeCanceledException(Long leagueId, LocalDateTime recruitingClosedAt) {
+	public LeagueParticipationCannotBeCanceledException(Long leagueId, LocalDateTime recruitingClosedAt) {
 		super(ErrorCode.INVALID_TIME_TO_CANCEL_LEAGUE_PARTICIPATION,
 			"[경기 일정 아이디 : " + leagueId + " 경기 모집 마감 날짜 : " + recruitingClosedAt + "]");
 	}
 
-	public LeagueCannotBeCanceledException(Long leagueId, LeagueStatus leagueStatus, Exception e) {
+	public LeagueParticipationCannotBeCanceledException(Long leagueId, LeagueStatus leagueStatus, Exception e) {
 		super(ErrorCode.INVALID_LEAGUE_STATUS_TO_CANCEL_LEAGUE_PARTICIPATION,
 			"[경기 일정 아이디 : " + leagueId + " 경기 상태 : " + leagueStatus.getDescription() + "]", e);
 	}

--- a/domain/src/main/java/org/badminton/domain/domain/league/LeagueParticipantServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/league/LeagueParticipantServiceImpl.java
@@ -3,8 +3,8 @@ package org.badminton.domain.domain.league;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-import org.badminton.domain.common.exception.league.LeagueCannotBeCanceledException;
 import org.badminton.domain.common.exception.league.LeagueOwnerCannotCancelLeagueParticipationException;
+import org.badminton.domain.common.exception.league.LeagueParticipationCannotBeCanceledException;
 import org.badminton.domain.common.exception.league.LeagueParticipationDuplicateException;
 import org.badminton.domain.common.exception.league.ParticipationLimitReachedException;
 import org.badminton.domain.domain.clubmember.ClubMemberReader;
@@ -52,11 +52,11 @@ public class LeagueParticipantServiceImpl implements LeagueParticipantService {
 			throw new LeagueOwnerCannotCancelLeagueParticipationException(memberToken, leagueId);
 		}
 		if (LocalDateTime.now().isAfter(league.getRecruitingClosedAt())) {
-			throw new LeagueCannotBeCanceledException(leagueId, league.getRecruitingClosedAt());
+			throw new LeagueParticipationCannotBeCanceledException(leagueId, league.getRecruitingClosedAt());
 		}
 		if (league.getLeagueStatus() == LeagueStatus.PLAYING || league.getLeagueStatus() == LeagueStatus.CANCELED
 			|| league.getLeagueStatus() == LeagueStatus.FINISHED) {
-			throw new LeagueCannotBeCanceledException(leagueId, league.getLeagueStatus());
+			throw new LeagueParticipationCannotBeCanceledException(leagueId, league.getLeagueStatus());
 		}
 		ClubMember clubMember = clubMemberReader.getClubMemberByMemberTokenAndClubToken(clubToken, memberToken);
 		LeagueParticipant leagueParticipant = leagueParticipantReader.findParticipant(leagueId,

--- a/domain/src/main/java/org/badminton/domain/domain/league/LeagueServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/league/LeagueServiceImpl.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.badminton.domain.common.exception.league.LeagueCannotBeCanceled;
 import org.badminton.domain.common.exception.league.LeagueCannotBeUpdated;
 import org.badminton.domain.common.exception.league.NotLeagueOwnerException;
 import org.badminton.domain.common.exception.league.OngoingAndUpcomingLeagueCanNotBePastException;
@@ -141,6 +142,9 @@ public class LeagueServiceImpl implements LeagueService {
 		var league = leagueReader.readLeague(clubToken, leagueId);
 		if (!league.getLeagueOwnerMemberToken().equals(memberToken)) {
 			throw new NotLeagueOwnerException(memberToken);
+		}
+		if (LocalDateTime.now().isAfter(league.getLeagueAt())) {
+			throw new LeagueCannotBeCanceled(leagueId, league.getLeagueAt());
 		}
 		league.cancelLeague();
 		leagueStore.store(league);


### PR DESCRIPTION
## PR에 대한 설명 🔍

경기를 취소할 때 현재 시간이 LeagueAt 이후라면 예외를 발생합니다. 

## 변경된 사항 📝


### After

```java
@Override
	public LeagueCancelInfo cancelLeague(String clubToken, Long leagueId, String memberToken) {
		var league = leagueReader.readLeague(clubToken, leagueId);
		if (!league.getLeagueOwnerMemberToken().equals(memberToken)) {
			throw new NotLeagueOwnerException(memberToken);
		}
		if (LocalDateTime.now().isAfter(league.getLeagueAt())) {
			throw new LeagueCannotBeCanceled(leagueId, league.getLeagueAt());
		}
		league.cancelLeague();
		leagueStore.store(league);
		return LeagueCancelInfo.from(league);
	}
```


## PR에서 중점적으로 확인되어야 하는 사항

경기를 취소하는 조건을 확인해주세요