### PR TITLE
refactor: Match 시작 시 League 상태를 PLAYING 으로 변경하는 로직을 추가

### DIFF
--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/FreeDoublesMatchStrategy.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/FreeDoublesMatchStrategy.java
@@ -3,13 +3,14 @@ package org.badminton.infrastructure.match.strategy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
+
 import org.badminton.domain.common.enums.MatchResult;
 import org.badminton.domain.common.enums.SetStatus;
 import org.badminton.domain.common.exception.match.AlreadyWinnerDeterminedException;
 import org.badminton.domain.common.exception.match.MatchDuplicateException;
 import org.badminton.domain.common.exception.match.SetFinishedException;
 import org.badminton.domain.domain.league.LeagueReader;
+import org.badminton.domain.domain.league.LeagueStore;
 import org.badminton.domain.domain.league.entity.League;
 import org.badminton.domain.domain.league.entity.LeagueParticipant;
 import org.badminton.domain.domain.league.vo.Team;
@@ -23,131 +24,137 @@ import org.badminton.domain.domain.match.service.AbstractDoublesMatchStrategy;
 import org.badminton.domain.domain.match.store.DoublesMatchReader;
 import org.springframework.stereotype.Component;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @Component
 public class FreeDoublesMatchStrategy extends AbstractDoublesMatchStrategy {
-    static final Integer LIMIT_SET_GAME = 3;
+	static final Integer LIMIT_SET_GAME = 3;
 
-    private final DoublesMatchReader doublesMatchReader;
-    private final DoublesMatchStore doublesMatchStore;
-    private final LeagueReader leagueReader;
+	private final DoublesMatchReader doublesMatchReader;
+	private final DoublesMatchStore doublesMatchStore;
+	private final LeagueReader leagueReader;
+	private final LeagueStore leagueStore;
 
-    public FreeDoublesMatchStrategy(DoublesMatchReader doublesMatchReader, DoublesMatchStore doublesMatchStore,
-                                    LeagueReader leagueReader) {
-        super(doublesMatchReader);
-        this.doublesMatchReader = doublesMatchReader;
-        this.doublesMatchStore = doublesMatchStore;
-        this.leagueReader = leagueReader;
-    }
+	public FreeDoublesMatchStrategy(DoublesMatchReader doublesMatchReader, DoublesMatchStore doublesMatchStore,
+		LeagueReader leagueReader, LeagueStore leagueStore) {
+		super(doublesMatchReader);
+		this.doublesMatchReader = doublesMatchReader;
+		this.doublesMatchStore = doublesMatchStore;
+		this.leagueReader = leagueReader;
+		this.leagueStore = leagueStore;
+	}
 
-    private static boolean isMatchWinnerDetermined(DoublesMatch doublesMatch) {
-        return doublesMatch.getTeam1MatchResult() == MatchResult.WIN
-                || doublesMatch.getTeam2MatchResult() == MatchResult.WIN;
-    }
+	private static boolean isMatchWinnerDetermined(DoublesMatch doublesMatch) {
+		return doublesMatch.getTeam1MatchResult() == MatchResult.WIN
+			|| doublesMatch.getTeam2MatchResult() == MatchResult.WIN;
+	}
 
-    @Override
-    public BracketInfo makeBracket(League league,
-                                   List<LeagueParticipant> leagueParticipantList) {
-        Collections.shuffle(leagueParticipantList);
-        List<DoublesMatch> doublesMatches = makeDoublesMatches(leagueParticipantList, league, 1);
-        doublesMatches.forEach(this::makeDoublesSetsInMatch);
-        return BracketInfo.fromDoubles(1, doublesMatches);
-    }
+	@Override
+	public BracketInfo makeBracket(League league,
+		List<LeagueParticipant> leagueParticipantList) {
+		Collections.shuffle(leagueParticipantList);
+		List<DoublesMatch> doublesMatches = makeDoublesMatches(leagueParticipantList, league, 1);
+		doublesMatches.forEach(this::makeDoublesSetsInMatch);
+		return BracketInfo.fromDoubles(1, doublesMatches);
+	}
 
-    @Override
-    public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
-                                                MatchCommand.UpdateSetScore updateSetScoreCommand) {
-        DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
+	@Override
+	public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
+		MatchCommand.UpdateSetScore updateSetScoreCommand) {
+		DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
 
-        if (isMatchWinnerDetermined(doublesMatch)) {
-            throw new AlreadyWinnerDeterminedException(doublesMatch.getId());
-        }
+		if (isMatchWinnerDetermined(doublesMatch)) {
+			throw new AlreadyWinnerDeterminedException(doublesMatch.getId());
+		}
 
-        if (doublesMatch.getDoublesSet(setNumber).getSetStatus() == SetStatus.FINISHED) {
-            throw new SetFinishedException(setNumber);
-        }
+		if (doublesMatch.getDoublesSet(setNumber).getSetStatus() == SetStatus.FINISHED) {
+			throw new SetFinishedException(setNumber);
+		}
 
-        doublesMatch.getDoublesSet(setNumber)
-                .endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
+		doublesMatch.getDoublesSet(setNumber)
+			.endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
 
-        if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
-            doublesMatch.team1WinSet();
-        } else {
-            doublesMatch.team2WinSet();
-        }
+		if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
+			doublesMatch.team1WinSet();
+		} else {
+			doublesMatch.team2WinSet();
+		}
 
-        if (LIMIT_SET_GAME > setNumber) {
-            changeNextSetStatus(doublesMatch, setNumber);
-        }
+		if (LIMIT_SET_GAME > setNumber) {
+			changeNextSetStatus(doublesMatch, setNumber);
+		}
 
-        if (isAllMatchFinished(doublesMatch)) {
-            leagueReader.readLeagueById(doublesMatch.getLeague().getLeagueId()).finishLeague();
-        }
+		if (isAllMatchFinished(doublesMatch)) {
+			leagueReader.readLeagueById(doublesMatch.getLeague().getLeagueId()).finishLeague();
+		}
 
-        doublesMatchStore.store(doublesMatch);
-        return SetInfo.fromDoublesSet(matchId, setNumber, doublesMatch.getDoublesSets().get(setNumber - 1));
-    }
+		doublesMatchStore.store(doublesMatch);
+		return SetInfo.fromDoublesSet(matchId, setNumber, doublesMatch.getDoublesSets().get(setNumber - 1));
+	}
 
-    private void changeNextSetStatus(DoublesMatch doublesMatch, Integer setNumber) {
-        setNumber++;
-        if (doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
-            doublesMatch.getDoublesSet(setNumber).open();
-        }
-        if (!doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
-            doublesMatch.getDoublesSet(setNumber).close();
-        }
-    }
+	private void changeNextSetStatus(DoublesMatch doublesMatch, Integer setNumber) {
+		setNumber++;
+		if (doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
+			doublesMatch.getDoublesSet(setNumber).open();
+		}
+		if (!doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
+			doublesMatch.getDoublesSet(setNumber).close();
+		}
+	}
 
-    private boolean isAllMatchFinished(DoublesMatch doublesMatch) {
-        return doublesMatchReader.allMatchesFinishedForLeague(
-                doublesMatch.getLeague().getLeagueId());
-    }
+	private boolean isAllMatchFinished(DoublesMatch doublesMatch) {
+		return doublesMatchReader.allMatchesFinishedForLeague(
+			doublesMatch.getLeague().getLeagueId());
+	}
 
-    @Override
-    public SetInfo.Main retrieveSet(Long matchId, int setNumber) {
-        DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
-        DoublesSet doublesSet = doublesMatch.getDoublesSet(setNumber);
-        return SetInfo.fromDoublesSet(matchId, setNumber, doublesSet);
-    }
+	@Override
+	public SetInfo.Main retrieveSet(Long matchId, int setNumber) {
+		DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
+		DoublesSet doublesSet = doublesMatch.getDoublesSet(setNumber);
+		return SetInfo.fromDoublesSet(matchId, setNumber, doublesSet);
+	}
 
