### PR TITLE
refactor: startMatch 메서드 수정 및 검증 추가

### DIFF
--- a/api/src/main/java/org/badminton/api/application/match/FreeMatchFacade.java
+++ b/api/src/main/java/org/badminton/api/application/match/FreeMatchFacade.java
@@ -42,10 +42,10 @@ public class FreeMatchFacade implements MatchOperationHandler {
 	}
 
 	@Override
-	public void startMatch(StartMatchCommand startMatchCommand) {
+	public void startMatch(Long leagueId, StartMatchCommand startMatchCommand) {
 		MatchStrategy matchStrategy = freeBracketGenerationService.makeSinglesOrDoublesMatchStrategy(
 			startMatchCommand.leagueId());
-		freeBracketGenerationService.startMatch(matchStrategy, startMatchCommand.matchId());
+		freeBracketGenerationService.startMatch(matchStrategy, leagueId, startMatchCommand.matchId());
 	}
 
 	@Override

--- a/api/src/main/java/org/badminton/api/application/match/FreeMatchFacade.java
+++ b/api/src/main/java/org/badminton/api/application/match/FreeMatchFacade.java
@@ -42,10 +42,11 @@ public class FreeMatchFacade implements MatchOperationHandler {
 	}
 
 	@Override
-	public void startMatch(Long leagueId, StartMatchCommand startMatchCommand) {
+	public void startMatch(StartMatchCommand startMatchCommand) {
 		MatchStrategy matchStrategy = freeBracketGenerationService.makeSinglesOrDoublesMatchStrategy(
 			startMatchCommand.leagueId());
-		freeBracketGenerationService.startMatch(matchStrategy, leagueId, startMatchCommand.matchId());
+		freeBracketGenerationService.startMatch(matchStrategy, startMatchCommand.leagueId(),
+			startMatchCommand.matchId());
 	}
 
 	@Override

--- a/api/src/main/java/org/badminton/api/application/match/MatchOperationHandler.java
+++ b/api/src/main/java/org/badminton/api/application/match/MatchOperationHandler.java
@@ -11,5 +11,5 @@ public interface MatchOperationHandler {
 	SetInfo.Main registerSetScoreInMatch(Long leagueId, Long matchId, Integer setIndex,
 		MatchCommand.UpdateSetScore updateSetScoreCommand, String memberToken);
 
-	void startMatch(Long leagueId, StartMatchCommand startMatchCommand);
+	void startMatch(StartMatchCommand startMatchCommand);
 }

--- a/api/src/main/java/org/badminton/api/application/match/MatchOperationHandler.java
+++ b/api/src/main/java/org/badminton/api/application/match/MatchOperationHandler.java
@@ -6,10 +6,10 @@ import org.badminton.domain.domain.match.info.BracketInfo;
 import org.badminton.domain.domain.match.info.SetInfo;
 
 public interface MatchOperationHandler {
-    BracketInfo generateInitialBracket(Long leagueId, String memberToken);
+	BracketInfo generateInitialBracket(Long leagueId, String memberToken);
 
-    SetInfo.Main registerSetScoreInMatch(Long leagueId, Long matchId, Integer setIndex,
-                                         MatchCommand.UpdateSetScore updateSetScoreCommand, String memberToken);
+	SetInfo.Main registerSetScoreInMatch(Long leagueId, Long matchId, Integer setIndex,
+		MatchCommand.UpdateSetScore updateSetScoreCommand, String memberToken);
 
-    void startMatch(StartMatchCommand startMatchCommand);
+	void startMatch(Long leagueId, StartMatchCommand startMatchCommand);
 }

--- a/api/src/main/java/org/badminton/api/application/match/TournamentMatchFacade.java
+++ b/api/src/main/java/org/badminton/api/application/match/TournamentMatchFacade.java
@@ -1,6 +1,5 @@
 package org.badminton.api.application.match;
 
-import lombok.extern.slf4j.Slf4j;
 import org.badminton.api.interfaces.match.dto.StartMatchCommand;
 import org.badminton.domain.domain.match.command.MatchCommand;
 import org.badminton.domain.domain.match.info.BracketInfo;
@@ -12,44 +11,46 @@ import org.badminton.domain.domain.match.service.MatchStrategy;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @Service
 public class TournamentMatchFacade implements MatchOperationHandler {
-    private final BracketGenerationService tournamentBracketGenerationService;
-    private final MatchProgressService tournamentMatchProgressService;
-    private final MatchRecordService matchRecordService;
+	private final BracketGenerationService tournamentBracketGenerationService;
+	private final MatchProgressService tournamentMatchProgressService;
+	private final MatchRecordService matchRecordService;
 
-    public TournamentMatchFacade(
-            @Qualifier("tournamentBracketGenerationServiceImpl") BracketGenerationService tournamentBracketGenerationService,
-            @Qualifier("tournamentMatchProgressServiceImpl") MatchProgressService tournamentMatchProgressService,
-            MatchRecordService matchRecordService) {
+	public TournamentMatchFacade(
+		@Qualifier("tournamentBracketGenerationServiceImpl") BracketGenerationService tournamentBracketGenerationService,
+		@Qualifier("tournamentMatchProgressServiceImpl") MatchProgressService tournamentMatchProgressService,
+		MatchRecordService matchRecordService) {
 
-        this.tournamentBracketGenerationService = tournamentBracketGenerationService;
-        this.tournamentMatchProgressService = tournamentMatchProgressService;
-        this.matchRecordService = matchRecordService;
-    }
+		this.tournamentBracketGenerationService = tournamentBracketGenerationService;
+		this.tournamentMatchProgressService = tournamentMatchProgressService;
+		this.matchRecordService = matchRecordService;
+	}
 
-    @Override
-    public BracketInfo generateInitialBracket(Long leagueId, String memberToken) {
-        MatchStrategy matchStrategy = tournamentBracketGenerationService.makeSinglesOrDoublesMatchStrategy(leagueId);
-        tournamentBracketGenerationService.checkLeagueRecruitingStatus(leagueId);
-        return tournamentBracketGenerationService.makeBracket(matchStrategy, leagueId, memberToken);
-    }
+	@Override
+	public BracketInfo generateInitialBracket(Long leagueId, String memberToken) {
+		MatchStrategy matchStrategy = tournamentBracketGenerationService.makeSinglesOrDoublesMatchStrategy(leagueId);
+		tournamentBracketGenerationService.checkLeagueRecruitingStatus(leagueId);
+		return tournamentBracketGenerationService.makeBracket(matchStrategy, leagueId, memberToken);
+	}
 
-    @Override
-    public SetInfo.Main registerSetScoreInMatch(Long leagueId, Long matchId, Integer setIndex,
-                                                MatchCommand.UpdateSetScore updateSetScoreCommand, String memberToken) {
-        MatchStrategy matchStrategy = tournamentMatchProgressService.makeSinglesOrDoublesMatchStrategy(leagueId);
-        SetInfo.Main main = tournamentMatchProgressService.registerSetScoreInMatch(matchStrategy, leagueId, matchId,
-                setIndex, updateSetScoreCommand, memberToken);
-        matchRecordService.processMatchResult(main.getMatchType(), matchId);
-        return main;
-    }
+	@Override
+	public SetInfo.Main registerSetScoreInMatch(Long leagueId, Long matchId, Integer setIndex,
+		MatchCommand.UpdateSetScore updateSetScoreCommand, String memberToken) {
+		MatchStrategy matchStrategy = tournamentMatchProgressService.makeSinglesOrDoublesMatchStrategy(leagueId);
+		SetInfo.Main main = tournamentMatchProgressService.registerSetScoreInMatch(matchStrategy, leagueId, matchId,
+			setIndex, updateSetScoreCommand, memberToken);
+		matchRecordService.processMatchResult(main.getMatchType(), matchId);
+		return main;
+	}
 
-    @Override
-    public void startMatch(StartMatchCommand startMatchCommand) {
-        MatchStrategy matchStrategy = tournamentBracketGenerationService.makeSinglesOrDoublesMatchStrategy(
-                startMatchCommand.leagueId());
-        tournamentBracketGenerationService.startMatch(matchStrategy, startMatchCommand.matchId());
-    }
+	@Override
+	public void startMatch(Long leagueId, StartMatchCommand startMatchCommand) {
+		MatchStrategy matchStrategy = tournamentBracketGenerationService.makeSinglesOrDoublesMatchStrategy(
+			startMatchCommand.leagueId());
+		tournamentBracketGenerationService.startMatch(matchStrategy, leagueId, startMatchCommand.matchId());
+	}
 }

--- a/api/src/main/java/org/badminton/api/application/match/TournamentMatchFacade.java
+++ b/api/src/main/java/org/badminton/api/application/match/TournamentMatchFacade.java
@@ -48,9 +48,10 @@ public class TournamentMatchFacade implements MatchOperationHandler {
 	}
 
 	@Override
-	public void startMatch(Long leagueId, StartMatchCommand startMatchCommand) {
+	public void startMatch(StartMatchCommand startMatchCommand) {
 		MatchStrategy matchStrategy = tournamentBracketGenerationService.makeSinglesOrDoublesMatchStrategy(
 			startMatchCommand.leagueId());
-		tournamentBracketGenerationService.startMatch(matchStrategy, leagueId, startMatchCommand.matchId());
+		tournamentBracketGenerationService.startMatch(matchStrategy, startMatchCommand.leagueId(),
+			startMatchCommand.matchId());
 	}
 }

--- a/api/src/main/java/org/badminton/api/interfaces/match/controller/MatchController.java
+++ b/api/src/main/java/org/badminton/api/interfaces/match/controller/MatchController.java
@@ -169,7 +169,7 @@ public class MatchController {
 		StartMatchCommand startMatchCommand =
 			new StartMatchCommand(clubToken, leagueId, matchId);
 		MatchOperationHandler matchOperationFacade = matchFacade.getMatchOperationHandler(leagueId);
-		matchOperationFacade.startMatch(leagueId, startMatchCommand);
+		matchOperationFacade.startMatch(startMatchCommand);
 		return CommonResponse.success("OK");
 	}
 }

--- a/api/src/main/java/org/badminton/api/interfaces/match/controller/MatchController.java
+++ b/api/src/main/java/org/badminton/api/interfaces/match/controller/MatchController.java
@@ -169,7 +169,7 @@ public class MatchController {
 		StartMatchCommand startMatchCommand =
 			new StartMatchCommand(clubToken, leagueId, matchId);
 		MatchOperationHandler matchOperationFacade = matchFacade.getMatchOperationHandler(leagueId);
-		matchOperationFacade.startMatch(startMatchCommand);
+		matchOperationFacade.startMatch(leagueId, startMatchCommand);
 		return CommonResponse.success("OK");
 	}
 }

