### PR TITLE
refactor: 이미지 변환 의존성 변경

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -10,7 +10,9 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.5.RELEASE'
     implementation "com.sksamuel.scrimage:scrimage-core:4.0.32"
     implementation "com.sksamuel.scrimage:scrimage-webp:4.0.32"
-    
+    implementation 'com.twelvemonkeys.imageio:imageio-webp:3.9.4'
+
+
     implementation 'org.mapstruct:mapstruct:1.4.2.Final'
     annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: '3.3.4'

--- a/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
@@ -18,19 +18,16 @@ public class ImageConversionService {
 
 	public byte[] convertToWebP(MultipartFile file) {
 		try {
-			// Read input image from MultipartFile
 			BufferedImage inputImage = ImageIO.read(file.getInputStream());
 			if (inputImage == null) {
 				throw new EmptyFileException();
 			}
 
-			// Write output image as WebP
 			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 			ImageIO.write(inputImage, "webp", outputStream);
 
 			return outputStream.toByteArray();
 		} catch (IOException exception) {
-			log.error("Image conversion failed for file: {}", file.getOriginalFilename(), exception);
 			throw new EmptyFileException(exception);
 		}
 

--- a/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
@@ -33,5 +33,15 @@ public class ImageConversionService {
 			log.error("Image conversion failed for file: {}", file.getOriginalFilename(), exception);
 			throw new EmptyFileException(exception);
 		}
+
+		// try {
+		// 	ImmutableImage image = ImmutableImage.loader().fromStream(file.getInputStream());
+		// 	ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		// 	WebpWriter writer = WebpWriter.DEFAULT;
+		// 	writer.write(image, ImageMetadata.fromStream(file.getInputStream()), outputStream);
+		// 	return outputStream.toByteArray();
+		// } catch (IOException exception) {
+		// 	throw new EmptyFileException(exception);
+		// }
 	}
 }

--- a/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
@@ -1,15 +1,14 @@
 package org.badminton.api.aws.s3.service;
 
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+
+import javax.imageio.ImageIO;
 
 import org.badminton.api.common.exception.EmptyFileException;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-
-import com.sksamuel.scrimage.ImmutableImage;
-import com.sksamuel.scrimage.metadata.ImageMetadata;
-import com.sksamuel.scrimage.webp.WebpWriter;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,15 +18,20 @@ public class ImageConversionService {
 
 	public byte[] convertToWebP(MultipartFile file) {
 		try {
-			ImmutableImage image = ImmutableImage.loader().fromStream(file.getInputStream());
+			// Read input image from MultipartFile
+			BufferedImage inputImage = ImageIO.read(file.getInputStream());
+			if (inputImage == null) {
+				throw new EmptyFileException();
+			}
+
+			// Write output image as WebP
 			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			WebpWriter writer = WebpWriter.DEFAULT;
-			writer.write(image, ImageMetadata.fromStream(file.getInputStream()), outputStream);
+			ImageIO.write(inputImage, "webp", outputStream);
+
 			return outputStream.toByteArray();
 		} catch (IOException exception) {
 			log.error("Image conversion failed for file: {}", file.getOriginalFilename(), exception);
 			throw new EmptyFileException(exception);
 		}
-
 	}
 }

--- a/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
@@ -11,7 +11,10 @@ import com.sksamuel.scrimage.ImmutableImage;
 import com.sksamuel.scrimage.metadata.ImageMetadata;
 import com.sksamuel.scrimage.webp.WebpWriter;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Service
+@Slf4j
 public class ImageConversionService {
 
 	public byte[] convertToWebP(MultipartFile file) {
@@ -22,6 +25,7 @@ public class ImageConversionService {
 			writer.write(image, ImageMetadata.fromStream(file.getInputStream()), outputStream);
 			return outputStream.toByteArray();
 		} catch (IOException exception) {
+			log.error("Image conversion failed for file: {}", file.getOriginalFilename(), exception);
 			throw new EmptyFileException(exception);
 		}
 


### PR DESCRIPTION
## PR에 대한 설명 🔍

```
implementation "com.sksamuel.scrimage:scrimage-core:4.0.32"
    implementation "com.sksamuel.scrimage:scrimage-webp:4.0.32"
```

위의 `scrimage` 의존성은`WebpWriter`가 내부적으로 사용하는 `cwebp` 바이너리가 `GLIBC` 버전을 충족하지 못해서 배포 환경에서 이미지 업로드를 실패합니다.

위의 이슈를 해결하기 위해 

`
    implementation 'com.twelvemonkeys.imageio:imageio-webp:3.9.4'
`

위의 `twelvemonkeys` 를 사용해서 이미지 업로드를 수정했습니다. 그러나 `twelvemonkeys` 의존성을 사용하면 이미지를 `webp` 로 변환을 할 때 이미지가 손상되는 이슈가 발생합니다.

QA 를 진행하기 위해 임시로 `twelvemonkeys` 를 사용하고 추후 어떻게 해야 할 지함께 고민해봐야 할 것 같습니다.