-    @Override
-    public void checkDuplicateInitialBracket(Long leagueId) {
-        boolean isBracketEmpty = doublesMatchReader.checkIfBracketEmpty(leagueId);
+	@Override
+	public void checkDuplicateInitialBracket(Long leagueId) {
+		boolean isBracketEmpty = doublesMatchReader.checkIfBracketEmpty(leagueId);
 
-        if (!isBracketEmpty && doublesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
-            doublesMatchStore.deleteDoublesBracket(leagueId);
-        } else if (!isBracketEmpty && !doublesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
-            throw new MatchDuplicateException(leagueId);
-        }
-    }
+		if (!isBracketEmpty && doublesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
+			doublesMatchStore.deleteDoublesBracket(leagueId);
+		} else if (!isBracketEmpty && !doublesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
+			throw new MatchDuplicateException(leagueId);
+		}
+	}
 
-    private void makeDoublesSetsInMatch(DoublesMatch doublesMatch) {
-        for (int i = 1; i <= 3; i++) {
-            doublesMatch.addSet(new DoublesSet(doublesMatch, i));
-        }
-        doublesMatchStore.store(doublesMatch);
-    }
+	private void makeDoublesSetsInMatch(DoublesMatch doublesMatch) {
+		for (int i = 1; i <= 3; i++) {
+			doublesMatch.addSet(new DoublesSet(doublesMatch, i));
+		}
+		doublesMatchStore.store(doublesMatch);
+	}
 
-    private List<DoublesMatch> makeDoublesMatches(List<LeagueParticipant> leagueParticipantList,
-                                                  League league, int roundNumber) {
+	private List<DoublesMatch> makeDoublesMatches(List<LeagueParticipant> leagueParticipantList,
+		League league, int roundNumber) {
 
-        List<DoublesMatch> doublesMatches = new ArrayList<>();
-        for (int i = 0; i < leagueParticipantList.size() - 3; i += 4) {
-            Team team1 = new Team(leagueParticipantList.get(i), leagueParticipantList.get(i + 1));
-            Team team2 = new Team(leagueParticipantList.get(i + 2), leagueParticipantList.get(i + 3));
-            DoublesMatch doublesMatch = new DoublesMatch(league, team1, team2, roundNumber);
-            doublesMatches.add(doublesMatch);
-            doublesMatchStore.store(doublesMatch);
-        }
-        return doublesMatches;
-    }
+		List<DoublesMatch> doublesMatches = new ArrayList<>();
+		for (int i = 0; i < leagueParticipantList.size() - 3; i += 4) {
+			Team team1 = new Team(leagueParticipantList.get(i), leagueParticipantList.get(i + 1));
+			Team team2 = new Team(leagueParticipantList.get(i + 2), leagueParticipantList.get(i + 3));
+			DoublesMatch doublesMatch = new DoublesMatch(league, team1, team2, roundNumber);
+			doublesMatches.add(doublesMatch);
+			doublesMatchStore.store(doublesMatch);
+		}
+		return doublesMatches;
+	}
 
-    @Override
-    public void startMatch(Long matchId) {
-        DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
-        doublesMatch.startMatch();
-        doublesMatch.getDoublesSet(1).startSet();
-        doublesMatchStore.store(doublesMatch);
-    }
-
+	@Override
+	public void startMatch(Long matchId) {
+		DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
+		League league = doublesMatch.getLeague();
+		league.startLeague();
+		leagueStore.store(league);
+		doublesMatch.startMatch();
+		doublesMatch.getDoublesSet(1).startSet();
+		doublesMatchStore.store(doublesMatch);
+	}
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/FreeSinglesMatchStrategy.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/FreeSinglesMatchStrategy.java
@@ -3,7 +3,7 @@ package org.badminton.infrastructure.match.strategy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
+
 import org.badminton.domain.common.enums.MatchResult;
 import org.badminton.domain.common.enums.MatchStatus;
 import org.badminton.domain.common.enums.SetStatus;
@@ -11,6 +11,7 @@ import org.badminton.domain.common.exception.match.AlreadyWinnerDeterminedExcept
 import org.badminton.domain.common.exception.match.MatchDuplicateException;
 import org.badminton.domain.common.exception.match.SetFinishedException;
 import org.badminton.domain.domain.league.LeagueReader;
+import org.badminton.domain.domain.league.LeagueStore;
 import org.badminton.domain.domain.league.entity.League;
 import org.badminton.domain.domain.league.entity.LeagueParticipant;
 import org.badminton.domain.domain.match.command.MatchCommand;
@@ -24,134 +25,139 @@ import org.badminton.domain.domain.match.service.AbstractSinglesMatchStrategy;
 import org.badminton.domain.domain.match.store.SinglesMatchReader;
 import org.springframework.stereotype.Component;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @Component
 public class FreeSinglesMatchStrategy extends AbstractSinglesMatchStrategy {
-    static final Integer LIMIT_SET_GAME = 3;
+	static final Integer LIMIT_SET_GAME = 3;
 
-    private final SinglesMatchReader singlesMatchReader;
-    private final SinglesMatchStore singlesMatchStore;
-    private final LeagueReader leagueReader;
+	private final SinglesMatchReader singlesMatchReader;
+	private final SinglesMatchStore singlesMatchStore;
+	private final LeagueReader leagueReader;
+	private final LeagueStore leagueStore;
 
-    public FreeSinglesMatchStrategy(SinglesMatchReader singlesMatchReader, SinglesMatchStore singlesMatchStore,
-                                    LeagueReader leagueReader) {
-        super(singlesMatchReader);
-        this.singlesMatchReader = singlesMatchReader;
-        this.singlesMatchStore = singlesMatchStore;
-        this.leagueReader = leagueReader;
-    }
+	public FreeSinglesMatchStrategy(SinglesMatchReader singlesMatchReader, SinglesMatchStore singlesMatchStore,
+		LeagueReader leagueReader, LeagueStore leagueStore) {
+		super(singlesMatchReader);
+		this.singlesMatchReader = singlesMatchReader;
+		this.singlesMatchStore = singlesMatchStore;
+		this.leagueReader = leagueReader;
+		this.leagueStore = leagueStore;
+	}
 
-    private static boolean isMatchWinnerDetermined(SinglesMatch singlesMatch) {
-        return singlesMatch.getPlayer1MatchResult() == MatchResult.WIN
-                || singlesMatch.getPlayer2MatchResult() == MatchResult.WIN;
-    }
+	private static boolean isMatchWinnerDetermined(SinglesMatch singlesMatch) {
+		return singlesMatch.getPlayer1MatchResult() == MatchResult.WIN
+			|| singlesMatch.getPlayer2MatchResult() == MatchResult.WIN;
+	}
 
-    private static boolean isMatchFinished(SinglesMatch singlesMatch) {
-        return singlesMatch.getMatchStatus() == MatchStatus.FINISHED;
-    }
+	private static boolean isMatchFinished(SinglesMatch singlesMatch) {
+		return singlesMatch.getMatchStatus() == MatchStatus.FINISHED;
+	}
 
-    @Override
-    public BracketInfo makeBracket(League league,
-                                   List<LeagueParticipant> leagueParticipantList) {
-        Collections.shuffle(leagueParticipantList);
-        List<SinglesMatch> singlesMatches = makeSinglesMatches(leagueParticipantList, league, 1);
-        singlesMatches.forEach(this::makeSetsInMatch);
-        return BracketInfo.fromSingles(1, singlesMatches);
-    }
+	@Override
+	public BracketInfo makeBracket(League league,
+		List<LeagueParticipant> leagueParticipantList) {
+		Collections.shuffle(leagueParticipantList);
+		List<SinglesMatch> singlesMatches = makeSinglesMatches(leagueParticipantList, league, 1);
+		singlesMatches.forEach(this::makeSetsInMatch);
+		return BracketInfo.fromSingles(1, singlesMatches);
+	}
 
-    @Override
-    public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
-                                                MatchCommand.UpdateSetScore updateSetScoreCommand) {
-        SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
+	@Override
+	public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
+		MatchCommand.UpdateSetScore updateSetScoreCommand) {
+		SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
 
-        if (isMatchWinnerDetermined(singlesMatch)) {
-            throw new AlreadyWinnerDeterminedException(singlesMatch.getId());
-        }
+		if (isMatchWinnerDetermined(singlesMatch)) {
+			throw new AlreadyWinnerDeterminedException(singlesMatch.getId());
+		}
 
-        if (singlesMatch.getSinglesSet(setNumber).getSetStatus() == SetStatus.FINISHED) {
-            throw new SetFinishedException(setNumber);
-        }
+		if (singlesMatch.getSinglesSet(setNumber).getSetStatus() == SetStatus.FINISHED) {
+			throw new SetFinishedException(setNumber);
+		}
 
-        singlesMatch.getSinglesSet(setNumber)
-                .endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
+		singlesMatch.getSinglesSet(setNumber)
+			.endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
 
-        if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
-            singlesMatch.player1WinSet();
-        } else {
-            singlesMatch.player2WinSet();
-        }
+		if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
+			singlesMatch.player1WinSet();
+		} else {
+			singlesMatch.player2WinSet();
+		}
 