--- a/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
+++ b/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
@@ -89,6 +89,7 @@ public enum ErrorCode {
 	INVALID_TIME_TO_CANCEL_LEAGUE_PARTICIPATION(412, "모집 마감 시간이 지나면 경기 참여를 취소할 수 없습니다."),
 	INVALID_TIME_TO_PARTICIPATE_IN_LEAGUE(412, "모집 마감 시간이 지나면 경기 참여 신청을 할 수 없습니다."),
 	INVALID_TIME_TO_CANCEL_LEAGUE(412, "경기 시작 시간이 지난 경기는 취소할 수 없습니다."),
+	INVALID_TIME_TO_START_MATCH(412, "경기 시작 시간 전에는 매치를 시작할 수 없습니다."),
 	LEAGUE_NOT_RECRUITING(412, "모집 중이 아닙니다."),
 	LEAGUE_PARTICIPANT_POWER_OF_TWO(412, "토너먼트 경기에서는 경기 참여 인원이 2의 제곱이어야 합니다"),
 	LEAGUE_PARTICIPANTS_NOT_EXISTS(412, "해당 매치의 참여자가 아직 정해지지 않았습니다"),

--- a/domain/src/main/java/org/badminton/domain/common/exception/league/CannotStartMatchException.java
+++ b/domain/src/main/java/org/badminton/domain/common/exception/league/CannotStartMatchException.java
@@ -1,0 +1,17 @@
+package org.badminton.domain.common.exception.league;
+
+import java.time.LocalDateTime;
+
+import org.badminton.domain.common.error.ErrorCode;
+import org.badminton.domain.common.exception.BadmintonException;
+
+public class CannotStartMatchException extends BadmintonException {
+
+	public CannotStartMatchException(Long leagueId, LocalDateTime leagueAt) {
+		super(ErrorCode.INVALID_TIME_TO_START_MATCH, "[경기 아이디 : " + leagueId + " 경기 시작 시간 : " + leagueAt + " ]");
+	}
+
+	public CannotStartMatchException(Long leagueId, LocalDateTime leagueAt, Exception e) {
+		super(ErrorCode.INVALID_TIME_TO_START_MATCH, "[경기 아이디 : " + leagueId + " 경기 시작 시간 : " + leagueAt + " ]", e);
+	}
+}

--- a/domain/src/main/java/org/badminton/domain/domain/match/service/AbstractDoublesMatchStrategy.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/service/AbstractDoublesMatchStrategy.java
@@ -17,6 +17,7 @@ import org.badminton.domain.domain.match.info.LeagueSetsScoreInProgressInfo;
 import org.badminton.domain.domain.match.info.MatchInfo;
 import org.badminton.domain.domain.match.info.MatchSetInfo;
 import org.badminton.domain.domain.match.info.SetInfo;
+import org.badminton.domain.domain.match.reader.DoublesMatchStore;
 import org.badminton.domain.domain.match.store.DoublesMatchReader;
 import org.springframework.stereotype.Service;
 
@@ -28,6 +29,7 @@ public abstract class AbstractDoublesMatchStrategy implements MatchStrategy {
 
 	public static final int FIRST_ROUND_NUMBER = 1;
 	private final DoublesMatchReader doublesMatchReader;
+	private final DoublesMatchStore doublesMatchStore;
 
 	@Override
 	public abstract void checkDuplicateInitialBracket(Long leagueId);
@@ -101,5 +103,13 @@ public abstract class AbstractDoublesMatchStrategy implements MatchStrategy {
 		DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
 		DoublesSet doublesSet = doublesMatch.getDoublesSet(setNumber);
 		return MatchSetInfo.fromDoubles(doublesSet);
+	}
+
+	@Override
+	public void startMatch(Long matchId) {
+		DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
+		doublesMatch.startMatch();
+		doublesMatch.getDoublesSet(1).startSet();
+		doublesMatchStore.store(doublesMatch);
 	}
 }

--- a/domain/src/main/java/org/badminton/domain/domain/match/service/AbstractSinglesMatchStrategy.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/service/AbstractSinglesMatchStrategy.java
@@ -17,6 +17,7 @@ import org.badminton.domain.domain.match.info.LeagueSetsScoreInProgressInfo;
 import org.badminton.domain.domain.match.info.MatchInfo;
 import org.badminton.domain.domain.match.info.MatchSetInfo;
 import org.badminton.domain.domain.match.info.SetInfo;
+import org.badminton.domain.domain.match.reader.SinglesMatchStore;
 import org.badminton.domain.domain.match.store.SinglesMatchReader;
 import org.springframework.stereotype.Service;
 
@@ -28,6 +29,7 @@ public abstract class AbstractSinglesMatchStrategy implements MatchStrategy {
 
 	public static final int FIRST_ROUND_NUMBER = 1;
 	private final SinglesMatchReader singlesMatchReader;
+	private final SinglesMatchStore singlesMatchStore;
 
 	@Override
 	public abstract void checkDuplicateInitialBracket(Long leagueId);
@@ -103,5 +105,13 @@ public abstract class AbstractSinglesMatchStrategy implements MatchStrategy {
 		SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
 		SinglesSet singlesSet = singlesMatch.getSinglesSet(setNumber);
 		return MatchSetInfo.fromSingles(singlesSet);
+	}
+
+	@Override
+	public void startMatch(Long matchId) {
+		SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
+		singlesMatch.startMatch();
+		singlesMatch.getSinglesSet(1).initMatch();
+		singlesMatchStore.store(singlesMatch);
 	}
 }

--- a/domain/src/main/java/org/badminton/domain/domain/match/service/BracketGenerationService.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/service/BracketGenerationService.java
@@ -12,5 +12,5 @@ public interface BracketGenerationService {
 
 	BracketInfo makeBracket(MatchStrategy matchStrategy, Long leagueId, String memberToken);
 
-	void startMatch(MatchStrategy matchStrategy, Long matchId);
+	void startMatch(MatchStrategy matchStrategy, Long leagueId, Long matchId);
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/FreeBracketGenerationServiceImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/FreeBracketGenerationServiceImpl.java
@@ -1,8 +1,9 @@
 package org.badminton.infrastructure.match.service;
 
-import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+
+import org.badminton.domain.common.exception.league.CannotStartMatchException;
 import org.badminton.domain.common.exception.league.InvalidPlayerCountException;
 import org.badminton.domain.common.exception.league.NotLeagueOwnerException;
 import org.badminton.domain.common.exception.match.LeagueRecruitingMustBeCompletedWhenBracketGenerationException;
@@ -22,72 +23,79 @@ import org.badminton.infrastructure.match.strategy.FreeDoublesMatchStrategy;
 import org.badminton.infrastructure.match.strategy.FreeSinglesMatchStrategy;
 import org.springframework.stereotype.Service;
 
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
 @Service
 @RequiredArgsConstructor
 public class FreeBracketGenerationServiceImpl implements BracketGenerationService {
 
-    private final LeagueReader leagueReader;
-    private final LeagueParticipantRepository leagueParticipantRepository;
-    private final SinglesMatchReader singlesMatchReader;
-    private final DoublesMatchReader doublesMatchReader;
-    private final SinglesMatchStore singlesMatchStore;
-    private final DoublesMatchStore doublesMatchStore;
+	private final LeagueReader leagueReader;
+	private final LeagueParticipantRepository leagueParticipantRepository;
+	private final SinglesMatchReader singlesMatchReader;
+	private final DoublesMatchReader doublesMatchReader;
+	private final SinglesMatchStore singlesMatchStore;
+	private final DoublesMatchStore doublesMatchStore;
 
-    @Override
-    public void checkLeagueRecruitingStatus(Long leagueId) {
-        League league = findLeague(leagueId);
-        /*
-         * 경기 상태가 COMPLETED 일 수 있는 상황
-         * 1. 모집 마감 날짜가 지났고, 모집 인원이 채워짐
-         * 2. 모집 마감 날짜가 지나지 않았지만, 경기 소유자가 모집 마감 상태로 변경(이때 최소 인원은 충족된다.)
-         * 3. 모집 마감 날짜가 지나지 않았지만, 모집 인원이 채워짐
-         */
-        if (league.getLeagueStatus() != LeagueStatus.RECRUITING_COMPLETED) {
-            throw new LeagueRecruitingMustBeCompletedWhenBracketGenerationException(leagueId, league.getLeagueStatus());
-        }
-    }
+	@Override
+	public void checkLeagueRecruitingStatus(Long leagueId) {
+		League league = findLeague(leagueId);
+		/*
+		 * 경기 상태가 COMPLETED 일 수 있는 상황
+		 * 1. 모집 마감 날짜가 지났고, 모집 인원이 채워짐
+		 * 2. 모집 마감 날짜가 지나지 않았지만, 경기 소유자가 모집 마감 상태로 변경(이때 최소 인원은 충족된다.)
+		 * 3. 모집 마감 날짜가 지나지 않았지만, 모집 인원이 채워짐
+		 */
+		if (league.getLeagueStatus() != LeagueStatus.RECRUITING_COMPLETED) {
+			throw new LeagueRecruitingMustBeCompletedWhenBracketGenerationException(leagueId, league.getLeagueStatus());
+		}
+	}
 
-    @Override
-    public MatchStrategy makeSinglesOrDoublesMatchStrategy(Long leagueId) {
-        League league = findLeague(leagueId);
-        return switch (league.getMatchType()) {
-            case SINGLES -> new FreeSinglesMatchStrategy(singlesMatchReader, singlesMatchStore, leagueReader);
-            case DOUBLES -> new FreeDoublesMatchStrategy(doublesMatchReader, doublesMatchStore, leagueReader);
-        };
-    }
+	@Override
+	public MatchStrategy makeSinglesOrDoublesMatchStrategy(Long leagueId) {
+		League league = findLeague(leagueId);
+		return switch (league.getMatchType()) {
+			case SINGLES -> new FreeSinglesMatchStrategy(singlesMatchReader, singlesMatchStore, leagueReader);
+			case DOUBLES -> new FreeDoublesMatchStrategy(doublesMatchReader, doublesMatchStore, leagueReader);
+		};
+	}
 
-    @Override
-    @Transactional
-    public BracketInfo makeBracket(MatchStrategy matchStrategy, Long leagueId, String memberToken) {
-        League league = findLeague(leagueId);
-        if (!league.getLeagueOwnerMemberToken().equals(memberToken)) {
-            throw new NotLeagueOwnerException(leagueId, memberToken);
-        }
-        matchStrategy.checkDuplicateInitialBracket(leagueId);
+	@Override
+	@Transactional
+	public BracketInfo makeBracket(MatchStrategy matchStrategy, Long leagueId, String memberToken) {
+		League league = findLeague(leagueId);
+		if (!league.getLeagueOwnerMemberToken().equals(memberToken)) {
+			throw new NotLeagueOwnerException(leagueId, memberToken);
+		}
+		matchStrategy.checkDuplicateInitialBracket(leagueId);
 
-        List<LeagueParticipant> leagueParticipantList = findLeagueParticipantList(leagueId);
+		List<LeagueParticipant> leagueParticipantList = findLeagueParticipantList(leagueId);
 
-        return matchStrategy.makeBracket(findLeague(leagueId), leagueParticipantList);
-    }
+		return matchStrategy.makeBracket(findLeague(leagueId), leagueParticipantList);
+	}
 
-    @Override
-    public void startMatch(MatchStrategy matchStrategy, Long matchId) {
-        matchStrategy.startMatch(matchId);
-    }
+	@Override
+	public void startMatch(MatchStrategy matchStrategy, Long leagueId, Long matchId) {
+		League league = leagueReader.readLeagueById(leagueId);
+		if (league.getLeagueAt().isBefore(LocalDateTime.now())) {
+			throw new CannotStartMatchException(league.getLeagueId(), league.getLeagueAt());
+		}
+		matchStrategy.startMatch(matchId);
+	}
 
-    private League findLeague(Long leagueId) {
-        return leagueReader.readLeagueById(leagueId);
-    }
+	private League findLeague(Long leagueId) {
+		return leagueReader.readLeagueById(leagueId);
+	}
 
-    private List<LeagueParticipant> findLeagueParticipantList(Long leagueId) {
-        /*
-         * LeagueStatus 가 COMPLETED 인데 League Participant 숫자가 0일 가능성은 없다.
-         */
-        List<LeagueParticipant> leagueParticipantList =
-                leagueParticipantRepository.findAllByLeagueLeagueIdAndCanceledFalse(leagueId);
-        if (leagueParticipantList.isEmpty()) {
-            throw new InvalidPlayerCountException(leagueId, 0);
-        }
-        return leagueParticipantList;
-    }
+	private List<LeagueParticipant> findLeagueParticipantList(Long leagueId) {
+		/*
+		 * LeagueStatus 가 COMPLETED 인데 League Participant 숫자가 0일 가능성은 없다.
+		 */
+		List<LeagueParticipant> leagueParticipantList =
+			leagueParticipantRepository.findAllByLeagueLeagueIdAndCanceledFalse(leagueId);
+		if (leagueParticipantList.isEmpty()) {
+			throw new InvalidPlayerCountException(leagueId, 0);
+		}
+		return leagueParticipantList;
+	}
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/FreeBracketGenerationServiceImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/FreeBracketGenerationServiceImpl.java
@@ -77,7 +77,7 @@ public class FreeBracketGenerationServiceImpl implements BracketGenerationServic
 	@Override
 	public void startMatch(MatchStrategy matchStrategy, Long leagueId, Long matchId) {
 		League league = leagueReader.readLeagueById(leagueId);
-		if (league.getLeagueAt().isBefore(LocalDateTime.now())) {
+		if (LocalDateTime.now().isBefore(league.getLeagueAt())) {
 			throw new CannotStartMatchException(league.getLeagueId(), league.getLeagueAt());
 		}
 		matchStrategy.startMatch(matchId);

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentBracketGenerationServiceImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentBracketGenerationServiceImpl.java
@@ -81,7 +81,7 @@ public class TournamentBracketGenerationServiceImpl implements BracketGeneration
 	@Override
 	public void startMatch(MatchStrategy matchStrategy, Long leagueId, Long matchId) {
 		League league = leagueReader.readLeagueById(leagueId);
-		if (league.getLeagueAt().isBefore(LocalDateTime.now())) {
+		if (LocalDateTime.now().isBefore(league.getLeagueAt())) {
 			throw new CannotStartMatchException(league.getLeagueId(), league.getLeagueAt());
 		}
 		matchStrategy.startMatch(matchId);

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentBracketGenerationServiceImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentBracketGenerationServiceImpl.java
@@ -1,7 +1,9 @@
 package org.badminton.infrastructure.match.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+
+import org.badminton.domain.common.exception.league.CannotStartMatchException;
 import org.badminton.domain.common.exception.league.InvalidPlayerCountException;
 import org.badminton.domain.common.exception.league.NotLeagueOwnerException;
 import org.badminton.domain.common.exception.match.LeagueRecruitingMustBeCompletedWhenBracketGenerationException;
@@ -22,74 +24,80 @@ import org.badminton.infrastructure.match.strategy.TournamentSinglesMatchStrateg
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
 @RequiredArgsConstructor
 public class TournamentBracketGenerationServiceImpl implements BracketGenerationService {
 
-    private final LeagueReader leagueReader;
-    private final SinglesMatchReader singlesMatchReader;
-    private final DoublesMatchReader doublesMatchReader;
-    private final SinglesMatchStore singlesMatchStore;
-    private final DoublesMatchStore doublesMatchStore;
-    private final LeagueParticipantReader leagueParticipantReader;
+	private final LeagueReader leagueReader;
+	private final SinglesMatchReader singlesMatchReader;
+	private final DoublesMatchReader doublesMatchReader;
+	private final SinglesMatchStore singlesMatchStore;
+	private final DoublesMatchStore doublesMatchStore;
+	private final LeagueParticipantReader leagueParticipantReader;
 
-    @Override
-    public void checkLeagueRecruitingStatus(Long leagueId) {
-        League league = findLeague(leagueId);
-        /*
-         * 경기 상태가 COMPLETED 일 수 있는 상황
-         * 1. 모집 마감 날짜가 지났고, 모집 인원이 채워짐
-         * 2. 모집 마감 날짜가 지나지 않았지만, 경기 소유자가 모집 마감 상태로 변경(이때 최소 인원은 충족된다.)
-         * 3. 모집 마감 날짜가 지나지 않았지만, 모집 인원이 채워짐
-         */
-        if (league.getLeagueStatus() != LeagueStatus.RECRUITING_COMPLETED) {
-            throw new LeagueRecruitingMustBeCompletedWhenBracketGenerationException(leagueId, league.getLeagueStatus());
-        }
-    }
+	@Override
+	public void checkLeagueRecruitingStatus(Long leagueId) {
+		League league = findLeague(leagueId);
+		/*
+		 * 경기 상태가 COMPLETED 일 수 있는 상황
+		 * 1. 모집 마감 날짜가 지났고, 모집 인원이 채워짐
+		 * 2. 모집 마감 날짜가 지나지 않았지만, 경기 소유자가 모집 마감 상태로 변경(이때 최소 인원은 충족된다.)
+		 * 3. 모집 마감 날짜가 지나지 않았지만, 모집 인원이 채워짐
+		 */
+		if (league.getLeagueStatus() != LeagueStatus.RECRUITING_COMPLETED) {
+			throw new LeagueRecruitingMustBeCompletedWhenBracketGenerationException(leagueId, league.getLeagueStatus());
+		}
+	}
 
-    @Override
-    public MatchStrategy makeSinglesOrDoublesMatchStrategy(Long leagueId) {
-        League league = findLeague(leagueId);
-        return switch (league.getMatchType()) {
-            case SINGLES ->
-                    new TournamentSinglesMatchStrategy(singlesMatchReader, singlesMatchStore, leagueParticipantReader,
-                            leagueReader);
-            case DOUBLES ->
-                    new TournamentDoublesMatchStrategy(doublesMatchReader, doublesMatchStore, leagueParticipantReader,
-                            leagueReader);
-        };
-    }
+	@Override
+	public MatchStrategy makeSinglesOrDoublesMatchStrategy(Long leagueId) {
+		League league = findLeague(leagueId);
+		return switch (league.getMatchType()) {
+			case SINGLES ->
+				new TournamentSinglesMatchStrategy(singlesMatchReader, singlesMatchStore, leagueParticipantReader,
+					leagueReader);
+			case DOUBLES ->
+				new TournamentDoublesMatchStrategy(doublesMatchReader, doublesMatchStore, leagueParticipantReader,
+					leagueReader);
+		};
+	}
 
-    @Override
-    @Transactional
-    public BracketInfo makeBracket(MatchStrategy matchStrategy, Long leagueId, String memberToken) {
-        League league = findLeague(leagueId);
-        if (!league.getLeagueOwnerMemberToken().equals(memberToken)) {
-            throw new NotLeagueOwnerException(memberToken);
-        }
-        matchStrategy.checkDuplicateInitialBracket(leagueId);
+	@Override
+	@Transactional
+	public BracketInfo makeBracket(MatchStrategy matchStrategy, Long leagueId, String memberToken) {
+		League league = findLeague(leagueId);
+		if (!league.getLeagueOwnerMemberToken().equals(memberToken)) {
+			throw new NotLeagueOwnerException(memberToken);
+		}
+		matchStrategy.checkDuplicateInitialBracket(leagueId);
 
-        List<LeagueParticipant> leagueParticipantList = findLeagueParticipantList(leagueId);
+		List<LeagueParticipant> leagueParticipantList = findLeagueParticipantList(leagueId);
 
-        return matchStrategy.makeBracket(findLeague(leagueId), leagueParticipantList);
-    }
+		return matchStrategy.makeBracket(findLeague(leagueId), leagueParticipantList);
+	}
 
-    @Override
-    public void startMatch(MatchStrategy matchStrategy, Long matchId) {
-        matchStrategy.startMatch(matchId);
-    }
+	@Override
+	public void startMatch(MatchStrategy matchStrategy, Long leagueId, Long matchId) {
+		League league = leagueReader.readLeagueById(leagueId);
+		if (league.getLeagueAt().isBefore(LocalDateTime.now())) {
+			throw new CannotStartMatchException(league.getLeagueId(), league.getLeagueAt());
+		}
+		matchStrategy.startMatch(matchId);
+	}
 
-    private League findLeague(Long leagueId) {
-        return leagueReader.readLeagueById(leagueId);
-    }
+	private League findLeague(Long leagueId) {
+		return leagueReader.readLeagueById(leagueId);
+	}
 
-    private List<LeagueParticipant> findLeagueParticipantList(Long leagueId) {
+	private List<LeagueParticipant> findLeagueParticipantList(Long leagueId) {
 
-        List<LeagueParticipant> leagueParticipantList =
-                leagueParticipantReader.findAllByLeagueIdAndCanceledFalse(leagueId);
-        if (leagueParticipantList.isEmpty()) {
-            throw new InvalidPlayerCountException(leagueId, 0);
-        }
-        return leagueParticipantList;
-    }
+		List<LeagueParticipant> leagueParticipantList =
+			leagueParticipantReader.findAllByLeagueIdAndCanceledFalse(leagueId);
+		if (leagueParticipantList.isEmpty()) {
+			throw new InvalidPlayerCountException(leagueId, 0);
+		}
+		return leagueParticipantList;
+	}
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/FreeDoublesMatchStrategy.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/FreeDoublesMatchStrategy.java
@@ -3,7 +3,7 @@ package org.badminton.infrastructure.match.strategy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
+
 import org.badminton.domain.common.enums.MatchResult;
 import org.badminton.domain.common.enums.SetStatus;
 import org.badminton.domain.common.exception.match.AlreadyWinnerDeterminedException;
@@ -23,131 +23,124 @@ import org.badminton.domain.domain.match.service.AbstractDoublesMatchStrategy;
 import org.badminton.domain.domain.match.store.DoublesMatchReader;
 import org.springframework.stereotype.Component;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @Component
 public class FreeDoublesMatchStrategy extends AbstractDoublesMatchStrategy {
-    static final Integer LIMIT_SET_GAME = 3;
+	static final Integer LIMIT_SET_GAME = 3;
 
-    private final DoublesMatchReader doublesMatchReader;
-    private final DoublesMatchStore doublesMatchStore;
-    private final LeagueReader leagueReader;
+	private final DoublesMatchReader doublesMatchReader;
+	private final DoublesMatchStore doublesMatchStore;
+	private final LeagueReader leagueReader;
 
-    public FreeDoublesMatchStrategy(DoublesMatchReader doublesMatchReader, DoublesMatchStore doublesMatchStore,
-                                    LeagueReader leagueReader) {
-        super(doublesMatchReader);
-        this.doublesMatchReader = doublesMatchReader;
-        this.doublesMatchStore = doublesMatchStore;
-        this.leagueReader = leagueReader;
-    }
+	public FreeDoublesMatchStrategy(DoublesMatchReader doublesMatchReader, DoublesMatchStore doublesMatchStore,
+		LeagueReader leagueReader) {
+		super(doublesMatchReader, doublesMatchStore);
+		this.doublesMatchReader = doublesMatchReader;
+		this.doublesMatchStore = doublesMatchStore;
+		this.leagueReader = leagueReader;
+	}
 
-    private static boolean isMatchWinnerDetermined(DoublesMatch doublesMatch) {
-        return doublesMatch.getTeam1MatchResult() == MatchResult.WIN
-                || doublesMatch.getTeam2MatchResult() == MatchResult.WIN;
-    }
+	private static boolean isMatchWinnerDetermined(DoublesMatch doublesMatch) {
+		return doublesMatch.getTeam1MatchResult() == MatchResult.WIN
+			|| doublesMatch.getTeam2MatchResult() == MatchResult.WIN;
+	}
 
-    @Override
-    public BracketInfo makeBracket(League league,
-                                   List<LeagueParticipant> leagueParticipantList) {
-        Collections.shuffle(leagueParticipantList);
-        List<DoublesMatch> doublesMatches = makeDoublesMatches(leagueParticipantList, league, 1);
-        doublesMatches.forEach(this::makeDoublesSetsInMatch);
-        return BracketInfo.fromDoubles(1, doublesMatches);
-    }
+	@Override
+	public BracketInfo makeBracket(League league,
+		List<LeagueParticipant> leagueParticipantList) {
+		Collections.shuffle(leagueParticipantList);
+		List<DoublesMatch> doublesMatches = makeDoublesMatches(leagueParticipantList, league, 1);
+		doublesMatches.forEach(this::makeDoublesSetsInMatch);
+		return BracketInfo.fromDoubles(1, doublesMatches);
+	}
 
-    @Override
-    public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
-                                                MatchCommand.UpdateSetScore updateSetScoreCommand) {
-        DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
+	@Override
+	public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
+		MatchCommand.UpdateSetScore updateSetScoreCommand) {
+		DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
 
-        if (isMatchWinnerDetermined(doublesMatch)) {
-            throw new AlreadyWinnerDeterminedException(doublesMatch.getId());
-        }
+		if (isMatchWinnerDetermined(doublesMatch)) {
+			throw new AlreadyWinnerDeterminedException(doublesMatch.getId());
+		}
 
-        if (doublesMatch.getDoublesSet(setNumber).getSetStatus() == SetStatus.FINISHED) {
-            throw new SetFinishedException(setNumber);
-        }
+		if (doublesMatch.getDoublesSet(setNumber).getSetStatus() == SetStatus.FINISHED) {
+			throw new SetFinishedException(setNumber);
+		}
 
-        doublesMatch.getDoublesSet(setNumber)
-                .endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
+		doublesMatch.getDoublesSet(setNumber)
+			.endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
 
-        if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
-            doublesMatch.team1WinSet();
-        } else {
-            doublesMatch.team2WinSet();
-        }
+		if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
+			doublesMatch.team1WinSet();
+		} else {
+			doublesMatch.team2WinSet();
+		}
 
-        if (LIMIT_SET_GAME > setNumber) {
-            changeNextSetStatus(doublesMatch, setNumber);
-        }
+		if (LIMIT_SET_GAME > setNumber) {
+			changeNextSetStatus(doublesMatch, setNumber);
+		}
 
-        if (isAllMatchFinished(doublesMatch)) {
-            leagueReader.readLeagueById(doublesMatch.getLeague().getLeagueId()).finishLeague();
-        }
+		if (isAllMatchFinished(doublesMatch)) {
+			leagueReader.readLeagueById(doublesMatch.getLeague().getLeagueId()).finishLeague();
+		}
 
-        doublesMatchStore.store(doublesMatch);
-        return SetInfo.fromDoublesSet(matchId, setNumber, doublesMatch.getDoublesSets().get(setNumber - 1));
-    }
+		doublesMatchStore.store(doublesMatch);
+		return SetInfo.fromDoublesSet(matchId, setNumber, doublesMatch.getDoublesSets().get(setNumber - 1));
+	}
 
-    private void changeNextSetStatus(DoublesMatch doublesMatch, Integer setNumber) {
-        setNumber++;
-        if (doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
-            doublesMatch.getDoublesSet(setNumber).open();
-        }
-        if (!doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
-            doublesMatch.getDoublesSet(setNumber).close();
-        }
-    }
+	private void changeNextSetStatus(DoublesMatch doublesMatch, Integer setNumber) {
+		setNumber++;
+		if (doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
+			doublesMatch.getDoublesSet(setNumber).open();
+		}
+		if (!doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
+			doublesMatch.getDoublesSet(setNumber).close();
+		}
+	}
 
-    private boolean isAllMatchFinished(DoublesMatch doublesMatch) {
-        return doublesMatchReader.allMatchesFinishedForLeague(
-                doublesMatch.getLeague().getLeagueId());
-    }
+	private boolean isAllMatchFinished(DoublesMatch doublesMatch) {
+		return doublesMatchReader.allMatchesFinishedForLeague(
+			doublesMatch.getLeague().getLeagueId());
+	}
 
-    @Override
-    public SetInfo.Main retrieveSet(Long matchId, int setNumber) {
-        DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
-        DoublesSet doublesSet = doublesMatch.getDoublesSet(setNumber);
-        return SetInfo.fromDoublesSet(matchId, setNumber, doublesSet);
-    }
+	@Override
+	public SetInfo.Main retrieveSet(Long matchId, int setNumber) {
+		DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
+		DoublesSet doublesSet = doublesMatch.getDoublesSet(setNumber);
+		return SetInfo.fromDoublesSet(matchId, setNumber, doublesSet);
+	}
 
-    @Override
-    public void checkDuplicateInitialBracket(Long leagueId) {
-        boolean isBracketEmpty = doublesMatchReader.checkIfBracketEmpty(leagueId);
+	@Override
+	public void checkDuplicateInitialBracket(Long leagueId) {
+		boolean isBracketEmpty = doublesMatchReader.checkIfBracketEmpty(leagueId);
 
-        if (!isBracketEmpty && doublesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
-            doublesMatchStore.deleteDoublesBracket(leagueId);
-        } else if (!isBracketEmpty && !doublesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
-            throw new MatchDuplicateException(leagueId);
-        }
-    }
+		if (!isBracketEmpty && doublesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
+			doublesMatchStore.deleteDoublesBracket(leagueId);
+		} else if (!isBracketEmpty && !doublesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
+			throw new MatchDuplicateException(leagueId);
+		}
+	}
 
-    private void makeDoublesSetsInMatch(DoublesMatch doublesMatch) {
-        for (int i = 1; i <= 3; i++) {
-            doublesMatch.addSet(new DoublesSet(doublesMatch, i));
-        }
-        doublesMatchStore.store(doublesMatch);
-    }
+	private void makeDoublesSetsInMatch(DoublesMatch doublesMatch) {
+		for (int i = 1; i <= 3; i++) {
+			doublesMatch.addSet(new DoublesSet(doublesMatch, i));
+		}
+		doublesMatchStore.store(doublesMatch);
+	}
 
-    private List<DoublesMatch> makeDoublesMatches(List<LeagueParticipant> leagueParticipantList,
-                                                  League league, int roundNumber) {
+	private List<DoublesMatch> makeDoublesMatches(List<LeagueParticipant> leagueParticipantList,
+		League league, int roundNumber) {
 
-        List<DoublesMatch> doublesMatches = new ArrayList<>();
-        for (int i = 0; i < leagueParticipantList.size() - 3; i += 4) {
-            Team team1 = new Team(leagueParticipantList.get(i), leagueParticipantList.get(i + 1));
-            Team team2 = new Team(leagueParticipantList.get(i + 2), leagueParticipantList.get(i + 3));
-            DoublesMatch doublesMatch = new DoublesMatch(league, team1, team2, roundNumber);
-            doublesMatches.add(doublesMatch);
-            doublesMatchStore.store(doublesMatch);
-        }
-        return doublesMatches;
-    }
-
-    @Override
-    public void startMatch(Long matchId) {
-        DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
-        doublesMatch.startMatch();
-        doublesMatch.getDoublesSet(1).startSet();
-        doublesMatchStore.store(doublesMatch);
-    }
-
+		List<DoublesMatch> doublesMatches = new ArrayList<>();
+		for (int i = 0; i < leagueParticipantList.size() - 3; i += 4) {
+			Team team1 = new Team(leagueParticipantList.get(i), leagueParticipantList.get(i + 1));
+			Team team2 = new Team(leagueParticipantList.get(i + 2), leagueParticipantList.get(i + 3));
+			DoublesMatch doublesMatch = new DoublesMatch(league, team1, team2, roundNumber);
+			doublesMatches.add(doublesMatch);
+			doublesMatchStore.store(doublesMatch);
+		}
+		return doublesMatches;
+	}
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/FreeSinglesMatchStrategy.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/FreeSinglesMatchStrategy.java
@@ -3,7 +3,7 @@ package org.badminton.infrastructure.match.strategy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
+
 import org.badminton.domain.common.enums.MatchResult;
 import org.badminton.domain.common.enums.MatchStatus;
 import org.badminton.domain.common.enums.SetStatus;
@@ -24,134 +24,127 @@ import org.badminton.domain.domain.match.service.AbstractSinglesMatchStrategy;
 import org.badminton.domain.domain.match.store.SinglesMatchReader;
 import org.springframework.stereotype.Component;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @Component
 public class FreeSinglesMatchStrategy extends AbstractSinglesMatchStrategy {
-    static final Integer LIMIT_SET_GAME = 3;
+	static final Integer LIMIT_SET_GAME = 3;
 
-    private final SinglesMatchReader singlesMatchReader;
-    private final SinglesMatchStore singlesMatchStore;
-    private final LeagueReader leagueReader;
+	private final SinglesMatchReader singlesMatchReader;
+	private final SinglesMatchStore singlesMatchStore;
+	private final LeagueReader leagueReader;
 
-    public FreeSinglesMatchStrategy(SinglesMatchReader singlesMatchReader, SinglesMatchStore singlesMatchStore,
-                                    LeagueReader leagueReader) {
-        super(singlesMatchReader);
-        this.singlesMatchReader = singlesMatchReader;
-        this.singlesMatchStore = singlesMatchStore;
-        this.leagueReader = leagueReader;
-    }
+	public FreeSinglesMatchStrategy(SinglesMatchReader singlesMatchReader, SinglesMatchStore singlesMatchStore,
+		LeagueReader leagueReader) {
+		super(singlesMatchReader, singlesMatchStore);
+		this.singlesMatchReader = singlesMatchReader;
+		this.singlesMatchStore = singlesMatchStore;
+		this.leagueReader = leagueReader;
+	}
 
-    private static boolean isMatchWinnerDetermined(SinglesMatch singlesMatch) {
-        return singlesMatch.getPlayer1MatchResult() == MatchResult.WIN
-                || singlesMatch.getPlayer2MatchResult() == MatchResult.WIN;
-    }
+	private static boolean isMatchWinnerDetermined(SinglesMatch singlesMatch) {
+		return singlesMatch.getPlayer1MatchResult() == MatchResult.WIN
+			|| singlesMatch.getPlayer2MatchResult() == MatchResult.WIN;
+	}
 
-    private static boolean isMatchFinished(SinglesMatch singlesMatch) {
-        return singlesMatch.getMatchStatus() == MatchStatus.FINISHED;
-    }
+	private static boolean isMatchFinished(SinglesMatch singlesMatch) {
+		return singlesMatch.getMatchStatus() == MatchStatus.FINISHED;
+	}
 
-    @Override
-    public BracketInfo makeBracket(League league,
-                                   List<LeagueParticipant> leagueParticipantList) {
-        Collections.shuffle(leagueParticipantList);
-        List<SinglesMatch> singlesMatches = makeSinglesMatches(leagueParticipantList, league, 1);
-        singlesMatches.forEach(this::makeSetsInMatch);
-        return BracketInfo.fromSingles(1, singlesMatches);
-    }
+	@Override
+	public BracketInfo makeBracket(League league,
+		List<LeagueParticipant> leagueParticipantList) {
+		Collections.shuffle(leagueParticipantList);
+		List<SinglesMatch> singlesMatches = makeSinglesMatches(leagueParticipantList, league, 1);
+		singlesMatches.forEach(this::makeSetsInMatch);
+		return BracketInfo.fromSingles(1, singlesMatches);
+	}
 
-    @Override
-    public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
-                                                MatchCommand.UpdateSetScore updateSetScoreCommand) {
-        SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
+	@Override
+	public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
+		MatchCommand.UpdateSetScore updateSetScoreCommand) {
+		SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
 
-        if (isMatchWinnerDetermined(singlesMatch)) {
-            throw new AlreadyWinnerDeterminedException(singlesMatch.getId());
-        }
+		if (isMatchWinnerDetermined(singlesMatch)) {
+			throw new AlreadyWinnerDeterminedException(singlesMatch.getId());
+		}
 
-        if (singlesMatch.getSinglesSet(setNumber).getSetStatus() == SetStatus.FINISHED) {
-            throw new SetFinishedException(setNumber);
-        }
+		if (singlesMatch.getSinglesSet(setNumber).getSetStatus() == SetStatus.FINISHED) {
+			throw new SetFinishedException(setNumber);
+		}
 
-        singlesMatch.getSinglesSet(setNumber)
-                .endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
+		singlesMatch.getSinglesSet(setNumber)
+			.endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
 
-        if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
-            singlesMatch.player1WinSet();
-        } else {
-            singlesMatch.player2WinSet();
-        }
+		if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
+			singlesMatch.player1WinSet();
+		} else {
+			singlesMatch.player2WinSet();
+		}
 
-        if (LIMIT_SET_GAME > setNumber) {
-            changeNextSetStatus(singlesMatch, setNumber);
-        }
+		if (LIMIT_SET_GAME > setNumber) {
+			changeNextSetStatus(singlesMatch, setNumber);
+		}
 
 		if (isAllMatchFinished(singlesMatch)) {
 			leagueReader.readLeagueById(singlesMatch.getLeague().getLeagueId()).finishLeague();
 		}
 
-        singlesMatchStore.store(singlesMatch);
-        return SetInfo.fromSinglesSet(matchId, setNumber, singlesMatch.getSinglesSets().get(setNumber - 1));
-    }
+		singlesMatchStore.store(singlesMatch);
+		return SetInfo.fromSinglesSet(matchId, setNumber, singlesMatch.getSinglesSets().get(setNumber - 1));
+	}
 
-    private void changeNextSetStatus(SinglesMatch singlesMatch, Integer setNumber) {
-        setNumber++;
+	private void changeNextSetStatus(SinglesMatch singlesMatch, Integer setNumber) {
+		setNumber++;
 		if (singlesMatch.getPlayer1MatchResult().equals(MatchResult.NONE)) {
 			singlesMatch.getSinglesSet(setNumber).open();
 		}
 		if (!singlesMatch.getPlayer1MatchResult().equals(MatchResult.NONE)) {
 			singlesMatch.getSinglesSet(setNumber).close();
 		}
-    }
+	}
 
-    private boolean isAllMatchFinished(SinglesMatch singlesMatch) {
-        return singlesMatchReader.allMatchesFinishedForLeague(
-                singlesMatch.getLeague().getLeagueId());
-    }
+	private boolean isAllMatchFinished(SinglesMatch singlesMatch) {
+		return singlesMatchReader.allMatchesFinishedForLeague(
+			singlesMatch.getLeague().getLeagueId());
+	}
 
-    @Override
-    public Main retrieveSet(Long matchId, int setNumber) {
-        SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
-        SinglesSet singlesSet = singlesMatch.getSinglesSet(1);
-        return SetInfo.fromSinglesSet(matchId, setNumber, singlesSet);
-    }
+	@Override
+	public Main retrieveSet(Long matchId, int setNumber) {
+		SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
+		SinglesSet singlesSet = singlesMatch.getSinglesSet(1);
+		return SetInfo.fromSinglesSet(matchId, setNumber, singlesSet);
+	}
 
-    @Override
-    public void checkDuplicateInitialBracket(Long leagueId) {
-        boolean isBracketEmpty = singlesMatchReader.checkIfBracketEmpty(leagueId);
+	@Override
+	public void checkDuplicateInitialBracket(Long leagueId) {
+		boolean isBracketEmpty = singlesMatchReader.checkIfBracketEmpty(leagueId);
 
-        if (!isBracketEmpty && singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
-            singlesMatchStore.deleteSinglesBracket(leagueId);
-        } else if (!isBracketEmpty && !singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
-            throw new MatchDuplicateException(leagueId);
-        }
-    }
+		if (!isBracketEmpty && singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
+			singlesMatchStore.deleteSinglesBracket(leagueId);
+		} else if (!isBracketEmpty && !singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
+			throw new MatchDuplicateException(leagueId);
+		}
+	}
 
-    private void makeSetsInMatch(SinglesMatch singlesMatch) {
-        for (int i = 1; i <= 3; i++) {
-            singlesMatch.addSet(new SinglesSet(singlesMatch, i));
-        }
-        singlesMatchStore.store(singlesMatch);
-    }
+	private void makeSetsInMatch(SinglesMatch singlesMatch) {
+		for (int i = 1; i <= 3; i++) {
+			singlesMatch.addSet(new SinglesSet(singlesMatch, i));
+		}
+		singlesMatchStore.store(singlesMatch);
+	}
 
-    private List<SinglesMatch> makeSinglesMatches(List<LeagueParticipant> leagueParticipantList,
-                                                  League league, int roundNumber) {
+	private List<SinglesMatch> makeSinglesMatches(List<LeagueParticipant> leagueParticipantList,
+		League league, int roundNumber) {
 
-        List<SinglesMatch> singlesMatches = new ArrayList<>();
-        for (int i = 0; i < leagueParticipantList.size() - 1; i += 2) {
-            SinglesMatch singlesMatch = new SinglesMatch(league, leagueParticipantList.get(i),
-                    leagueParticipantList.get(i + 1), roundNumber);
-            singlesMatches.add(singlesMatch);
-            singlesMatchStore.store(singlesMatch);
-        }
-        return singlesMatches;
-    }
-
-    public void startMatch(Long matchId) {
-        SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
-        singlesMatch.startMatch();
-        singlesMatch.getSinglesSet(1).initMatch();
-        singlesMatchStore.store(singlesMatch);
-    }
-
+		List<SinglesMatch> singlesMatches = new ArrayList<>();
+		for (int i = 0; i < leagueParticipantList.size() - 1; i += 2) {
+			SinglesMatch singlesMatch = new SinglesMatch(league, leagueParticipantList.get(i),
+				leagueParticipantList.get(i + 1), roundNumber);
+			singlesMatches.add(singlesMatch);
+			singlesMatchStore.store(singlesMatch);
+		}
+		return singlesMatches;
+	}
 }
-

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/TournamentDoublesMatchStrategy.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/TournamentDoublesMatchStrategy.java
@@ -3,7 +3,7 @@ package org.badminton.infrastructure.match.strategy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
+
 import org.badminton.domain.common.enums.MatchResult;
 import org.badminton.domain.common.enums.SetStatus;
 import org.badminton.domain.common.exception.match.AlreadyWinnerDeterminedException;
@@ -27,224 +27,217 @@ import org.badminton.domain.domain.match.store.DoublesMatchReader;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @Component
 public class TournamentDoublesMatchStrategy extends AbstractDoublesMatchStrategy {
 
-    public static final int SET_COUNT = 3;
-    public static final int PARTICIPANTS_PER_TEAM = 2;
-    public static final int TEAMS_PER_MATCH = 2;
-    static final Integer LIMIT_SET_GAME = 3;
-    private final DoublesMatchReader doublesMatchReader;
-    private final DoublesMatchStore doublesMatchStore;
-    private final LeagueParticipantReader leagueParticipantReader;
-    private final LeagueReader leagueReader;
+	public static final int SET_COUNT = 3;
+	public static final int PARTICIPANTS_PER_TEAM = 2;
+	public static final int TEAMS_PER_MATCH = 2;
+	static final Integer LIMIT_SET_GAME = 3;
+	private final DoublesMatchReader doublesMatchReader;
+	private final DoublesMatchStore doublesMatchStore;
+	private final LeagueParticipantReader leagueParticipantReader;
+	private final LeagueReader leagueReader;
 
-    public TournamentDoublesMatchStrategy(DoublesMatchReader doublesMatchReader, DoublesMatchStore doublesMatchStore,
-                                          LeagueParticipantReader leagueParticipantReader, LeagueReader leagueReader) {
-        super(doublesMatchReader);
-        this.doublesMatchReader = doublesMatchReader;
-        this.doublesMatchStore = doublesMatchStore;
-        this.leagueParticipantReader = leagueParticipantReader;
-        this.leagueReader = leagueReader;
-    }
+	public TournamentDoublesMatchStrategy(DoublesMatchReader doublesMatchReader, DoublesMatchStore doublesMatchStore,
+		LeagueParticipantReader leagueParticipantReader, LeagueReader leagueReader) {
+		super(doublesMatchReader, doublesMatchStore);
+		this.doublesMatchReader = doublesMatchReader;
+		this.doublesMatchStore = doublesMatchStore;
+		this.leagueParticipantReader = leagueParticipantReader;
+		this.leagueReader = leagueReader;
+	}
 
-    private static boolean isMatchWinnerDetermined(DoublesMatch doublesMatch) {
-        return doublesMatch.getTeam1MatchResult() == MatchResult.WIN
-                || doublesMatch.getTeam2MatchResult() == MatchResult.WIN;
-    }
+	private static boolean isMatchWinnerDetermined(DoublesMatch doublesMatch) {
+		return doublesMatch.getTeam1MatchResult() == MatchResult.WIN
+			|| doublesMatch.getTeam2MatchResult() == MatchResult.WIN;
+	}
 
-    @Override
-    public BracketInfo makeBracket(League league, List<LeagueParticipant> leagueParticipantList) {
-        List<DoublesMatch> allMatches = new ArrayList<>();
-        List<LeagueParticipant> currentParticipants = new ArrayList<>(leagueParticipantList);
-        Collections.shuffle(currentParticipants);
+	@Override
+	public BracketInfo makeBracket(League league, List<LeagueParticipant> leagueParticipantList) {
+		List<DoublesMatch> allMatches = new ArrayList<>();
+		List<LeagueParticipant> currentParticipants = new ArrayList<>(leagueParticipantList);
+		Collections.shuffle(currentParticipants);
 
-        int totalRounds = MatchUtils.calculateTotalRounds(currentParticipants.size() / PARTICIPANTS_PER_TEAM);
-        league.defineTotalRounds(totalRounds);
+		int totalRounds = MatchUtils.calculateTotalRounds(currentParticipants.size() / PARTICIPANTS_PER_TEAM);
+		league.defineTotalRounds(totalRounds);
 
-        allMatches.addAll(createFirstRoundMatches(league, currentParticipants));
-        allMatches.addAll(createSubsequentRoundsMatches(league, totalRounds));
+		allMatches.addAll(createFirstRoundMatches(league, currentParticipants));
+		allMatches.addAll(createSubsequentRoundsMatches(league, totalRounds));
 
-        return BracketInfo.fromDoubles(totalRounds, allMatches);
-    }
+		return BracketInfo.fromDoubles(totalRounds, allMatches);
+	}
 
-    @Override
-    public void checkDuplicateInitialBracket(Long leagueId) {
-        boolean isBracketEmpty = doublesMatchReader.checkIfBracketEmpty(leagueId);
+	@Override
+	public void checkDuplicateInitialBracket(Long leagueId) {
+		boolean isBracketEmpty = doublesMatchReader.checkIfBracketEmpty(leagueId);
 
-        if (!isBracketEmpty && doublesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
-            doublesMatchStore.deleteDoublesBracket(leagueId);
-        } else if (!isBracketEmpty && !doublesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
-            throw new MatchDuplicateException(leagueId);
-        }
-    }
+		if (!isBracketEmpty && doublesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
+			doublesMatchStore.deleteDoublesBracket(leagueId);
+		} else if (!isBracketEmpty && !doublesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
+			throw new MatchDuplicateException(leagueId);
+		}
+	}
 
-    @Override
-    @Transactional
-    public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
-                                                MatchCommand.UpdateSetScore updateSetScoreCommand) {
-        DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
+	@Override
+	@Transactional
+	public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
+		MatchCommand.UpdateSetScore updateSetScoreCommand) {
+		DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
 
-        if (isMatchWinnerDetermined(doublesMatch)) {
-            throw new AlreadyWinnerDeterminedException(doublesMatch.getId());
-        }
+		if (isMatchWinnerDetermined(doublesMatch)) {
+			throw new AlreadyWinnerDeterminedException(doublesMatch.getId());
+		}
 
-        if (doublesMatch.getDoublesSet(setNumber).getSetStatus() == SetStatus.FINISHED) {
-            throw new SetFinishedException(setNumber);
-        }
+		if (doublesMatch.getDoublesSet(setNumber).getSetStatus() == SetStatus.FINISHED) {
+			throw new SetFinishedException(setNumber);
+		}
 
-        if (doublesMatch.getTeam1() == null || doublesMatch.getTeam2() == null) {
-            throw new LeagueParticipantsNotExistsException(matchId);
-        }
+		if (doublesMatch.getTeam1() == null || doublesMatch.getTeam2() == null) {
+			throw new LeagueParticipantsNotExistsException(matchId);
+		}
 
-        updateSetScore(doublesMatch, setNumber, updateSetScoreCommand);
-        doublesMatchStore.store(doublesMatch);
+		updateSetScore(doublesMatch, setNumber, updateSetScoreCommand);
+		doublesMatchStore.store(doublesMatch);
 
-        if (LIMIT_SET_GAME > setNumber) {
-            changeNextSetStatus(doublesMatch, setNumber);
-        }
+		if (LIMIT_SET_GAME > setNumber) {
+			changeNextSetStatus(doublesMatch, setNumber);
+		}
 
-        if (isMatchWinnerDetermined(doublesMatch)) {
-            doublesMatchStore.store(doublesMatch);
-            updateNextRoundMatch(doublesMatch);
-        }
-        if (isAllMatchFinished(doublesMatch)) {
-            leagueReader.readLeagueById(doublesMatch.getLeague().getLeagueId()).finishLeague();
-        }
+		if (isMatchWinnerDetermined(doublesMatch)) {
+			doublesMatchStore.store(doublesMatch);
+			updateNextRoundMatch(doublesMatch);
+		}
+		if (isAllMatchFinished(doublesMatch)) {
+			leagueReader.readLeagueById(doublesMatch.getLeague().getLeagueId()).finishLeague();
+		}
 
-        return SetInfo.fromDoublesSet(matchId, setNumber, doublesMatch.getDoublesSets().get(setNumber - 1));
-    }
+		return SetInfo.fromDoublesSet(matchId, setNumber, doublesMatch.getDoublesSets().get(setNumber - 1));
+	}
 
