### PR TITLE
feat: 도커 빌드 버전 업데이트 및 exception 수정

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,10 +1,15 @@
 
 # badminton-api Dockerfile
+# Ubuntu 20.04 기반 이미지 사용
+FROM ubuntu:20.04
 
-FROM amazoncorretto:17
+# 필수 패키지 업데이트 및 Java 17 설치
+RUN apt-get update && apt-get install -y \
+    openjdk-17-jdk \
+    && rm -rf /var/lib/apt/lists/*
 
-LABEL authors="hit team"
-
+# 애플리케이션 JAR 파일 복사
 COPY build/libs/api.jar /api.jar
 
+# Spring Boot 애플리케이션 실행
 ENTRYPOINT ["java", "-jar", "/api.jar"]

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -10,9 +10,6 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.5.RELEASE'
     implementation "com.sksamuel.scrimage:scrimage-core:4.0.32"
     implementation "com.sksamuel.scrimage:scrimage-webp:4.0.32"
-    implementation 'com.twelvemonkeys.imageio:imageio-webp:3.9.4'
-    implementation 'javax.xml.bind:jaxb-api:2.3.1'
-
 
     implementation 'org.mapstruct:mapstruct:1.4.2.Final'
     annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"

--- a/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
@@ -1,31 +1,28 @@
 package org.badminton.api.aws.s3.service;
 
-import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-
-import javax.imageio.ImageIO;
 
 import org.badminton.api.common.exception.EmptyFileException;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.sksamuel.scrimage.ImmutableImage;
+import com.sksamuel.scrimage.metadata.ImageMetadata;
+import com.sksamuel.scrimage.webp.WebpWriter;
+
 import lombok.extern.slf4j.Slf4j;
 
-@Service
 @Slf4j
+@Service
 public class ImageConversionService {
 
 	public byte[] convertToWebP(MultipartFile file) {
 		try {
-			BufferedImage inputImage = ImageIO.read(file.getInputStream());
-			if (inputImage == null) {
-				throw new EmptyFileException();
-			}
-
+			ImmutableImage image = ImmutableImage.loader().fromStream(file.getInputStream());
 			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			ImageIO.write(inputImage, "webp", outputStream);
-
+			WebpWriter writer = WebpWriter.DEFAULT;
+			writer.write(image, ImageMetadata.fromStream(file.getInputStream()), outputStream);
 			return outputStream.toByteArray();
 		} catch (IOException exception) {
 			throw new EmptyFileException(exception);

--- a/domain/src/main/java/org/badminton/domain/common/exception/BadmintonException.java
+++ b/domain/src/main/java/org/badminton/domain/common/exception/BadmintonException.java
@@ -29,7 +29,7 @@ public class BadmintonException extends RuntimeException {
 	public BadmintonException(ErrorCode errorCode, Exception exception) {
 		super(errorCode.getDescription(), exception);
 		this.errorCode = errorCode;
-		this.errorMessage = errorCode.getDescription();
+		this.errorMessage = errorCode.getDescription() + exception.getMessage();
 	}
 
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍
- PR의 내용에 대한 설명을 자세히 설명 
- 이미지 배포 환경에서 exception발생 

## 변경된 사항 📝

### 원인
- Ubuntu GLIBC 버전 호환 문제

### After
- Ubuntu GLIBC 버전 업데이트
![image](https://github.com/user-attachments/assets/19ca6f77-f24b-45bc-a7da-1184227df6c1)

기존 ```FROM amazoncorretto:17``` 에서 제공하는 GLIBC 버전이 2.26 이였습니다. 
애플리케이션에서 사용하는 이미지는 GLIBC 2.29 이상이 필요합니다. 
따라서 아마존에서 제공하는 빌드 버전이 아닌 우분투에서 제공하는 빌드 버전으로 변경할 필요가 있었습니다. 
우분투 20.4에서 제공하는 GLIBC 버전은 2.31입니다. 

## PR에서 중점적으로 확인되어야 하는 사항
도커 이미지 자체에서 사용되는 리소스 버전들은  대부분 도커 컨테이너가 동작하는 환경에서의 리소스 버전과 별도로 동작합니다. 
GLIBC 도 그 중 하나이지요. 
아마존 EC2 컴퓨터 내부의 GLIBC 버전은 2.34 이 지만 우리가 그 동안 도커 내부에서 사용한 버전은 2.26이라 에러가 발생한 듯 합니다. 
만약 위와 같이 버전문제가 발생하면 도커 터미널에서 버전을 확인해야 에러를 해결하기 쉬울 겁니다! 