-        if (LIMIT_SET_GAME > setNumber) {
-            changeNextSetStatus(singlesMatch, setNumber);
-        }
+		if (LIMIT_SET_GAME > setNumber) {
+			changeNextSetStatus(singlesMatch, setNumber);
+		}
 
 		if (isAllMatchFinished(singlesMatch)) {
 			leagueReader.readLeagueById(singlesMatch.getLeague().getLeagueId()).finishLeague();
 		}
 
-        singlesMatchStore.store(singlesMatch);
-        return SetInfo.fromSinglesSet(matchId, setNumber, singlesMatch.getSinglesSets().get(setNumber - 1));
-    }
+		singlesMatchStore.store(singlesMatch);
+		return SetInfo.fromSinglesSet(matchId, setNumber, singlesMatch.getSinglesSets().get(setNumber - 1));
+	}
 
-    private void changeNextSetStatus(SinglesMatch singlesMatch, Integer setNumber) {
-        setNumber++;
+	private void changeNextSetStatus(SinglesMatch singlesMatch, Integer setNumber) {
+		setNumber++;
 		if (singlesMatch.getPlayer1MatchResult().equals(MatchResult.NONE)) {
 			singlesMatch.getSinglesSet(setNumber).open();
 		}
 		if (!singlesMatch.getPlayer1MatchResult().equals(MatchResult.NONE)) {
 			singlesMatch.getSinglesSet(setNumber).close();
 		}
-    }
+	}
 
-    private boolean isAllMatchFinished(SinglesMatch singlesMatch) {
-        return singlesMatchReader.allMatchesFinishedForLeague(
-                singlesMatch.getLeague().getLeagueId());
-    }
+	private boolean isAllMatchFinished(SinglesMatch singlesMatch) {
+		return singlesMatchReader.allMatchesFinishedForLeague(
+			singlesMatch.getLeague().getLeagueId());
+	}
 
-    @Override
-    public Main retrieveSet(Long matchId, int setNumber) {
-        SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
-        SinglesSet singlesSet = singlesMatch.getSinglesSet(1);
-        return SetInfo.fromSinglesSet(matchId, setNumber, singlesSet);
-    }
+	@Override
+	public Main retrieveSet(Long matchId, int setNumber) {
+		SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
+		SinglesSet singlesSet = singlesMatch.getSinglesSet(1);
+		return SetInfo.fromSinglesSet(matchId, setNumber, singlesSet);
+	}
 
-    @Override
-    public void checkDuplicateInitialBracket(Long leagueId) {
-        boolean isBracketEmpty = singlesMatchReader.checkIfBracketEmpty(leagueId);
+	@Override
+	public void checkDuplicateInitialBracket(Long leagueId) {
+		boolean isBracketEmpty = singlesMatchReader.checkIfBracketEmpty(leagueId);
 
-        if (!isBracketEmpty && singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
-            singlesMatchStore.deleteSinglesBracket(leagueId);
-        } else if (!isBracketEmpty && !singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
-            throw new MatchDuplicateException(leagueId);
-        }
-    }
+		if (!isBracketEmpty && singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
+			singlesMatchStore.deleteSinglesBracket(leagueId);
+		} else if (!isBracketEmpty && !singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
+			throw new MatchDuplicateException(leagueId);
+		}
+	}
 
-    private void makeSetsInMatch(SinglesMatch singlesMatch) {
-        for (int i = 1; i <= 3; i++) {
-            singlesMatch.addSet(new SinglesSet(singlesMatch, i));
-        }
-        singlesMatchStore.store(singlesMatch);
-    }
+	private void makeSetsInMatch(SinglesMatch singlesMatch) {
+		for (int i = 1; i <= 3; i++) {
+			singlesMatch.addSet(new SinglesSet(singlesMatch, i));
+		}
+		singlesMatchStore.store(singlesMatch);
+	}
 
-    private List<SinglesMatch> makeSinglesMatches(List<LeagueParticipant> leagueParticipantList,
-                                                  League league, int roundNumber) {
+	private List<SinglesMatch> makeSinglesMatches(List<LeagueParticipant> leagueParticipantList,
+		League league, int roundNumber) {
 
-        List<SinglesMatch> singlesMatches = new ArrayList<>();
-        for (int i = 0; i < leagueParticipantList.size() - 1; i += 2) {
-            SinglesMatch singlesMatch = new SinglesMatch(league, leagueParticipantList.get(i),
-                    leagueParticipantList.get(i + 1), roundNumber);
-            singlesMatches.add(singlesMatch);
-            singlesMatchStore.store(singlesMatch);
-        }
-        return singlesMatches;
-    }
+		List<SinglesMatch> singlesMatches = new ArrayList<>();
+		for (int i = 0; i < leagueParticipantList.size() - 1; i += 2) {
+			SinglesMatch singlesMatch = new SinglesMatch(league, leagueParticipantList.get(i),
+				leagueParticipantList.get(i + 1), roundNumber);
+			singlesMatches.add(singlesMatch);
+			singlesMatchStore.store(singlesMatch);
+		}
+		return singlesMatches;
+	}
 
-    public void startMatch(Long matchId) {
-        SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
-        singlesMatch.startMatch();
-        singlesMatch.getSinglesSet(1).initMatch();
-        singlesMatchStore.store(singlesMatch);
-    }
-
+	public void startMatch(Long matchId) {
+		SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
+		League league = singlesMatch.getLeague();
+		league.startLeague();
+		leagueStore.store(league);
+		singlesMatch.startMatch();
+		singlesMatch.getSinglesSet(1).initMatch();
+		singlesMatchStore.store(singlesMatch);
+	}
 }
-

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/TournamentDoublesMatchStrategy.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/TournamentDoublesMatchStrategy.java
@@ -3,7 +3,7 @@ package org.badminton.infrastructure.match.strategy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
+
 import org.badminton.domain.common.enums.MatchResult;
 import org.badminton.domain.common.enums.SetStatus;
 import org.badminton.domain.common.exception.match.AlreadyWinnerDeterminedException;