-    private void changeNextSetStatus(DoublesMatch doublesMatch, Integer setNumber) {
-        setNumber++;
-        if (doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
-            doublesMatch.getDoublesSet(setNumber).open();
-        }
-        if (!doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
-            doublesMatch.getDoublesSet(setNumber).close();
-        }
-    }
+	private void changeNextSetStatus(DoublesMatch doublesMatch, Integer setNumber) {
+		setNumber++;
+		if (doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
+			doublesMatch.getDoublesSet(setNumber).open();
+		}
+		if (!doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
+			doublesMatch.getDoublesSet(setNumber).close();
+		}
+	}
 
-    private boolean isAllMatchFinished(DoublesMatch doublesMatch) {
-        return doublesMatchReader.allMatchesFinishedForLeague(
-                doublesMatch.getLeague().getLeagueId());
-    }
+	private boolean isAllMatchFinished(DoublesMatch doublesMatch) {
+		return doublesMatchReader.allMatchesFinishedForLeague(
+			doublesMatch.getLeague().getLeagueId());
+	}
 
-    @Override
-    public Main retrieveSet(Long matchId, int setNumber) {
-        DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
-        DoublesSet doublesSet = doublesMatch.getDoublesSet(setNumber);
-        return SetInfo.fromDoublesSet(matchId, setNumber, doublesSet);
-    }
+	@Override
+	public Main retrieveSet(Long matchId, int setNumber) {
+		DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
+		DoublesSet doublesSet = doublesMatch.getDoublesSet(setNumber);
+		return SetInfo.fromDoublesSet(matchId, setNumber, doublesSet);
+	}
 
