### PR TITLE
refactor: 동호회에 지원한 회원 리스트 조회 시 페이지네이션 적용

### DIFF
--- a/api/src/main/java/org/badminton/api/application/club/ClubFacade.java
+++ b/api/src/main/java/org/badminton/api/application/club/ClubFacade.java
@@ -1,6 +1,5 @@
 package org.badminton.api.application.club;
 
-import java.util.List;
 import java.util.Map;
 
 import org.badminton.domain.common.policy.ClubMemberPolicy;
@@ -81,8 +80,8 @@ public class ClubFacade {
 	}
 
 	@Transactional
-	public List<ClubApplicantInfo> readClubApplicants(String memberToken, String clubToken) {
+	public Page<ClubApplicantInfo> readClubApplicants(String memberToken, String clubToken, Pageable pageable) {
 		clubMemberPolicy.validateAboveClubManager(memberToken, clubToken);
-		return clubService.readClubApplicants(clubToken);
+		return clubService.readClubApplicants(clubToken, pageable);
 	}
 }

--- a/api/src/main/java/org/badminton/api/interfaces/club/controller/ClubController.java
+++ b/api/src/main/java/org/badminton/api/interfaces/club/controller/ClubController.java
@@ -1,7 +1,6 @@
 package org.badminton.api.interfaces.club.controller;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.badminton.api.application.club.ClubFacade;
 import org.badminton.api.application.club.ClubRankFacade;