@@ -12,6 +12,7 @@ import org.badminton.domain.common.exception.match.MatchDuplicateException;
 import org.badminton.domain.common.exception.match.SetFinishedException;
 import org.badminton.domain.domain.league.LeagueParticipantReader;
 import org.badminton.domain.domain.league.LeagueReader;
+import org.badminton.domain.domain.league.LeagueStore;
 import org.badminton.domain.domain.league.entity.League;
 import org.badminton.domain.domain.league.entity.LeagueParticipant;
 import org.badminton.domain.domain.league.vo.Team;
@@ -27,224 +28,230 @@ import org.badminton.domain.domain.match.store.DoublesMatchReader;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @Component
 public class TournamentDoublesMatchStrategy extends AbstractDoublesMatchStrategy {
 
-    public static final int SET_COUNT = 3;
-    public static final int PARTICIPANTS_PER_TEAM = 2;
-    public static final int TEAMS_PER_MATCH = 2;
-    static final Integer LIMIT_SET_GAME = 3;
-    private final DoublesMatchReader doublesMatchReader;
-    private final DoublesMatchStore doublesMatchStore;
-    private final LeagueParticipantReader leagueParticipantReader;
-    private final LeagueReader leagueReader;
+	public static final int SET_COUNT = 3;
+	public static final int PARTICIPANTS_PER_TEAM = 2;
+	public static final int TEAMS_PER_MATCH = 2;
+	static final Integer LIMIT_SET_GAME = 3;
+	private final DoublesMatchReader doublesMatchReader;
+	private final DoublesMatchStore doublesMatchStore;
+	private final LeagueParticipantReader leagueParticipantReader;
+	private final LeagueReader leagueReader;
+	private final LeagueStore leagueStore;
 
-    public TournamentDoublesMatchStrategy(DoublesMatchReader doublesMatchReader, DoublesMatchStore doublesMatchStore,
-                                          LeagueParticipantReader leagueParticipantReader, LeagueReader leagueReader) {
-        super(doublesMatchReader);
-        this.doublesMatchReader = doublesMatchReader;
-        this.doublesMatchStore = doublesMatchStore;
-        this.leagueParticipantReader = leagueParticipantReader;
-        this.leagueReader = leagueReader;
-    }
+	public TournamentDoublesMatchStrategy(DoublesMatchReader doublesMatchReader, DoublesMatchStore doublesMatchStore,
+		LeagueParticipantReader leagueParticipantReader, LeagueReader leagueReader, LeagueStore leagueStore) {
+		super(doublesMatchReader);
+		this.doublesMatchReader = doublesMatchReader;
+		this.doublesMatchStore = doublesMatchStore;
+		this.leagueParticipantReader = leagueParticipantReader;
+		this.leagueReader = leagueReader;
+		this.leagueStore = leagueStore;
+	}
 
-    private static boolean isMatchWinnerDetermined(DoublesMatch doublesMatch) {
-        return doublesMatch.getTeam1MatchResult() == MatchResult.WIN
-                || doublesMatch.getTeam2MatchResult() == MatchResult.WIN;
-    }
+	private static boolean isMatchWinnerDetermined(DoublesMatch doublesMatch) {
+		return doublesMatch.getTeam1MatchResult() == MatchResult.WIN
+			|| doublesMatch.getTeam2MatchResult() == MatchResult.WIN;
+	}
 
-    @Override
-    public BracketInfo makeBracket(League league, List<LeagueParticipant> leagueParticipantList) {
-        List<DoublesMatch> allMatches = new ArrayList<>();
-        List<LeagueParticipant> currentParticipants = new ArrayList<>(leagueParticipantList);
-        Collections.shuffle(currentParticipants);
+	@Override
+	public BracketInfo makeBracket(League league, List<LeagueParticipant> leagueParticipantList) {
+		List<DoublesMatch> allMatches = new ArrayList<>();
+		List<LeagueParticipant> currentParticipants = new ArrayList<>(leagueParticipantList);
+		Collections.shuffle(currentParticipants);
 
-        int totalRounds = MatchUtils.calculateTotalRounds(currentParticipants.size() / PARTICIPANTS_PER_TEAM);
-        league.defineTotalRounds(totalRounds);
+		int totalRounds = MatchUtils.calculateTotalRounds(currentParticipants.size() / PARTICIPANTS_PER_TEAM);
+		league.defineTotalRounds(totalRounds);
 
-        allMatches.addAll(createFirstRoundMatches(league, currentParticipants));
-        allMatches.addAll(createSubsequentRoundsMatches(league, totalRounds));
+		allMatches.addAll(createFirstRoundMatches(league, currentParticipants));
+		allMatches.addAll(createSubsequentRoundsMatches(league, totalRounds));
 
-        return BracketInfo.fromDoubles(totalRounds, allMatches);
-    }
+		return BracketInfo.fromDoubles(totalRounds, allMatches);
+	}
 
-    @Override
-    public void checkDuplicateInitialBracket(Long leagueId) {
-        boolean isBracketEmpty = doublesMatchReader.checkIfBracketEmpty(leagueId);
+	@Override
+	public void checkDuplicateInitialBracket(Long leagueId) {
+		boolean isBracketEmpty = doublesMatchReader.checkIfBracketEmpty(leagueId);
 
-        if (!isBracketEmpty && doublesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
-            doublesMatchStore.deleteDoublesBracket(leagueId);
-        } else if (!isBracketEmpty && !doublesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
-            throw new MatchDuplicateException(leagueId);
-        }
-    }
+		if (!isBracketEmpty && doublesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
+			doublesMatchStore.deleteDoublesBracket(leagueId);
+		} else if (!isBracketEmpty && !doublesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
+			throw new MatchDuplicateException(leagueId);
+		}
+	}
 
-    @Override
-    @Transactional
-    public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
-                                                MatchCommand.UpdateSetScore updateSetScoreCommand) {
-        DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
+	@Override
+	@Transactional
+	public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
+		MatchCommand.UpdateSetScore updateSetScoreCommand) {
+		DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
 
-        if (isMatchWinnerDetermined(doublesMatch)) {
-            throw new AlreadyWinnerDeterminedException(doublesMatch.getId());
-        }
+		if (isMatchWinnerDetermined(doublesMatch)) {
+			throw new AlreadyWinnerDeterminedException(doublesMatch.getId());
+		}
 
-        if (doublesMatch.getDoublesSet(setNumber).getSetStatus() == SetStatus.FINISHED) {
-            throw new SetFinishedException(setNumber);
-        }
+		if (doublesMatch.getDoublesSet(setNumber).getSetStatus() == SetStatus.FINISHED) {
+			throw new SetFinishedException(setNumber);
+		}
 
-        if (doublesMatch.getTeam1() == null || doublesMatch.getTeam2() == null) {
-            throw new LeagueParticipantsNotExistsException(matchId);
-        }
+		if (doublesMatch.getTeam1() == null || doublesMatch.getTeam2() == null) {
+			throw new LeagueParticipantsNotExistsException(matchId);
+		}
 
-        updateSetScore(doublesMatch, setNumber, updateSetScoreCommand);
-        doublesMatchStore.store(doublesMatch);
+		updateSetScore(doublesMatch, setNumber, updateSetScoreCommand);
+		doublesMatchStore.store(doublesMatch);
 
-        if (LIMIT_SET_GAME > setNumber) {
-            changeNextSetStatus(doublesMatch, setNumber);
-        }
+		if (LIMIT_SET_GAME > setNumber) {
+			changeNextSetStatus(doublesMatch, setNumber);
+		}
 
-        if (isMatchWinnerDetermined(doublesMatch)) {
-            doublesMatchStore.store(doublesMatch);
-            updateNextRoundMatch(doublesMatch);
-        }
-        if (isAllMatchFinished(doublesMatch)) {
-            leagueReader.readLeagueById(doublesMatch.getLeague().getLeagueId()).finishLeague();
-        }
+		if (isMatchWinnerDetermined(doublesMatch)) {
+			doublesMatchStore.store(doublesMatch);
+			updateNextRoundMatch(doublesMatch);
+		}
+		if (isAllMatchFinished(doublesMatch)) {
+			leagueReader.readLeagueById(doublesMatch.getLeague().getLeagueId()).finishLeague();
+		}
 
-        return SetInfo.fromDoublesSet(matchId, setNumber, doublesMatch.getDoublesSets().get(setNumber - 1));
-    }
+		return SetInfo.fromDoublesSet(matchId, setNumber, doublesMatch.getDoublesSets().get(setNumber - 1));
+	}
 