-    private List<DoublesMatch> createFirstRoundMatches(League league, List<LeagueParticipant> participants) {
-        List<DoublesMatch> matches = new ArrayList<>();
-        for (int i = 0; i < participants.size(); i += PARTICIPANTS_PER_TEAM * TEAMS_PER_MATCH) {
-            Team team1 = new Team(participants.get(i), participants.get(i + 1));
-            Team team2 = new Team(participants.get(i + 2), participants.get(i + 3));
-            DoublesMatch match = new DoublesMatch(league, team1, team2, 1);
-            makeSetsInMatch(match);
-            doublesMatchStore.store(match);
-            matches.add(match);
-        }
-        return matches;
-    }
+	private List<DoublesMatch> createFirstRoundMatches(League league, List<LeagueParticipant> participants) {
+		List<DoublesMatch> matches = new ArrayList<>();
+		for (int i = 0; i < participants.size(); i += PARTICIPANTS_PER_TEAM * TEAMS_PER_MATCH) {
+			Team team1 = new Team(participants.get(i), participants.get(i + 1));
+			Team team2 = new Team(participants.get(i + 2), participants.get(i + 3));
+			DoublesMatch match = new DoublesMatch(league, team1, team2, 1);
+			makeSetsInMatch(match);
+			doublesMatchStore.store(match);
+			matches.add(match);
+		}
+		return matches;
+	}
 
