### PR TITLE
refactor: 세트 Response에 SetStatus 추가

### DIFF
--- a/api/src/main/java/org/badminton/api/interfaces/match/dto/MatchSetResponse.java
+++ b/api/src/main/java/org/badminton/api/interfaces/match/dto/MatchSetResponse.java
@@ -1,37 +1,41 @@
 package org.badminton.api.interfaces.match.dto;
 
+import org.badminton.domain.common.enums.SetStatus;
+import org.badminton.domain.domain.match.info.MatchSetInfo;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
-import org.badminton.domain.domain.match.info.MatchSetInfo;
 
 public record MatchSetResponse(
-        @Schema(description = "단식 경기 참가자")
-        SinglesMatchPlayerResponse singlesMatchPlayerResponse,
-        @Schema(description = "복식 경기 참가자")
-        DoublesMatchPlayerResponse doublesMatchPlayerResponse,
-        @Schema(description = "세트 점수 1", requiredMode = RequiredMode.REQUIRED)
-        int setScore1,
-        @Schema(description = "세트 점수 2", requiredMode = RequiredMode.REQUIRED)
-        int setScore2,
-        @Schema(description = "이긴 세트수 1", requiredMode = RequiredMode.REQUIRED)
-        int winSetScore1,
-        @Schema(description = "이긴 세트수 2", requiredMode = RequiredMode.REQUIRED)
-        int winSetScore2,
-        @Schema(description = "세트 번호 (1 | 2 | 3)", requiredMode = RequiredMode.REQUIRED)
-        int setNumber
+	@Schema(description = "단식 경기 참가자")
+	SinglesMatchPlayerResponse singlesMatchPlayerResponse,
+	@Schema(description = "복식 경기 참가자")
+	DoublesMatchPlayerResponse doublesMatchPlayerResponse,
+	@Schema(description = "세트 상태", requiredMode = RequiredMode.REQUIRED)
+	SetStatus setStatus,
+	@Schema(description = "세트 점수 1", requiredMode = RequiredMode.REQUIRED)
+	int setScore1,
+	@Schema(description = "세트 점수 2", requiredMode = RequiredMode.REQUIRED)
+	int setScore2,
+	@Schema(description = "이긴 세트수 1", requiredMode = RequiredMode.REQUIRED)
+	int winSetScore1,
+	@Schema(description = "이긴 세트수 2", requiredMode = RequiredMode.REQUIRED)
+	int winSetScore2,
+	@Schema(description = "세트 번호 (1 | 2 | 3)", requiredMode = RequiredMode.REQUIRED)
+	int setNumber
 ) {
 
-    public static MatchSetResponse from(MatchSetInfo matchSetInfo) {
-        return new MatchSetResponse(
-                SinglesMatchPlayerResponse.from(matchSetInfo.singlesMatchPlayerInfo()),
-                DoublesMatchPlayerResponse.of(matchSetInfo.doublesMatchPlayerInfo()),
-                matchSetInfo.setScore1(),
-                matchSetInfo.setScore2(),
-                matchSetInfo.winSetScore1(),
-                matchSetInfo.winSetScore2(),
-                matchSetInfo.setNumber()
-        );
-    }
+	public static MatchSetResponse from(MatchSetInfo matchSetInfo) {
+		return new MatchSetResponse(
+			SinglesMatchPlayerResponse.from(matchSetInfo.singlesMatchPlayerInfo()),
+			DoublesMatchPlayerResponse.of(matchSetInfo.doublesMatchPlayerInfo()),
+			matchSetInfo.setStatus(),
+			matchSetInfo.setScore1(),
+			matchSetInfo.setScore2(),
+			matchSetInfo.winSetScore1(),
+			matchSetInfo.winSetScore2(),
+			matchSetInfo.setNumber()
+		);
+	}
 
 }

--- a/domain/src/main/java/org/badminton/domain/domain/match/info/MatchSetInfo.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/info/MatchSetInfo.java
@@ -1,11 +1,13 @@
 package org.badminton.domain.domain.match.info;
 
+import org.badminton.domain.common.enums.SetStatus;
 import org.badminton.domain.domain.match.entity.DoublesSet;
 import org.badminton.domain.domain.match.entity.SinglesSet;
 
 public record MatchSetInfo(
 	SinglesMatchPlayerInfo singlesMatchPlayerInfo,
 	DoublesMatchPlayerInfo doublesMatchPlayerInfo,
+	SetStatus setStatus,
 	int setScore1,
 	int setScore2,
 	int winSetScore1,
@@ -17,6 +19,7 @@ public record MatchSetInfo(
 		return new MatchSetInfo(
 			SinglesMatchPlayerInfo.fromSinglesMatch(singlesSet.getSinglesMatch()),
 			null,
+			singlesSet.getSetStatus(),
 			singlesSet.getPlayer1Score(),
 			singlesSet.getPlayer2Score(),
 			singlesSet.getSinglesMatch().getPlayer1WinSetCount(),
@@ -29,6 +32,7 @@ public record MatchSetInfo(
 		return new MatchSetInfo(
 			null,
 			DoublesMatchPlayerInfo.from(doublesSet.getDoublesMatch()),
+			doublesSet.getSetStatus(),
 			doublesSet.getTeam1Score(),
 			doublesSet.getTeam2Score(),
 			doublesSet.getDoublesMatch().getTeam1WinSetCount(),


### PR DESCRIPTION
## PR에 대한 설명 🔍

세트 상세 점수를 조회할 때 Set Status 를 추가했습니다. 

## 변경된 사항 📝

```sql
{
  "result": "SUCCESS",
  "data": {
    "singles_match_player_response": null,
    "doubles_match_player_response": {
      "participant1_name": "왕히어로",
      "participant1_image": "https://d36om9pjoifd2y.cloudfront.net/member/pelican.jpg",
      "participant2_name": "김수아",
      "participant2_image": "https://d36om9pjoifd2y.cloudfront.net/member/zebra.jpg",
      "participant3_name": "치즈케이크",
      "participant3_image": "https://d36om9pjoifd2y.cloudfront.net/member/cat.jpg",
      "participant4_name": "젤리빈",
      "participant4_image": "https://d36om9pjoifd2y.cloudfront.net/member/cow.jpg"
    },
    "set_status": "IN_PROGRESS",
    "set_score1": 2,
    "set_score2": 3,
    "win_set_score1": 1,
    "win_set_score2": 0,
    "set_number": 2
  }
}
```

### Before

Set Status 가 없었습니다. 

### After

응답에 Set Status를 포함했습니다.

## PR에서 중점적으로 확인되어야 하는 사항

MatchSetResponse에 더 포함되어야 하는 필드를 확인해주세요.