-    private void changeNextSetStatus(DoublesMatch doublesMatch, Integer setNumber) {
-        setNumber++;
-        if (doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
-            doublesMatch.getDoublesSet(setNumber).open();
-        }
-        if (!doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
-            doublesMatch.getDoublesSet(setNumber).close();
-        }
-    }
+	private void changeNextSetStatus(DoublesMatch doublesMatch, Integer setNumber) {
+		setNumber++;
+		if (doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
+			doublesMatch.getDoublesSet(setNumber).open();
+		}
+		if (!doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
+			doublesMatch.getDoublesSet(setNumber).close();
+		}
+	}
 
-    private boolean isAllMatchFinished(DoublesMatch doublesMatch) {
-        return doublesMatchReader.allMatchesFinishedForLeague(
-                doublesMatch.getLeague().getLeagueId());
-    }
+	private boolean isAllMatchFinished(DoublesMatch doublesMatch) {
+		return doublesMatchReader.allMatchesFinishedForLeague(
+			doublesMatch.getLeague().getLeagueId());
+	}
 
-    @Override
-    public Main retrieveSet(Long matchId, int setNumber) {
-        DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
-        DoublesSet doublesSet = doublesMatch.getDoublesSet(setNumber);
-        return SetInfo.fromDoublesSet(matchId, setNumber, doublesSet);
-    }
+	@Override
+	public Main retrieveSet(Long matchId, int setNumber) {
+		DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
+		DoublesSet doublesSet = doublesMatch.getDoublesSet(setNumber);
+		return SetInfo.fromDoublesSet(matchId, setNumber, doublesSet);
+	}
 
-    private List<DoublesMatch> createFirstRoundMatches(League league, List<LeagueParticipant> participants) {
-        List<DoublesMatch> matches = new ArrayList<>();
-        for (int i = 0; i < participants.size(); i += PARTICIPANTS_PER_TEAM * TEAMS_PER_MATCH) {
-            Team team1 = new Team(participants.get(i), participants.get(i + 1));
-            Team team2 = new Team(participants.get(i + 2), participants.get(i + 3));
-            DoublesMatch match = new DoublesMatch(league, team1, team2, 1);
-            makeSetsInMatch(match);
-            doublesMatchStore.store(match);
-            matches.add(match);
-        }
-        return matches;
-    }
+	private List<DoublesMatch> createFirstRoundMatches(League league, List<LeagueParticipant> participants) {
+		List<DoublesMatch> matches = new ArrayList<>();
+		for (int i = 0; i < participants.size(); i += PARTICIPANTS_PER_TEAM * TEAMS_PER_MATCH) {
+			Team team1 = new Team(participants.get(i), participants.get(i + 1));
+			Team team2 = new Team(participants.get(i + 2), participants.get(i + 3));
+			DoublesMatch match = new DoublesMatch(league, team1, team2, 1);
+			makeSetsInMatch(match);
+			doublesMatchStore.store(match);
+			matches.add(match);
+		}
+		return matches;
+	}
 
-    private List<DoublesMatch> createRoundMatches(League league, List<DoublesMatch> previousMatches, int roundNumber) {
-        List<DoublesMatch> currentRoundMatches = new ArrayList<>();
-        for (int i = 0; i < previousMatches.size(); i += TEAMS_PER_MATCH) {
-            DoublesMatch match = new DoublesMatch(league, null, null, roundNumber);
-            makeSetsInMatch(match);
-            doublesMatchStore.store(match);
-            currentRoundMatches.add(match);
-        }
-        return currentRoundMatches;
-    }
+	private List<DoublesMatch> createRoundMatches(League league, List<DoublesMatch> previousMatches, int roundNumber) {
+		List<DoublesMatch> currentRoundMatches = new ArrayList<>();
+		for (int i = 0; i < previousMatches.size(); i += TEAMS_PER_MATCH) {
+			DoublesMatch match = new DoublesMatch(league, null, null, roundNumber);
+			makeSetsInMatch(match);
+			doublesMatchStore.store(match);
+			currentRoundMatches.add(match);
+		}
+		return currentRoundMatches;
+	}
 
-    private List<DoublesMatch> createSubsequentRoundsMatches(League league, int totalRounds) {
-        List<DoublesMatch> matches = new ArrayList<>();
-        List<DoublesMatch> previousMatches = doublesMatchReader.findMatchesByLeagueAndRound(league.getLeagueId(), 1);
+	private List<DoublesMatch> createSubsequentRoundsMatches(League league, int totalRounds) {
+		List<DoublesMatch> matches = new ArrayList<>();
+		List<DoublesMatch> previousMatches = doublesMatchReader.findMatchesByLeagueAndRound(league.getLeagueId(), 1);
 
-        for (int roundNumber = 2; roundNumber <= totalRounds; roundNumber++) {
-            List<DoublesMatch> currentRoundMatches = createRoundMatches(league, previousMatches, roundNumber);
-            matches.addAll(currentRoundMatches);
-            previousMatches = currentRoundMatches;
-        }
+		for (int roundNumber = 2; roundNumber <= totalRounds; roundNumber++) {
+			List<DoublesMatch> currentRoundMatches = createRoundMatches(league, previousMatches, roundNumber);
+			matches.addAll(currentRoundMatches);
+			previousMatches = currentRoundMatches;
+		}
 
-        return matches;
-    }
+		return matches;
+	}
 
-    private void makeSetsInMatch(DoublesMatch doublesMatch) {
-        for (int i = 1; i <= SET_COUNT; i++) {
-            DoublesSet set = new DoublesSet(doublesMatch, i);
-            doublesMatch.addSet(set);
-        }
-        doublesMatchStore.store(doublesMatch);
-    }
+	private void makeSetsInMatch(DoublesMatch doublesMatch) {
+		for (int i = 1; i <= SET_COUNT; i++) {
+			DoublesSet set = new DoublesSet(doublesMatch, i);
+			doublesMatch.addSet(set);
+		}
+		doublesMatchStore.store(doublesMatch);
+	}
 
-    private void updateSetScore(DoublesMatch doublesMatch, int setIndex,
-                                MatchCommand.UpdateSetScore updateSetScoreCommand) {
-        DoublesSet set = doublesMatch.getDoublesSet(setIndex);
-        set.endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
+	private void updateSetScore(DoublesMatch doublesMatch, int setIndex,
+		MatchCommand.UpdateSetScore updateSetScoreCommand) {
+		DoublesSet set = doublesMatch.getDoublesSet(setIndex);
+		set.endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
 
-        if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
-            doublesMatch.team1WinSet();
-        } else {
-            doublesMatch.team2WinSet();
-        }
-    }
+		if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
+			doublesMatch.team1WinSet();
+		} else {
+			doublesMatch.team2WinSet();
+		}
+	}
 