-    private List<DoublesMatch> createRoundMatches(League league, List<DoublesMatch> previousMatches, int roundNumber) {
-        List<DoublesMatch> currentRoundMatches = new ArrayList<>();
-        for (int i = 0; i < previousMatches.size(); i += TEAMS_PER_MATCH) {
-            DoublesMatch match = new DoublesMatch(league, null, null, roundNumber);
-            makeSetsInMatch(match);
-            doublesMatchStore.store(match);
-            currentRoundMatches.add(match);
-        }
-        return currentRoundMatches;
-    }
+	private List<DoublesMatch> createRoundMatches(League league, List<DoublesMatch> previousMatches, int roundNumber) {
+		List<DoublesMatch> currentRoundMatches = new ArrayList<>();
+		for (int i = 0; i < previousMatches.size(); i += TEAMS_PER_MATCH) {
+			DoublesMatch match = new DoublesMatch(league, null, null, roundNumber);
+			makeSetsInMatch(match);
+			doublesMatchStore.store(match);
+			currentRoundMatches.add(match);
+		}
+		return currentRoundMatches;
+	}
 
-    private List<DoublesMatch> createSubsequentRoundsMatches(League league, int totalRounds) {
-        List<DoublesMatch> matches = new ArrayList<>();
-        List<DoublesMatch> previousMatches = doublesMatchReader.findMatchesByLeagueAndRound(league.getLeagueId(), 1);
+	private List<DoublesMatch> createSubsequentRoundsMatches(League league, int totalRounds) {
+		List<DoublesMatch> matches = new ArrayList<>();
+		List<DoublesMatch> previousMatches = doublesMatchReader.findMatchesByLeagueAndRound(league.getLeagueId(), 1);
 
-        for (int roundNumber = 2; roundNumber <= totalRounds; roundNumber++) {
-            List<DoublesMatch> currentRoundMatches = createRoundMatches(league, previousMatches, roundNumber);
-            matches.addAll(currentRoundMatches);
-            previousMatches = currentRoundMatches;
-        }
+		for (int roundNumber = 2; roundNumber <= totalRounds; roundNumber++) {
+			List<DoublesMatch> currentRoundMatches = createRoundMatches(league, previousMatches, roundNumber);
+			matches.addAll(currentRoundMatches);
+			previousMatches = currentRoundMatches;
+		}
 
-        return matches;
-    }
+		return matches;
+	}
 