@@ -27,6 +26,8 @@ import org.badminton.domain.domain.club.info.ClubCreateInfo;
 import org.badminton.domain.domain.club.info.ClubDeleteInfo;
 import org.badminton.domain.domain.club.info.ClubUpdateInfo;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -72,14 +73,14 @@ public class ClubController {
 	@Operation(summary = "동호회 수정",
 		description = """
 			새로운 동호회를 수정합니다. 다음 조건을 만족해야 합니다:
-			
+						
 			1. 동호회 이름:
 			   - 필수 입력
 			   - 2자 이상 20자 이하
-			
+						
 			2. 동호회 소개:
 			   - 2자 이상 1000자 이하
-			
+						
 			3. 동호회 이미지 URL:
 			   - 호스트: badminton-team.s3.ap-northeast-2.amazonaws.com
 			   - 경로: /club-banner/로 시작
@@ -104,10 +105,10 @@ public class ClubController {
 			1. 동호회 이름:
 			   - 필수 입력
 			   - 2자 이상 20자 이하
-			
+						
 			2. 동호회 소개:
 			   - 2자 이상 1000자 이하
-			
+						
 			3. 동호회 이미지 URL:
 			   - 호스트: badminton-team.s3.ap-northeast-2.amazonaws.com
 			   - 경로: /club-banner/로 시작
@@ -196,13 +197,16 @@ public class ClubController {
 		description = "특정 동호회에 가입 신청한 유저 리스트 조회",
 		tags = {"Club"})
 	@GetMapping("/{clubToken}/applicants")
-	public CommonResponse<List<ClubApplicantResponse>> getClubApplicant(@PathVariable String clubToken,
-		@AuthenticationPrincipal CustomOAuth2Member member) {
-		List<ClubApplicantInfo> clubApplies = clubFacade.readClubApplicants(member.getMemberToken(), clubToken);
-		List<ClubApplicantResponse> response = clubApplies.stream()
-			.map(ClubApplicantResponse::from)
-			.collect(Collectors.toList());
-
-		return CommonResponse.success(response);
+	public CommonResponse<CustomPageResponse<ClubApplicantResponse>> getClubApplicant(
+		@PathVariable String clubToken,
+		@AuthenticationPrincipal CustomOAuth2Member member,
+		@RequestParam(defaultValue = DEFAULT_PAGE_VALUE) int page,
+		@RequestParam(defaultValue = DEFAULT_SIZE_VALUE) int size
+	) {
+		Sort sort = Sort.by(Sort.Order.by("createdAt"));
+		Page<ClubApplicantInfo> clubApplies = clubFacade.readClubApplicants(member.getMemberToken(), clubToken,
+			PageRequest.of(page, size, sort));
+		Page<ClubApplicantResponse> clubApply = clubApplies.map(ClubApplicantResponse::from);
+		return CommonResponse.success(new CustomPageResponse<>(clubApply));
 	}
 }

--- a/domain/src/main/java/org/badminton/domain/domain/club/ClubApplyReader.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/ClubApplyReader.java
@@ -1,9 +1,9 @@
 package org.badminton.domain.domain.club;
 
-import java.util.List;
-
 import org.badminton.domain.domain.club.entity.ClubApply;
 import org.badminton.domain.domain.club.info.ClubApplicantInfo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ClubApplyReader {
 
@@ -13,6 +13,6 @@ public interface ClubApplyReader {
 
 	void validateEmailApply(String clubToken, String memberToken);
 
-	List<ClubApplicantInfo> getClubApplyByClubToken(String clubToken, ClubApply.ApplyStatus applyStatus);
-
+	Page<ClubApplicantInfo> getClubApplyByClubToken(String clubToken, ClubApply.ApplyStatus applyStatus,
+		Pageable pageable);
 }

--- a/domain/src/main/java/org/badminton/domain/domain/club/ClubService.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/ClubService.java
@@ -28,7 +28,7 @@ public interface ClubService {
 
 	ClubCardInfo readClubById(Long clubId);
 
-	List<ClubApplicantInfo> readClubApplicants(String clubToken);
+	Page<ClubApplicantInfo> readClubApplicants(String clubToken, Pageable pageable);
 
 	List<ClubCardInfo> readRecentlyClub();
 }

--- a/domain/src/main/java/org/badminton/domain/domain/club/ClubServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/ClubServiceImpl.java
@@ -106,10 +106,9 @@ public class ClubServiceImpl implements ClubService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public List<ClubApplicantInfo> readClubApplicants(String clubToken) {
+	public Page<ClubApplicantInfo> readClubApplicants(String clubToken, Pageable pageable) {
 		return clubApplyReader.getClubApplyByClubToken(clubToken,
-			ClubApply.ApplyStatus.PENDING);
-
+			ClubApply.ApplyStatus.PENDING, pageable);
 	}
 
 	private Page<Club> getClubs(String keyword, Pageable pageable) {

--- a/domain/src/main/java/org/badminton/domain/domain/club/entity/ClubApply.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/entity/ClubApply.java
@@ -1,5 +1,6 @@
 package org.badminton.domain.domain.club.entity;
 
+import org.badminton.domain.common.AbstractBaseTime;
 import org.badminton.domain.domain.member.entity.Member;
 
 import jakarta.persistence.Column;
@@ -22,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "club_apply")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ClubApply {
+public class ClubApply extends AbstractBaseTime {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubApplyReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubApplyReaderImpl.java
@@ -1,11 +1,11 @@
 package org.badminton.infrastructure.club;
 
-import java.util.List;
-
 import org.badminton.domain.common.exception.clubmember.MemberAlreadyApplyClubException;
 import org.badminton.domain.domain.club.ClubApplyReader;
 import org.badminton.domain.domain.club.entity.ClubApply;
 import org.badminton.domain.domain.club.info.ClubApplicantInfo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -38,12 +38,10 @@ public class ClubApplyReaderImpl implements ClubApplyReader {
 	}
 
 	@Override
-	public List<ClubApplicantInfo> getClubApplyByClubToken(String clubToken, ClubApply.ApplyStatus applyStatus) {
-		List<ClubApply> clubApplicants = clubApplyRepository.findAllByClubClubTokenAndStatus(clubToken,
-			applyStatus);
-
-		return clubApplicants.stream()
-			.map(ClubApplicantInfo::from)
-			.toList();
+	public Page<ClubApplicantInfo> getClubApplyByClubToken(String clubToken, ClubApply.ApplyStatus applyStatus,
+		Pageable pageable) {
+		Page<ClubApply> clubApplicants = clubApplyRepository.findAllByClubClubTokenAndStatus(clubToken,
+			applyStatus, pageable);
+		return clubApplicants.map(ClubApplicantInfo::from);
 	}
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubApplyRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubApplyRepository.java
@@ -1,8 +1,8 @@
 package org.badminton.infrastructure.club;
 
-import java.util.List;
-
 import org.badminton.domain.domain.club.entity.ClubApply;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClubApplyRepository extends JpaRepository<ClubApply, Long> {
@@ -12,7 +12,7 @@ public interface ClubApplyRepository extends JpaRepository<ClubApply, Long> {
 	boolean existsByClubClubTokenAndMemberMemberTokenAndStatus(String clubToken, String memberToken,
 		ClubApply.ApplyStatus status);
 
-	List<ClubApply> findAllByClubClubTokenAndStatus(String clubToken, ClubApply.ApplyStatus status);
+	Page<ClubApply> findAllByClubClubTokenAndStatus(String clubToken, ClubApply.ApplyStatus status, Pageable pageable);
 
 	boolean existsByClubClubTokenAndMemberMemberToken(String clubToken, String memberToken);
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍

- [x] 동호회에 지원한 회원 리스트 조회 시 페이지네이션 적용
- [x] ClubApply Entity에 AbstractBaseTime 추가했습니다.

## 변경된 사항 📝

```java
Sort sort = Sort.by(Sort.Order.by("createdAt"));
Page<ClubApplicantInfo> clubApplies = clubFacade.readClubApplicants(member.getMemberToken(), clubToken, PageRequest.of(page, size, sort));
```

```java
public class ClubApply extends AbstractBaseTime {
```

## PR에서 중점적으로 확인되어야 하는 사항

ClubApply Entity 에 createdAt, modifiedAt 필드를 추가해 배포 시 DB 스키마 변경이 필요합니다. 