-    private void updateNextRoundMatch(DoublesMatch doublesMatch) {
-        Team winner = determineWinner(doublesMatch);
-        if (winner == null) {
-            return;
-        }
-        int totalRounds = doublesMatch.getLeague().getTotalRounds();
-        if (doublesMatch.getRoundNumber() == totalRounds) {
-            return;
-        }
+	private void updateNextRoundMatch(DoublesMatch doublesMatch) {
+		Team winner = determineWinner(doublesMatch);
+		if (winner == null) {
+			return;
+		}
+		int totalRounds = doublesMatch.getLeague().getTotalRounds();
+		if (doublesMatch.getRoundNumber() == totalRounds) {
+			return;
+		}
 
-        DoublesMatch startMatch = doublesMatchReader.findFirstMatchByLeagueId(
-                doublesMatch.getLeague().getLeagueId());
+		DoublesMatch startMatch = doublesMatchReader.findFirstMatchByLeagueId(
+			doublesMatch.getLeague().getLeagueId());
 
-        int nextRoundMatchId = MatchUtils.calculateNextRoundMatchId(Math.toIntExact(doublesMatch.getId()),
-                leagueParticipantReader.countParticipantMember(doublesMatch.getLeague().getLeagueId())
-                        / PARTICIPANTS_PER_TEAM,
-                Math.toIntExact(startMatch.getId()));
+		int nextRoundMatchId = MatchUtils.calculateNextRoundMatchId(Math.toIntExact(doublesMatch.getId()),
+			leagueParticipantReader.countParticipantMember(doublesMatch.getLeague().getLeagueId())
+				/ PARTICIPANTS_PER_TEAM,
+			Math.toIntExact(startMatch.getId()));
 
-        DoublesMatch nextRoundMatch = doublesMatchReader.getDoublesMatch((long) nextRoundMatchId);
-        if (nextRoundMatch != null) {
-            assignWinnerToNextRoundMatch(nextRoundMatch, winner);
-            doublesMatchStore.store(nextRoundMatch);
-        }
+		DoublesMatch nextRoundMatch = doublesMatchReader.getDoublesMatch((long)nextRoundMatchId);
+		if (nextRoundMatch != null) {
+			assignWinnerToNextRoundMatch(nextRoundMatch, winner);
+			doublesMatchStore.store(nextRoundMatch);
+		}
 
-    }
+	}
 
-    private void assignWinnerToNextRoundMatch(DoublesMatch nextRoundMatch, Team winner) {
-        if (nextRoundMatch.getTeam1() == null) {
-            nextRoundMatch.defineTeam1(winner);
-        } else {
-            nextRoundMatch.defineTeam2(winner);
-        }
-    }
+	private void assignWinnerToNextRoundMatch(DoublesMatch nextRoundMatch, Team winner) {
+		if (nextRoundMatch.getTeam1() == null) {
+			nextRoundMatch.defineTeam1(winner);
+		} else {
+			nextRoundMatch.defineTeam2(winner);
+		}
+	}
 
-    private Team determineWinner(DoublesMatch match) {
-        if (match.getTeam1MatchResult() == MatchResult.WIN) {
-            return match.getTeam1();
-        }
-        if (match.getTeam2MatchResult() == MatchResult.WIN) {
-            return match.getTeam2();
-        }
-        return null;
-    }
+	private Team determineWinner(DoublesMatch match) {
+		if (match.getTeam1MatchResult() == MatchResult.WIN) {
+			return match.getTeam1();
+		}
+		if (match.getTeam2MatchResult() == MatchResult.WIN) {
+			return match.getTeam2();
+		}
+		return null;
+	}
 
-    @Override
-    public void startMatch(Long matchId) {
-        DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
-        doublesMatch.startMatch();
-        doublesMatch.getDoublesSet(1).startSet();
-        doublesMatchStore.store(doublesMatch);
-
-    }
+	@Override
+	public void startMatch(Long matchId) {
+		DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
+		League league = doublesMatch.getLeague();
+		league.startLeague();
+		leagueStore.store(league);
+		doublesMatch.startMatch();
+		doublesMatch.getDoublesSet(1).startSet();
+		doublesMatchStore.store(doublesMatch);
+	}
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/TournamentSinglesMatchStrategy.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/TournamentSinglesMatchStrategy.java
@@ -3,7 +3,7 @@ package org.badminton.infrastructure.match.strategy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
+
 import org.badminton.domain.common.enums.MatchResult;
 import org.badminton.domain.common.enums.SetStatus;
 import org.badminton.domain.common.exception.match.AlreadyWinnerDeterminedException;
@@ -12,6 +12,7 @@ import org.badminton.domain.common.exception.match.MatchDuplicateException;
 import org.badminton.domain.common.exception.match.SetFinishedException;
 import org.badminton.domain.domain.league.LeagueParticipantReader;
 import org.badminton.domain.domain.league.LeagueReader;
+import org.badminton.domain.domain.league.LeagueStore;
 import org.badminton.domain.domain.league.entity.League;
 import org.badminton.domain.domain.league.entity.LeagueParticipant;
 import org.badminton.domain.domain.match.command.MatchCommand;