-    private void makeSetsInMatch(DoublesMatch doublesMatch) {
-        for (int i = 1; i <= SET_COUNT; i++) {
-            DoublesSet set = new DoublesSet(doublesMatch, i);
-            doublesMatch.addSet(set);
-        }
-        doublesMatchStore.store(doublesMatch);
-    }
+	private void makeSetsInMatch(DoublesMatch doublesMatch) {
+		for (int i = 1; i <= SET_COUNT; i++) {
+			DoublesSet set = new DoublesSet(doublesMatch, i);
+			doublesMatch.addSet(set);
+		}
+		doublesMatchStore.store(doublesMatch);
+	}
 
-    private void updateSetScore(DoublesMatch doublesMatch, int setIndex,
-                                MatchCommand.UpdateSetScore updateSetScoreCommand) {
-        DoublesSet set = doublesMatch.getDoublesSet(setIndex);
-        set.endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
+	private void updateSetScore(DoublesMatch doublesMatch, int setIndex,
+		MatchCommand.UpdateSetScore updateSetScoreCommand) {
+		DoublesSet set = doublesMatch.getDoublesSet(setIndex);
+		set.endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
 
-        if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
-            doublesMatch.team1WinSet();
-        } else {
-            doublesMatch.team2WinSet();
-        }
-    }
+		if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
+			doublesMatch.team1WinSet();
+		} else {
+			doublesMatch.team2WinSet();
+		}
+	}
 
