### PR TITLE
feat: 이메일 인코딩 깨짐 현상 수정

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,13 +3,18 @@
 # Ubuntu 20.04 기반 이미지 사용
 FROM ubuntu:20.04
 
+
 # 필수 패키지 업데이트 및 Java 17 설치
 RUN apt-get update && apt-get install -y \
     openjdk-17-jdk \
-    && rm -rf /var/lib/apt/lists/*
+    locales \
+    && rm -rf /var/lib/apt/lists/* \
+    # 시스템 로케일을 en_US.UTF-8로 설정
+    && locale-gen en_US.UTF-8 \
+    && update-locale LANG=en_US.UTF-8
 
 # 애플리케이션 JAR 파일 복사
 COPY build/libs/api.jar /api.jar
 
-# Spring Boot 애플리케이션 실행
-ENTRYPOINT ["java", "-jar", "/api.jar"]
+# Spring Boot 애플리케이션 실행 시 UTF-8 인코딩 강제 설정
+ENTRYPOINT ["java", "-Dfile.encoding=UTF-8", "-jar", "/api.jar"]

--- a/domain/src/main/java/org/badminton/domain/domain/mail/MailServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/mail/MailServiceImpl.java
@@ -1,7 +1,5 @@
 package org.badminton.domain.domain.mail;
 
-import java.nio.charset.StandardCharsets;
-
 import org.badminton.domain.common.exception.clubmember.ClubMemberAlreadyExistsException;
 import org.badminton.domain.domain.club.ClubApplyReader;
 import org.badminton.domain.domain.club.ClubReader;
@@ -82,15 +80,13 @@ public class MailServiceImpl implements MailService {
 	}
 
 	private void sendEmail(String senderMailAddress, String title, String message) {
-		String utf8Message = new String(message.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8);
-		String utf8Title = new String(title.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8);
 
 		SimpleMailMessage mailMessage = new SimpleMailMessage();
 
 		mailMessage.setTo(senderMailAddress);
 		mailMessage.setFrom(fromAddress);
-		mailMessage.setSubject(utf8Title);
-		mailMessage.setText(utf8Message);
+		mailMessage.setSubject(title);
+		mailMessage.setText(message);
 
 		mailSender.send(mailMessage);
 	}

--- a/domain/src/main/java/org/badminton/domain/domain/mail/MailServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/mail/MailServiceImpl.java
@@ -1,5 +1,7 @@
 package org.badminton.domain.domain.mail;
 
+import java.nio.charset.StandardCharsets;
+
 import org.badminton.domain.common.exception.clubmember.ClubMemberAlreadyExistsException;
 import org.badminton.domain.domain.club.ClubApplyReader;
 import org.badminton.domain.domain.club.ClubReader;
@@ -80,13 +82,15 @@ public class MailServiceImpl implements MailService {
 	}
 
 	private void sendEmail(String senderMailAddress, String title, String message) {
+		String utf8Message = new String(message.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8);
+		String utf8Title = new String(title.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8);
 
 		SimpleMailMessage mailMessage = new SimpleMailMessage();
 
 		mailMessage.setTo(senderMailAddress);
 		mailMessage.setFrom(fromAddress);
-		mailMessage.setSubject(title);
-		mailMessage.setText(message);
+		mailMessage.setSubject(utf8Title);
+		mailMessage.setText(utf8Message);
 
 		mailSender.send(mailMessage);
 	}


### PR DESCRIPTION
## PR에 대한 설명 🔍
- PR의 내용에 대한 설명을 자세히 설명 
- 이메일 인코딩 깨짐 현상을 수정 

## 변경된 사항 📝

![image](https://github.com/user-attachments/assets/a3ddf3e9-9a12-414e-bcf0-21cfffa2ee97)
배포 서버에서 이메일 사용 시 깨짐 현상이 발생하였습니다.
메일 측 서버에서 제공하는 기본 인코딩이 ISO-8859-1 입니다. 
따라서 utf-8로 변환 시켜서  이메일을 발송하는 코드로 수정하였습니다. 

## PR에서 중점적으로 확인되어야 하는 사항