@@ -25,64 +26,68 @@ import org.badminton.domain.domain.match.store.SinglesMatchReader;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @Component
 public class TournamentSinglesMatchStrategy extends AbstractSinglesMatchStrategy {
 
-    public static final int SET_COUNT = 3;
-    public static final int PARTICIPANTS_PER_MATCH = 2;
-    static final Integer LIMIT_SET_GAME = 3;
-    private final SinglesMatchStore singlesMatchStore;
-    private final LeagueParticipantReader leagueParticipantReader;
-    private final SinglesMatchReader singlesMatchReader;
-    private final LeagueReader leagueReader;
+	public static final int SET_COUNT = 3;
+	public static final int PARTICIPANTS_PER_MATCH = 2;
+	static final Integer LIMIT_SET_GAME = 3;
+	private final SinglesMatchStore singlesMatchStore;
+	private final LeagueParticipantReader leagueParticipantReader;
+	private final SinglesMatchReader singlesMatchReader;
+	private final LeagueReader leagueReader;
+	private final LeagueStore leagueStore;
 
-    public TournamentSinglesMatchStrategy(SinglesMatchReader singlesMatchReader, SinglesMatchStore singlesMatchStore,
-                                          LeagueParticipantReader leagueParticipantReader, LeagueReader leagueReader) {
-        super(singlesMatchReader);
-        this.singlesMatchReader = singlesMatchReader;
-        this.singlesMatchStore = singlesMatchStore;
-        this.leagueParticipantReader = leagueParticipantReader;
-        this.leagueReader = leagueReader;
-    }
+	public TournamentSinglesMatchStrategy(SinglesMatchReader singlesMatchReader, SinglesMatchStore singlesMatchStore,
+		LeagueParticipantReader leagueParticipantReader, LeagueReader leagueReader, LeagueStore leagueStore) {
+		super(singlesMatchReader);
+		this.singlesMatchReader = singlesMatchReader;
+		this.singlesMatchStore = singlesMatchStore;
+		this.leagueParticipantReader = leagueParticipantReader;
+		this.leagueReader = leagueReader;
+		this.leagueStore = leagueStore;
+	}
 
-    private static boolean isMatchWinnerDetermined(SinglesMatch singlesMatch) {
-        return singlesMatch.getPlayer1MatchResult() == MatchResult.WIN
-                || singlesMatch.getPlayer2MatchResult() == MatchResult.WIN;
-    }
+	private static boolean isMatchWinnerDetermined(SinglesMatch singlesMatch) {
+		return singlesMatch.getPlayer1MatchResult() == MatchResult.WIN
+			|| singlesMatch.getPlayer2MatchResult() == MatchResult.WIN;
+	}
 
-    @Override
-    public BracketInfo makeBracket(League league, List<LeagueParticipant> leagueParticipantList) {
-        List<SinglesMatch> allMatches = new ArrayList<>();
+	@Override
+	public BracketInfo makeBracket(League league, List<LeagueParticipant> leagueParticipantList) {
+		List<SinglesMatch> allMatches = new ArrayList<>();
 
-        List<LeagueParticipant> currentParticipants = new ArrayList<>(leagueParticipantList);
-        Collections.shuffle(currentParticipants);
-        int totalRounds = MatchUtils.calculateTotalRounds(currentParticipants.size());
-        league.defineTotalRounds(totalRounds);
+		List<LeagueParticipant> currentParticipants = new ArrayList<>(leagueParticipantList);
+		Collections.shuffle(currentParticipants);
+		int totalRounds = MatchUtils.calculateTotalRounds(currentParticipants.size());
+		league.defineTotalRounds(totalRounds);
 
-        allMatches.addAll(createFirstRoundMatches(league, currentParticipants));
-        allMatches.addAll(createSubsequentRoundsMatches(league, totalRounds));
+		allMatches.addAll(createFirstRoundMatches(league, currentParticipants));
+		allMatches.addAll(createSubsequentRoundsMatches(league, totalRounds));
 
-        return BracketInfo.fromSingles(totalRounds, allMatches);
+		return BracketInfo.fromSingles(totalRounds, allMatches);
 
-    }
+	}
 
-    @Override
-    public void checkDuplicateInitialBracket(Long leagueId) {
-        boolean isBracketEmpty = singlesMatchReader.checkIfBracketEmpty(leagueId);
+	@Override
+	public void checkDuplicateInitialBracket(Long leagueId) {
+		boolean isBracketEmpty = singlesMatchReader.checkIfBracketEmpty(leagueId);
 
-        if (!isBracketEmpty && singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
-            singlesMatchStore.deleteSinglesBracket(leagueId);
-        } else if (!isBracketEmpty && !singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
-            throw new MatchDuplicateException(leagueId);
-        }
-    }
+		if (!isBracketEmpty && singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
+			singlesMatchStore.deleteSinglesBracket(leagueId);
+		} else if (!isBracketEmpty && !singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
+			throw new MatchDuplicateException(leagueId);
+		}
+	}
 
-    @Override
-    @Transactional
-    public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
-                                                MatchCommand.UpdateSetScore updateSetScoreCommand) {
-        SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
+	@Override
+	@Transactional
+	public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
+		MatchCommand.UpdateSetScore updateSetScoreCommand) {
+		SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
 
 		if (isMatchWinnerDetermined(singlesMatch)) {
 			throw new AlreadyWinnerDeterminedException(singlesMatch.getId());
@@ -96,152 +101,155 @@ public class TournamentSinglesMatchStrategy extends AbstractSinglesMatchStrategy
 			throw new LeagueParticipantsNotExistsException(matchId);
 		}
 
-        updateSetScore(singlesMatch, setNumber, updateSetScoreCommand);
-        singlesMatchStore.store(singlesMatch);
+		updateSetScore(singlesMatch, setNumber, updateSetScoreCommand);
+		singlesMatchStore.store(singlesMatch);
 
-        if (LIMIT_SET_GAME > setNumber) {
-            changeNextSetStatus(singlesMatch, setNumber);
-        }
+		if (LIMIT_SET_GAME > setNumber) {
+			changeNextSetStatus(singlesMatch, setNumber);
+		}
 
-        // 최종 승자가 정해지면 matchResult 업데이트
-        if (isMatchWinnerDetermined(singlesMatch)) {
-            singlesMatchStore.store(singlesMatch);
-            updateNextRoundMatch(singlesMatch);
-        }
+		// 최종 승자가 정해지면 matchResult 업데이트
+		if (isMatchWinnerDetermined(singlesMatch)) {
+			singlesMatchStore.store(singlesMatch);
+			updateNextRoundMatch(singlesMatch);
+		}
 
 		if (isAllMatchFinished(singlesMatch)) {
 			leagueReader.readLeagueById(singlesMatch.getLeague().getLeagueId()).finishLeague();
 		}
 
-        return SetInfo.fromSinglesSet(matchId, setNumber, singlesMatch.getSinglesSets().get(setNumber - 1));
-    }
+		return SetInfo.fromSinglesSet(matchId, setNumber, singlesMatch.getSinglesSets().get(setNumber - 1));
+	}
 
-    private void changeNextSetStatus(SinglesMatch singlesMatch, Integer setNumber) {
-        setNumber++;
+	private void changeNextSetStatus(SinglesMatch singlesMatch, Integer setNumber) {
+		setNumber++;
 		if (singlesMatch.getPlayer1MatchResult().equals(MatchResult.NONE)) {
 			singlesMatch.getSinglesSet(setNumber).open();
 		}
 		if (!singlesMatch.getPlayer1MatchResult().equals(MatchResult.NONE)) {
 			singlesMatch.getSinglesSet(setNumber).close();
 		}
-    }
+	}
 
-    private boolean isAllMatchFinished(SinglesMatch singlesMatch) {
-        return singlesMatchReader.allMatchesFinishedForLeague(
-                singlesMatch.getLeague().getLeagueId());
-    }
+	private boolean isAllMatchFinished(SinglesMatch singlesMatch) {
+		return singlesMatchReader.allMatchesFinishedForLeague(
+			singlesMatch.getLeague().getLeagueId());
+	}
 
-    @Override
-    public SetInfo.Main retrieveSet(Long matchId, int setNumber) {
-        SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
-        SinglesSet singlesSet = singlesMatch.getSinglesSet(1);
-        return SetInfo.fromSinglesSet(matchId, setNumber, singlesSet);
-    }
+	@Override
+	public SetInfo.Main retrieveSet(Long matchId, int setNumber) {
+		SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
+		SinglesSet singlesSet = singlesMatch.getSinglesSet(1);
+		return SetInfo.fromSinglesSet(matchId, setNumber, singlesSet);
+	}
 
-    private List<SinglesMatch> createFirstRoundMatches(League league, List<LeagueParticipant> participants) {
-        List<SinglesMatch> matches = new ArrayList<>();
-        for (int i = 0; i < participants.size(); i += PARTICIPANTS_PER_MATCH) {
-            SinglesMatch match = new SinglesMatch(league, participants.get(i), participants.get(i + 1), 1);
-            makeSetsInMatch(match);
-            singlesMatchStore.store(match);
-            matches.add(match);
-        }
-        return matches;
-    }
+	private List<SinglesMatch> createFirstRoundMatches(League league, List<LeagueParticipant> participants) {
+		List<SinglesMatch> matches = new ArrayList<>();
+		for (int i = 0; i < participants.size(); i += PARTICIPANTS_PER_MATCH) {
+			SinglesMatch match = new SinglesMatch(league, participants.get(i), participants.get(i + 1), 1);
+			makeSetsInMatch(match);
+			singlesMatchStore.store(match);
+			matches.add(match);
+		}
+		return matches;
+	}
 
-    private List<SinglesMatch> createRoundMatches(League league, List<SinglesMatch> previousMatches, int roundNumber) {
-        List<SinglesMatch> currentRoundMatches = new ArrayList<>();
-        for (int i = 0; i < previousMatches.size(); i += PARTICIPANTS_PER_MATCH) {
-            SinglesMatch match = new SinglesMatch(league, null, null, roundNumber);
-            makeSetsInMatch(match);
-            singlesMatchStore.store(match);
-            currentRoundMatches.add(match);
-        }
-        return currentRoundMatches;
-    }
+	private List<SinglesMatch> createRoundMatches(League league, List<SinglesMatch> previousMatches, int roundNumber) {
+		List<SinglesMatch> currentRoundMatches = new ArrayList<>();
+		for (int i = 0; i < previousMatches.size(); i += PARTICIPANTS_PER_MATCH) {
+			SinglesMatch match = new SinglesMatch(league, null, null, roundNumber);
+			makeSetsInMatch(match);
+			singlesMatchStore.store(match);
+			currentRoundMatches.add(match);
+		}
+		return currentRoundMatches;
+	}
 