-    private void updateNextRoundMatch(DoublesMatch doublesMatch) {
-        Team winner = determineWinner(doublesMatch);
-        if (winner == null) {
-            return;
-        }
-        int totalRounds = doublesMatch.getLeague().getTotalRounds();
-        if (doublesMatch.getRoundNumber() == totalRounds) {
-            return;
-        }
+	private void updateNextRoundMatch(DoublesMatch doublesMatch) {
+		Team winner = determineWinner(doublesMatch);
+		if (winner == null) {
+			return;
+		}
+		int totalRounds = doublesMatch.getLeague().getTotalRounds();
+		if (doublesMatch.getRoundNumber() == totalRounds) {
+			return;
+		}
 
-        DoublesMatch startMatch = doublesMatchReader.findFirstMatchByLeagueId(
-                doublesMatch.getLeague().getLeagueId());
+		DoublesMatch startMatch = doublesMatchReader.findFirstMatchByLeagueId(
+			doublesMatch.getLeague().getLeagueId());
 
-        int nextRoundMatchId = MatchUtils.calculateNextRoundMatchId(Math.toIntExact(doublesMatch.getId()),
-                leagueParticipantReader.countParticipantMember(doublesMatch.getLeague().getLeagueId())
-                        / PARTICIPANTS_PER_TEAM,
-                Math.toIntExact(startMatch.getId()));
+		int nextRoundMatchId = MatchUtils.calculateNextRoundMatchId(Math.toIntExact(doublesMatch.getId()),
+			leagueParticipantReader.countParticipantMember(doublesMatch.getLeague().getLeagueId())
+				/ PARTICIPANTS_PER_TEAM,
+			Math.toIntExact(startMatch.getId()));
 
-        DoublesMatch nextRoundMatch = doublesMatchReader.getDoublesMatch((long) nextRoundMatchId);
-        if (nextRoundMatch != null) {
-            assignWinnerToNextRoundMatch(nextRoundMatch, winner);
-            doublesMatchStore.store(nextRoundMatch);
-        }
+		DoublesMatch nextRoundMatch = doublesMatchReader.getDoublesMatch((long)nextRoundMatchId);
+		if (nextRoundMatch != null) {
+			assignWinnerToNextRoundMatch(nextRoundMatch, winner);
+			doublesMatchStore.store(nextRoundMatch);
+		}
 
-    }
+	}
 
-    private void assignWinnerToNextRoundMatch(DoublesMatch nextRoundMatch, Team winner) {
-        if (nextRoundMatch.getTeam1() == null) {
-            nextRoundMatch.defineTeam1(winner);
-        } else {
-            nextRoundMatch.defineTeam2(winner);
-        }
-    }
+	private void assignWinnerToNextRoundMatch(DoublesMatch nextRoundMatch, Team winner) {
+		if (nextRoundMatch.getTeam1() == null) {
+			nextRoundMatch.defineTeam1(winner);
+		} else {
+			nextRoundMatch.defineTeam2(winner);
+		}
+	}
 
-    private Team determineWinner(DoublesMatch match) {
-        if (match.getTeam1MatchResult() == MatchResult.WIN) {
-            return match.getTeam1();
-        }
-        if (match.getTeam2MatchResult() == MatchResult.WIN) {
-            return match.getTeam2();
-        }
-        return null;
-    }
-
-    @Override
-    public void startMatch(Long matchId) {
-        DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
-        doublesMatch.startMatch();
-        doublesMatch.getDoublesSet(1).startSet();
-        doublesMatchStore.store(doublesMatch);
-
-    }
+	private Team determineWinner(DoublesMatch match) {
+		if (match.getTeam1MatchResult() == MatchResult.WIN) {
+			return match.getTeam1();
+		}
+		if (match.getTeam2MatchResult() == MatchResult.WIN) {
+			return match.getTeam2();
+		}
+		return null;
+	}
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/TournamentSinglesMatchStrategy.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/TournamentSinglesMatchStrategy.java
@@ -3,7 +3,7 @@ package org.badminton.infrastructure.match.strategy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
+
 import org.badminton.domain.common.enums.MatchResult;
 import org.badminton.domain.common.enums.SetStatus;
 import org.badminton.domain.common.exception.match.AlreadyWinnerDeterminedException;
@@ -25,64 +25,66 @@ import org.badminton.domain.domain.match.store.SinglesMatchReader;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @Component
 public class TournamentSinglesMatchStrategy extends AbstractSinglesMatchStrategy {
 
-    public static final int SET_COUNT = 3;
-    public static final int PARTICIPANTS_PER_MATCH = 2;
-    static final Integer LIMIT_SET_GAME = 3;
-    private final SinglesMatchStore singlesMatchStore;
-    private final LeagueParticipantReader leagueParticipantReader;
-    private final SinglesMatchReader singlesMatchReader;
-    private final LeagueReader leagueReader;
+	public static final int SET_COUNT = 3;
+	public static final int PARTICIPANTS_PER_MATCH = 2;
+	static final Integer LIMIT_SET_GAME = 3;
+	private final SinglesMatchStore singlesMatchStore;
+	private final LeagueParticipantReader leagueParticipantReader;
+	private final SinglesMatchReader singlesMatchReader;
+	private final LeagueReader leagueReader;
 
-    public TournamentSinglesMatchStrategy(SinglesMatchReader singlesMatchReader, SinglesMatchStore singlesMatchStore,
-                                          LeagueParticipantReader leagueParticipantReader, LeagueReader leagueReader) {
-        super(singlesMatchReader);
-        this.singlesMatchReader = singlesMatchReader;
-        this.singlesMatchStore = singlesMatchStore;
-        this.leagueParticipantReader = leagueParticipantReader;
-        this.leagueReader = leagueReader;
-    }
+	public TournamentSinglesMatchStrategy(SinglesMatchReader singlesMatchReader, SinglesMatchStore singlesMatchStore,
+		LeagueParticipantReader leagueParticipantReader, LeagueReader leagueReader) {
+		super(singlesMatchReader, singlesMatchStore);
+		this.singlesMatchReader = singlesMatchReader;
+		this.singlesMatchStore = singlesMatchStore;
+		this.leagueParticipantReader = leagueParticipantReader;
+		this.leagueReader = leagueReader;
+	}
 
-    private static boolean isMatchWinnerDetermined(SinglesMatch singlesMatch) {
-        return singlesMatch.getPlayer1MatchResult() == MatchResult.WIN
-                || singlesMatch.getPlayer2MatchResult() == MatchResult.WIN;
-    }
+	private static boolean isMatchWinnerDetermined(SinglesMatch singlesMatch) {
+		return singlesMatch.getPlayer1MatchResult() == MatchResult.WIN
+			|| singlesMatch.getPlayer2MatchResult() == MatchResult.WIN;
+	}
 
-    @Override
-    public BracketInfo makeBracket(League league, List<LeagueParticipant> leagueParticipantList) {
-        List<SinglesMatch> allMatches = new ArrayList<>();
+	@Override
+	public BracketInfo makeBracket(League league, List<LeagueParticipant> leagueParticipantList) {
+		List<SinglesMatch> allMatches = new ArrayList<>();
 
-        List<LeagueParticipant> currentParticipants = new ArrayList<>(leagueParticipantList);
-        Collections.shuffle(currentParticipants);
-        int totalRounds = MatchUtils.calculateTotalRounds(currentParticipants.size());
-        league.defineTotalRounds(totalRounds);
+		List<LeagueParticipant> currentParticipants = new ArrayList<>(leagueParticipantList);
+		Collections.shuffle(currentParticipants);
+		int totalRounds = MatchUtils.calculateTotalRounds(currentParticipants.size());
+		league.defineTotalRounds(totalRounds);
 
-        allMatches.addAll(createFirstRoundMatches(league, currentParticipants));
-        allMatches.addAll(createSubsequentRoundsMatches(league, totalRounds));
+		allMatches.addAll(createFirstRoundMatches(league, currentParticipants));
+		allMatches.addAll(createSubsequentRoundsMatches(league, totalRounds));
 
-        return BracketInfo.fromSingles(totalRounds, allMatches);
+		return BracketInfo.fromSingles(totalRounds, allMatches);
 
-    }
+	}
 
-    @Override
-    public void checkDuplicateInitialBracket(Long leagueId) {
-        boolean isBracketEmpty = singlesMatchReader.checkIfBracketEmpty(leagueId);
+	@Override
+	public void checkDuplicateInitialBracket(Long leagueId) {
+		boolean isBracketEmpty = singlesMatchReader.checkIfBracketEmpty(leagueId);
 
-        if (!isBracketEmpty && singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
-            singlesMatchStore.deleteSinglesBracket(leagueId);
-        } else if (!isBracketEmpty && !singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
-            throw new MatchDuplicateException(leagueId);
-        }
-    }
+		if (!isBracketEmpty && singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
+			singlesMatchStore.deleteSinglesBracket(leagueId);
+		} else if (!isBracketEmpty && !singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
+			throw new MatchDuplicateException(leagueId);
+		}
+	}
 
-    @Override
-    @Transactional
-    public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
-                                                MatchCommand.UpdateSetScore updateSetScoreCommand) {
-        SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
+	@Override
+	@Transactional
+	public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
+		MatchCommand.UpdateSetScore updateSetScoreCommand) {
+		SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
 
 		if (isMatchWinnerDetermined(singlesMatch)) {
 			throw new AlreadyWinnerDeterminedException(singlesMatch.getId());
@@ -96,152 +98,143 @@ public class TournamentSinglesMatchStrategy extends AbstractSinglesMatchStrategy
 			throw new LeagueParticipantsNotExistsException(matchId);
 		}
 
-        updateSetScore(singlesMatch, setNumber, updateSetScoreCommand);
-        singlesMatchStore.store(singlesMatch);
+		updateSetScore(singlesMatch, setNumber, updateSetScoreCommand);
+		singlesMatchStore.store(singlesMatch);
 
-        if (LIMIT_SET_GAME > setNumber) {
-            changeNextSetStatus(singlesMatch, setNumber);
-        }
+		if (LIMIT_SET_GAME > setNumber) {
+			changeNextSetStatus(singlesMatch, setNumber);
+		}
 
-        // 최종 승자가 정해지면 matchResult 업데이트
-        if (isMatchWinnerDetermined(singlesMatch)) {
-            singlesMatchStore.store(singlesMatch);
-            updateNextRoundMatch(singlesMatch);
-        }
+		// 최종 승자가 정해지면 matchResult 업데이트
+		if (isMatchWinnerDetermined(singlesMatch)) {
+			singlesMatchStore.store(singlesMatch);
+			updateNextRoundMatch(singlesMatch);
+		}
 
 		if (isAllMatchFinished(singlesMatch)) {
 			leagueReader.readLeagueById(singlesMatch.getLeague().getLeagueId()).finishLeague();
 		}
 
-        return SetInfo.fromSinglesSet(matchId, setNumber, singlesMatch.getSinglesSets().get(setNumber - 1));
-    }
+		return SetInfo.fromSinglesSet(matchId, setNumber, singlesMatch.getSinglesSets().get(setNumber - 1));
+	}
 
-    private void changeNextSetStatus(SinglesMatch singlesMatch, Integer setNumber) {
-        setNumber++;
+	private void changeNextSetStatus(SinglesMatch singlesMatch, Integer setNumber) {
+		setNumber++;
 		if (singlesMatch.getPlayer1MatchResult().equals(MatchResult.NONE)) {
 			singlesMatch.getSinglesSet(setNumber).open();
 		}
 		if (!singlesMatch.getPlayer1MatchResult().equals(MatchResult.NONE)) {
 			singlesMatch.getSinglesSet(setNumber).close();
 		}
-    }
+	}
 