-    private List<SinglesMatch> createSubsequentRoundsMatches(League league, int totalRounds) {
-        List<SinglesMatch> matches = new ArrayList<>();
-        List<SinglesMatch> previousMatches = singlesMatchReader.findMatchesByLeagueAndRound(league.getLeagueId(), 1);
+	private List<SinglesMatch> createSubsequentRoundsMatches(League league, int totalRounds) {
+		List<SinglesMatch> matches = new ArrayList<>();
+		List<SinglesMatch> previousMatches = singlesMatchReader.findMatchesByLeagueAndRound(league.getLeagueId(), 1);
 
-        for (int roundNumber = 2; roundNumber <= totalRounds; roundNumber++) {
-            List<SinglesMatch> currentRoundMatches = createRoundMatches(league, previousMatches, roundNumber);
-            matches.addAll(currentRoundMatches);
-            previousMatches = currentRoundMatches;
-        }
+		for (int roundNumber = 2; roundNumber <= totalRounds; roundNumber++) {
+			List<SinglesMatch> currentRoundMatches = createRoundMatches(league, previousMatches, roundNumber);
+			matches.addAll(currentRoundMatches);
+			previousMatches = currentRoundMatches;
+		}
 
-        return matches;
-    }
+		return matches;
+	}
 
-    private void makeSetsInMatch(SinglesMatch singlesMatch) {
-        for (int i = 1; i <= SET_COUNT; i++) {
-            SinglesSet set = new SinglesSet(singlesMatch, i);
-            singlesMatch.addSet(set);
-        }
-        singlesMatchStore.store(singlesMatch);
-    }
+	private void makeSetsInMatch(SinglesMatch singlesMatch) {
+		for (int i = 1; i <= SET_COUNT; i++) {
+			SinglesSet set = new SinglesSet(singlesMatch, i);
+			singlesMatch.addSet(set);
+		}
+		singlesMatchStore.store(singlesMatch);
+	}
 
-    private void updateSetScore(SinglesMatch singlesMatch, int setNumber,
-                                MatchCommand.UpdateSetScore updateSetScoreCommand) {
-        SinglesSet set = singlesMatch.getSinglesSet(setNumber);
-        set.endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
+	private void updateSetScore(SinglesMatch singlesMatch, int setNumber,
+		MatchCommand.UpdateSetScore updateSetScoreCommand) {
+		SinglesSet set = singlesMatch.getSinglesSet(setNumber);
+		set.endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
 
-        if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
-            singlesMatch.player1WinSet();
-        } else {
-            singlesMatch.player2WinSet();
-        }
-    }
+		if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
+			singlesMatch.player1WinSet();
+		} else {
+			singlesMatch.player2WinSet();
+		}
+	}
 
-    private void updateNextRoundMatch(SinglesMatch singlesMatch) {
-        LeagueParticipant winner = determineWinner(singlesMatch);
+	private void updateNextRoundMatch(SinglesMatch singlesMatch) {
+		LeagueParticipant winner = determineWinner(singlesMatch);
 		if (winner == null) {
 			return;
 		}
-        int totalRounds = singlesMatch.getLeague().getTotalRounds();
-        if (singlesMatch.getRoundNumber() == totalRounds) {
-            return;
-        }
+		int totalRounds = singlesMatch.getLeague().getTotalRounds();
+		if (singlesMatch.getRoundNumber() == totalRounds) {
+			return;
+		}
 
-        SinglesMatch startMatch = singlesMatchReader.findFirstMatchByLeagueId(
-                singlesMatch.getLeague().getLeagueId());
+		SinglesMatch startMatch = singlesMatchReader.findFirstMatchByLeagueId(
+			singlesMatch.getLeague().getLeagueId());
 
-        int nextRoundMatchId = MatchUtils.calculateNextRoundMatchId(Math.toIntExact(singlesMatch.getId()),
-                leagueParticipantReader.countParticipantMember(singlesMatch.getLeague().getLeagueId()),
-                Math.toIntExact(startMatch.getId()));
+		int nextRoundMatchId = MatchUtils.calculateNextRoundMatchId(Math.toIntExact(singlesMatch.getId()),
+			leagueParticipantReader.countParticipantMember(singlesMatch.getLeague().getLeagueId()),
+			Math.toIntExact(startMatch.getId()));
 
-        SinglesMatch nextRoundMatch = singlesMatchReader.getSinglesMatch((long) nextRoundMatchId);
-        if (nextRoundMatch != null) {
-            assignWinnerToNextRoundMatch(nextRoundMatch, winner);
-            singlesMatchStore.store(nextRoundMatch);
-        }
+		SinglesMatch nextRoundMatch = singlesMatchReader.getSinglesMatch((long)nextRoundMatchId);
+		if (nextRoundMatch != null) {
+			assignWinnerToNextRoundMatch(nextRoundMatch, winner);
+			singlesMatchStore.store(nextRoundMatch);
+		}
 
-    }
+	}
 
-    private void assignWinnerToNextRoundMatch(SinglesMatch nextRoundMatch, LeagueParticipant winner) {
-        if (nextRoundMatch.getLeagueParticipant1() == null) {
-            nextRoundMatch.defineLeagueParticipant1(winner);
-        } else {
-            nextRoundMatch.defineLeagueParticipant2(winner);
-        }
-    }
+	private void assignWinnerToNextRoundMatch(SinglesMatch nextRoundMatch, LeagueParticipant winner) {
+		if (nextRoundMatch.getLeagueParticipant1() == null) {
+			nextRoundMatch.defineLeagueParticipant1(winner);
+		} else {
+			nextRoundMatch.defineLeagueParticipant2(winner);
+		}
+	}
 
-    private LeagueParticipant determineWinner(SinglesMatch match) {
-        if (match.getPlayer1MatchResult() == MatchResult.WIN) {
-            return match.getLeagueParticipant1();
-        }
-        if (match.getPlayer2MatchResult() == MatchResult.WIN) {
-            return match.getLeagueParticipant2();
-        }
-        return null;
-    }
+	private LeagueParticipant determineWinner(SinglesMatch match) {
+		if (match.getPlayer1MatchResult() == MatchResult.WIN) {
+			return match.getLeagueParticipant1();
+		}
+		if (match.getPlayer2MatchResult() == MatchResult.WIN) {
+			return match.getLeagueParticipant2();
+		}
+		return null;
+	}
 
-    @Override
-    public void startMatch(Long matchId) {
-        SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
-        singlesMatch.startMatch();
-        singlesMatch.getSinglesSet(1).initMatch();
-        singlesMatchStore.store(singlesMatch);
-    }
+	@Override
+	public void startMatch(Long matchId) {
+		SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
+		League league = singlesMatch.getLeague();
+		league.startLeague();
+		leagueStore.store(league);
+		singlesMatch.startMatch();
+		singlesMatch.getSinglesSet(1).initMatch();
+		singlesMatchStore.store(singlesMatch);
+	}
 
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍

Match 시작 시 League 상태를 `PLAYING` 으로 변경합니다.
다만, 모든 Match 에 대해 해당 상태를 변경하는데, 이를 개선할 수 있는 방법이 있을까요?
또, 지금은 `Free` / `Tournament` 에 따라 코드가 중복되고 있습니다. Match Strategy 를 4개로 분리함에 따라 코드가 중복되었는데, 이를 abstract 메서드를 활용하여 개선할 수 있을까요? 

## 변경된 사항 📝

Match 시작 시 League 상태도 함께 변경합니다. 기존에는 Match 가 시작되어도 League 가 `RECRUITING_COMPLETED` 상태가 유지됩니다.

## PR에서 중점적으로 확인되어야 하는 사항

Match Strategy 의 코드 중복을 개선할 방법이 있을까요?