-    private boolean isAllMatchFinished(SinglesMatch singlesMatch) {
-        return singlesMatchReader.allMatchesFinishedForLeague(
-                singlesMatch.getLeague().getLeagueId());
-    }
+	private boolean isAllMatchFinished(SinglesMatch singlesMatch) {
+		return singlesMatchReader.allMatchesFinishedForLeague(
+			singlesMatch.getLeague().getLeagueId());
+	}
 
-    @Override
-    public SetInfo.Main retrieveSet(Long matchId, int setNumber) {
-        SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
-        SinglesSet singlesSet = singlesMatch.getSinglesSet(1);
-        return SetInfo.fromSinglesSet(matchId, setNumber, singlesSet);
-    }
+	@Override
+	public SetInfo.Main retrieveSet(Long matchId, int setNumber) {
+		SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
+		SinglesSet singlesSet = singlesMatch.getSinglesSet(1);
+		return SetInfo.fromSinglesSet(matchId, setNumber, singlesSet);
+	}
 
-    private List<SinglesMatch> createFirstRoundMatches(League league, List<LeagueParticipant> participants) {
-        List<SinglesMatch> matches = new ArrayList<>();
-        for (int i = 0; i < participants.size(); i += PARTICIPANTS_PER_MATCH) {
-            SinglesMatch match = new SinglesMatch(league, participants.get(i), participants.get(i + 1), 1);
-            makeSetsInMatch(match);
-            singlesMatchStore.store(match);
-            matches.add(match);
-        }
-        return matches;
-    }
+	private List<SinglesMatch> createFirstRoundMatches(League league, List<LeagueParticipant> participants) {
+		List<SinglesMatch> matches = new ArrayList<>();
+		for (int i = 0; i < participants.size(); i += PARTICIPANTS_PER_MATCH) {
+			SinglesMatch match = new SinglesMatch(league, participants.get(i), participants.get(i + 1), 1);
+			makeSetsInMatch(match);
+			singlesMatchStore.store(match);
+			matches.add(match);
+		}
+		return matches;
+	}
 
-    private List<SinglesMatch> createRoundMatches(League league, List<SinglesMatch> previousMatches, int roundNumber) {
-        List<SinglesMatch> currentRoundMatches = new ArrayList<>();
-        for (int i = 0; i < previousMatches.size(); i += PARTICIPANTS_PER_MATCH) {
-            SinglesMatch match = new SinglesMatch(league, null, null, roundNumber);
-            makeSetsInMatch(match);
-            singlesMatchStore.store(match);
-            currentRoundMatches.add(match);
-        }
-        return currentRoundMatches;
-    }
+	private List<SinglesMatch> createRoundMatches(League league, List<SinglesMatch> previousMatches, int roundNumber) {
+		List<SinglesMatch> currentRoundMatches = new ArrayList<>();
+		for (int i = 0; i < previousMatches.size(); i += PARTICIPANTS_PER_MATCH) {
+			SinglesMatch match = new SinglesMatch(league, null, null, roundNumber);
+			makeSetsInMatch(match);
+			singlesMatchStore.store(match);
+			currentRoundMatches.add(match);
+		}
+		return currentRoundMatches;
+	}
 
-    private List<SinglesMatch> createSubsequentRoundsMatches(League league, int totalRounds) {
-        List<SinglesMatch> matches = new ArrayList<>();
-        List<SinglesMatch> previousMatches = singlesMatchReader.findMatchesByLeagueAndRound(league.getLeagueId(), 1);
+	private List<SinglesMatch> createSubsequentRoundsMatches(League league, int totalRounds) {
+		List<SinglesMatch> matches = new ArrayList<>();
+		List<SinglesMatch> previousMatches = singlesMatchReader.findMatchesByLeagueAndRound(league.getLeagueId(), 1);
 
-        for (int roundNumber = 2; roundNumber <= totalRounds; roundNumber++) {
-            List<SinglesMatch> currentRoundMatches = createRoundMatches(league, previousMatches, roundNumber);
-            matches.addAll(currentRoundMatches);
-            previousMatches = currentRoundMatches;
-        }
+		for (int roundNumber = 2; roundNumber <= totalRounds; roundNumber++) {
+			List<SinglesMatch> currentRoundMatches = createRoundMatches(league, previousMatches, roundNumber);
+			matches.addAll(currentRoundMatches);
+			previousMatches = currentRoundMatches;
+		}
 
-        return matches;
-    }
+		return matches;
+	}
 
-    private void makeSetsInMatch(SinglesMatch singlesMatch) {
-        for (int i = 1; i <= SET_COUNT; i++) {
-            SinglesSet set = new SinglesSet(singlesMatch, i);
-            singlesMatch.addSet(set);
-        }
-        singlesMatchStore.store(singlesMatch);
-    }
+	private void makeSetsInMatch(SinglesMatch singlesMatch) {
+		for (int i = 1; i <= SET_COUNT; i++) {
+			SinglesSet set = new SinglesSet(singlesMatch, i);
+			singlesMatch.addSet(set);
+		}
+		singlesMatchStore.store(singlesMatch);
+	}
 
-    private void updateSetScore(SinglesMatch singlesMatch, int setNumber,
-                                MatchCommand.UpdateSetScore updateSetScoreCommand) {
-        SinglesSet set = singlesMatch.getSinglesSet(setNumber);
-        set.endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
+	private void updateSetScore(SinglesMatch singlesMatch, int setNumber,
+		MatchCommand.UpdateSetScore updateSetScoreCommand) {
+		SinglesSet set = singlesMatch.getSinglesSet(setNumber);
+		set.endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
 
-        if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
-            singlesMatch.player1WinSet();
-        } else {
-            singlesMatch.player2WinSet();
-        }
-    }
+		if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
+			singlesMatch.player1WinSet();
+		} else {
+			singlesMatch.player2WinSet();
+		}
+	}
 
-    private void updateNextRoundMatch(SinglesMatch singlesMatch) {
-        LeagueParticipant winner = determineWinner(singlesMatch);
+	private void updateNextRoundMatch(SinglesMatch singlesMatch) {
+		LeagueParticipant winner = determineWinner(singlesMatch);
 		if (winner == null) {
 			return;
 		}
-        int totalRounds = singlesMatch.getLeague().getTotalRounds();
-        if (singlesMatch.getRoundNumber() == totalRounds) {
-            return;
-        }
+		int totalRounds = singlesMatch.getLeague().getTotalRounds();
+		if (singlesMatch.getRoundNumber() == totalRounds) {
+			return;
+		}
 
-        SinglesMatch startMatch = singlesMatchReader.findFirstMatchByLeagueId(
-                singlesMatch.getLeague().getLeagueId());
+		SinglesMatch startMatch = singlesMatchReader.findFirstMatchByLeagueId(
+			singlesMatch.getLeague().getLeagueId());
 
-        int nextRoundMatchId = MatchUtils.calculateNextRoundMatchId(Math.toIntExact(singlesMatch.getId()),
-                leagueParticipantReader.countParticipantMember(singlesMatch.getLeague().getLeagueId()),
-                Math.toIntExact(startMatch.getId()));
+		int nextRoundMatchId = MatchUtils.calculateNextRoundMatchId(Math.toIntExact(singlesMatch.getId()),
+			leagueParticipantReader.countParticipantMember(singlesMatch.getLeague().getLeagueId()),
+			Math.toIntExact(startMatch.getId()));
 
-        SinglesMatch nextRoundMatch = singlesMatchReader.getSinglesMatch((long) nextRoundMatchId);
-        if (nextRoundMatch != null) {
-            assignWinnerToNextRoundMatch(nextRoundMatch, winner);
-            singlesMatchStore.store(nextRoundMatch);
-        }
+		SinglesMatch nextRoundMatch = singlesMatchReader.getSinglesMatch((long)nextRoundMatchId);
+		if (nextRoundMatch != null) {
+			assignWinnerToNextRoundMatch(nextRoundMatch, winner);
+			singlesMatchStore.store(nextRoundMatch);
+		}
 
-    }
+	}
 
-    private void assignWinnerToNextRoundMatch(SinglesMatch nextRoundMatch, LeagueParticipant winner) {
-        if (nextRoundMatch.getLeagueParticipant1() == null) {
-            nextRoundMatch.defineLeagueParticipant1(winner);
-        } else {
-            nextRoundMatch.defineLeagueParticipant2(winner);
-        }
-    }
+	private void assignWinnerToNextRoundMatch(SinglesMatch nextRoundMatch, LeagueParticipant winner) {
+		if (nextRoundMatch.getLeagueParticipant1() == null) {
+			nextRoundMatch.defineLeagueParticipant1(winner);
+		} else {
+			nextRoundMatch.defineLeagueParticipant2(winner);
+		}
+	}
 
-    private LeagueParticipant determineWinner(SinglesMatch match) {
-        if (match.getPlayer1MatchResult() == MatchResult.WIN) {
-            return match.getLeagueParticipant1();
-        }
-        if (match.getPlayer2MatchResult() == MatchResult.WIN) {
-            return match.getLeagueParticipant2();
-        }
-        return null;
-    }
-
-    @Override
-    public void startMatch(Long matchId) {
-        SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
-        singlesMatch.startMatch();
-        singlesMatch.getSinglesSet(1).initMatch();
-        singlesMatchStore.store(singlesMatch);
-    }
-
+	private LeagueParticipant determineWinner(SinglesMatch match) {
+		if (match.getPlayer1MatchResult() == MatchResult.WIN) {
+			return match.getLeagueParticipant1();
+		}
+		if (match.getPlayer2MatchResult() == MatchResult.WIN) {
+			return match.getLeagueParticipant2();
+		}
+		return null;
+	}
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍

startMatch 메서드의 중복되는 코드를 해결하기 위해 AbstractMatchStrategy 내부로 옮겼습니다. 또한 startMatch 를 하기 위한 조건을 추가했습니다. LeagueAt 전에는 match 를 시작할 수 없습니다.


## 변경된 사항 📝

1. `FreeSinglesMatchStrategy`, `TournamentSinglesMatchStrategy`의 startMatch 메서드가 동일한 문제를 해결했습니다.

```java
	@Override
	public void startMatch(Long matchId) {
		DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
		doublesMatch.startMatch();
		doublesMatch.getDoublesSet(1).startSet();
		doublesMatchStore.store(doublesMatch);
	}
```
해당 메서드를 `AbstractSinglesMatchStrategy`로 옮겼습니다. 
Doubles Match 의 경우에도 동일한 문제가 있어 `AbstractSinglesMatchStrategy`로 옮겼습니다.

2. LeagueAt 이전에는 startMatch 메서드를 실행할 수 없도록 검증을 추가했습니다.

```java
	@Override
	public void startMatch(MatchStrategy matchStrategy, Long leagueId, Long matchId) {
		League league = leagueReader.readLeagueById(leagueId);
		if (LocalDateTime.now().isBefore(league.getLeagueAt())) {
			throw new CannotStartMatchException(league.getLeagueId(), league.getLeagueAt());
		}
		matchStrategy.startMatch(matchId);
	}
```

현재 시간이 LeagueAt 이전이라면 예외를 발생합니다. `CannotStartMatchException`
에러 메시지는 아래와 같습니다.
```
"경기 시작 시간 전에는 매치를 시작할 수 없습니다."
```

## PR에서 중점적으로 확인되어야 하는 사항

- AbstractMatchStrategy 로 잘 옮겨졌는지 확인해주세요.
- Match Strategy 의 중복 코드를 정리해야 할 것 같습니다.