### PR TITLE
refactor: 매치 점수 조회 응답을 수정했습니다.

### DIFF
--- a/api/src/main/java/org/badminton/api/interfaces/match/controller/MatchController.java
+++ b/api/src/main/java/org/badminton/api/interfaces/match/controller/MatchController.java
@@ -54,7 +54,7 @@ public class MatchController {
 
 	@GetMapping("/{matchId}")
 	@Operation(summary = "특정 게임의 세트별 점수 상세 조회",
-		description = "특정 게임의 세트별 점수를 상세 조회합니다.",
+		description = "특정 게임의 세트별 점수를 상세 조회합니다. FINISHED 인 세트만 조회합니다.",
 		tags = {"Match"})
 	public CommonResponse<MatchDetailsResponse> getMatchDetails(
 		@PathVariable String clubToken,

--- a/api/src/main/java/org/badminton/api/interfaces/match/dto/DoublesMatchResponse.java
+++ b/api/src/main/java/org/badminton/api/interfaces/match/dto/DoublesMatchResponse.java
@@ -11,22 +11,22 @@ public record DoublesMatchResponse(
 
 	@Schema(description = "매치 아이디", requiredMode = Schema.RequiredMode.REQUIRED)
 	Long matchId,
+	@Schema(description = "매치의 라운드 번호", requiredMode = Schema.RequiredMode.REQUIRED)
 	int roundNumber,
 	@Schema(description = "매치 상태(NOT_STARTED | IN_PROGRESS | FINISHED)", requiredMode = Schema.RequiredMode.REQUIRED)
 	MatchStatus matchStatus,
-
 	@Schema(description = "팀1", requiredMode = Schema.RequiredMode.REQUIRED)
 	MatchTeamResponse team1,
-
 	@Schema(description = "팀2", requiredMode = Schema.RequiredMode.REQUIRED)
 	MatchTeamResponse team2,
-
 	@Schema(description = "승자의 멤버토큰", requiredMode = Schema.RequiredMode.REQUIRED)
 	List<String> winnersToken
 
 ) {
 
 	public static DoublesMatchResponse fromDoublesMatchInfo(DoublesMatchInfo doublesMatchInfo) {
+		if (doublesMatchInfo == null)
+			return null;
 		return new DoublesMatchResponse(
 			doublesMatchInfo.matchId(),
 			doublesMatchInfo.roundNumber(),

--- a/api/src/main/java/org/badminton/api/interfaces/match/dto/DoublesSetResponse.java
+++ b/api/src/main/java/org/badminton/api/interfaces/match/dto/DoublesSetResponse.java
@@ -1,5 +1,6 @@
 package org.badminton.api.interfaces.match.dto;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.badminton.domain.common.enums.SetStatus;
@@ -20,7 +21,7 @@ public record DoublesSetResponse(
 
 	public static List<DoublesSetResponse> fromDoublesSetInfoList(List<DoublesSetInfo> doublesSetInfoList) {
 		if (doublesSetInfoList == null)
-			return null;
+			return Collections.emptyList();
 		return doublesSetInfoList.stream()
 			.map(doublesSet -> new DoublesSetResponse(doublesSet.setNumber(), doublesSet.score1(), doublesSet.score2(),
 				doublesSet.setStatus()))

--- a/api/src/main/java/org/badminton/api/interfaces/match/dto/DoublesSetResponse.java
+++ b/api/src/main/java/org/badminton/api/interfaces/match/dto/DoublesSetResponse.java
@@ -1,6 +1,5 @@
 package org.badminton.api.interfaces.match.dto;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.badminton.domain.common.enums.SetStatus;
@@ -21,7 +20,7 @@ public record DoublesSetResponse(
 
 	public static List<DoublesSetResponse> fromDoublesSetInfoList(List<DoublesSetInfo> doublesSetInfoList) {
 		if (doublesSetInfoList == null)
-			return Collections.emptyList();
+			return null;
 		return doublesSetInfoList.stream()
 			.map(doublesSet -> new DoublesSetResponse(doublesSet.setNumber(), doublesSet.score1(), doublesSet.score2(),
 				doublesSet.setStatus()))

--- a/api/src/main/java/org/badminton/api/interfaces/match/dto/DoublesSetResponse.java
+++ b/api/src/main/java/org/badminton/api/interfaces/match/dto/DoublesSetResponse.java
@@ -1,25 +1,29 @@
 package org.badminton.api.interfaces.match.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.ArrayList;
 import java.util.List;
+
+import org.badminton.domain.common.enums.SetStatus;
 import org.badminton.domain.domain.match.info.DoublesSetInfo;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record DoublesSetResponse(
-        @Schema(description = "세트 번호 (1 | 2 | 3)")
-        int setNumber,
-        @Schema(description = "스코어 1")
-        int score1,
-        @Schema(description = "스코어 2")
-        int score2
+	@Schema(description = "세트 번호 (1 | 2 | 3)")
+	int setNumber,
+	@Schema(description = "스코어 1")
+	int score1,
+	@Schema(description = "스코어 2")
+	int score2,
+	@Schema(description = "세트 상태")
+	SetStatus setStatus
 ) {
 
-    public static List<DoublesSetResponse> fromDoublesSetInfoList(List<DoublesSetInfo> doublesSetInfoList) {
-        List<DoublesSetResponse> doublesSetResponses = new ArrayList<>();
-        for (DoublesSetInfo doublesSetInfo : doublesSetInfoList) {
-            doublesSetResponses.add(new DoublesSetResponse(doublesSetInfo.setNumber(), doublesSetInfo.score1(),
-                    doublesSetInfo.score2()));
-        }
-        return doublesSetResponses;
-    }
+	public static List<DoublesSetResponse> fromDoublesSetInfoList(List<DoublesSetInfo> doublesSetInfoList) {
+		if (doublesSetInfoList == null)
+			return null;
+		return doublesSetInfoList.stream()
+			.map(doublesSet -> new DoublesSetResponse(doublesSet.setNumber(), doublesSet.score1(), doublesSet.score2(),
+				doublesSet.setStatus()))
+			.toList();
+	}
 }

--- a/api/src/main/java/org/badminton/api/interfaces/match/dto/MatchDetailsResponse.java
+++ b/api/src/main/java/org/badminton/api/interfaces/match/dto/MatchDetailsResponse.java
@@ -1,45 +1,53 @@
 package org.badminton.api.interfaces.match.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import java.util.List;
+
 import org.badminton.domain.common.enums.MatchType;
 import org.badminton.domain.domain.match.info.MatchInfo;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+
 public record MatchDetailsResponse(
-        @Schema(description = "매치 아이디", requiredMode = RequiredMode.REQUIRED)
-        Long matchId,
-        @Schema(description = "경기 아이디", requiredMode = RequiredMode.REQUIRED)
-        Long leagueId,
-        @Schema(description = "매치 타입", requiredMode = RequiredMode.REQUIRED)
-        MatchType matchType,
-        @Schema(description = "단식 경기")
-        SinglesMatchResponse singlesMatch,
-        @Schema(description = "복식 경기")
-        DoublesMatchResponse doublesMatch,
-        @Schema(description = "단식 경기 세트")
-        List<SinglesSetResponse> singlesSets,
-        @Schema(description = "복식 경기 세트")
-        List<DoublesSetResponse> doublesSets
+	@Schema(description = "매치 아이디", requiredMode = RequiredMode.REQUIRED)
+	Long matchId,
+	@Schema(description = "경기 아이디", requiredMode = RequiredMode.REQUIRED)
+	Long leagueId,
+	@Schema(description = "경기 제목", requiredMode = RequiredMode.REQUIRED)
+	String leagueTitle,
+	@Schema(description = "매치 타입", requiredMode = RequiredMode.REQUIRED)
+	MatchType matchType,
+	@Schema(description = "현재 진행 중인 세트 넘버, 만약 진행 중인 세트가 없다면 null 응답", requiredMode = RequiredMode.REQUIRED)
+	Integer setNumberInProgress,
+	@Schema(description = "단식 경기")
+	SinglesMatchResponse singlesMatch,
+	@Schema(description = "복식 경기")
+	DoublesMatchResponse doublesMatch,
+	@Schema(description = "상태가 FINISHED 인 단식 경기 세트")
+	List<SinglesSetResponse> singlesSets,
+	@Schema(description = "상태가 FINISHED 인 복식 경기 세트")
+	List<DoublesSetResponse> doublesSets
 ) {
 
-    public static MatchDetailsResponse fromMatchDetailsInfo(MatchInfo.SetScoreDetails matchDetails) {
-        return new MatchDetailsResponse(
-                matchDetails.matchId(),
-                matchDetails.leagueId(),
-                matchDetails.matchType(),
-                matchDetails.matchType() == MatchType.SINGLES
-                        ? SinglesMatchResponse.fromSinglesMatchInfo(matchDetails.singlesMatch())
-                        : null,
-                matchDetails.matchType() == MatchType.DOUBLES
-                        ? DoublesMatchResponse.fromDoublesMatchInfo(matchDetails.doublesMatch())
-                        : null,
-                matchDetails.matchType() == MatchType.SINGLES
-                        ? SinglesSetResponse.fromSinglesSetInfoList(matchDetails.singlesSets())
-                        : null,
-                matchDetails.matchType() == MatchType.DOUBLES
-                        ? DoublesSetResponse.fromDoublesSetInfoList(matchDetails.doublesSets())
-                        : null
-        );
-    }
+	public static MatchDetailsResponse fromMatchDetailsInfo(MatchInfo.SetScoreDetails matchDetails) {
+		return new MatchDetailsResponse(
+			matchDetails.matchId(),
+			matchDetails.leagueId(),
+			matchDetails.leagueName(),
+			matchDetails.matchType(),
+			matchDetails.setNumberInProgress(),
+			matchDetails.matchType() == MatchType.SINGLES
+				? SinglesMatchResponse.fromSinglesMatchInfo(matchDetails.singlesMatch())
+				: null,
+			matchDetails.matchType() == MatchType.DOUBLES
+				? DoublesMatchResponse.fromDoublesMatchInfo(matchDetails.doublesMatch())
+				: null,
+			matchDetails.matchType() == MatchType.SINGLES
+				? SinglesSetResponse.fromSinglesSetInfoList(matchDetails.singlesSets())
+				: null,
+			matchDetails.matchType() == MatchType.DOUBLES
+				? DoublesSetResponse.fromDoublesSetInfoList(matchDetails.doublesSets())
+				: null
+		);
+	}
 }

--- a/api/src/main/java/org/badminton/api/interfaces/match/dto/MatchDetailsResponse.java
+++ b/api/src/main/java/org/badminton/api/interfaces/match/dto/MatchDetailsResponse.java
@@ -36,18 +36,10 @@ public record MatchDetailsResponse(
 			matchDetails.leagueName(),
 			matchDetails.matchType(),
 			matchDetails.setNumberInProgress(),
-			matchDetails.matchType() == MatchType.SINGLES
-				? SinglesMatchResponse.fromSinglesMatchInfo(matchDetails.singlesMatch())
-				: null,
-			matchDetails.matchType() == MatchType.DOUBLES
-				? DoublesMatchResponse.fromDoublesMatchInfo(matchDetails.doublesMatch())
-				: null,
-			matchDetails.matchType() == MatchType.SINGLES
-				? SinglesSetResponse.fromSinglesSetInfoList(matchDetails.singlesSets())
-				: null,
-			matchDetails.matchType() == MatchType.DOUBLES
-				? DoublesSetResponse.fromDoublesSetInfoList(matchDetails.doublesSets())
-				: null
+			SinglesMatchResponse.fromSinglesMatchInfo(matchDetails.singlesMatch()),
+			DoublesMatchResponse.fromDoublesMatchInfo(matchDetails.doublesMatch()),
+			SinglesSetResponse.fromSinglesSetInfoList(matchDetails.singlesSets()),
+			DoublesSetResponse.fromDoublesSetInfoList(matchDetails.doublesSets())
 		);
 	}
 }

--- a/api/src/main/java/org/badminton/api/interfaces/match/dto/SinglesMatchResponse.java
+++ b/api/src/main/java/org/badminton/api/interfaces/match/dto/SinglesMatchResponse.java
@@ -23,7 +23,6 @@ public record SinglesMatchResponse(
 
 	public static SinglesMatchResponse fromSinglesMatchInfo(SinglesMatchInfo singlesMatchInfo) {
 		return new SinglesMatchResponse(
-
 			singlesMatchInfo.matchId(),
 			singlesMatchInfo.roundNumber(),
 			singlesMatchInfo.matchStatus(),

--- a/api/src/main/java/org/badminton/api/interfaces/match/dto/SinglesMatchResponse.java
+++ b/api/src/main/java/org/badminton/api/interfaces/match/dto/SinglesMatchResponse.java
@@ -22,6 +22,9 @@ public record SinglesMatchResponse(
 ) {
 
 	public static SinglesMatchResponse fromSinglesMatchInfo(SinglesMatchInfo singlesMatchInfo) {
+		if (singlesMatchInfo == null) {
+			return null;
+		}
 		return new SinglesMatchResponse(
 			singlesMatchInfo.matchId(),
 			singlesMatchInfo.roundNumber(),

--- a/api/src/main/java/org/badminton/api/interfaces/match/dto/SinglesSetResponse.java
+++ b/api/src/main/java/org/badminton/api/interfaces/match/dto/SinglesSetResponse.java
@@ -1,25 +1,30 @@
 package org.badminton.api.interfaces.match.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.ArrayList;
 import java.util.List;
+
+import org.badminton.domain.common.enums.SetStatus;
 import org.badminton.domain.domain.match.info.SinglesSetInfo;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record SinglesSetResponse(
-        @Schema(description = "세트 번호 (1 | 2 | 3)")
-        int setNumber,
-        @Schema(description = "스코어 1")
-        int score1,
-        @Schema(description = "스코어 2")
-        int score2
+	@Schema(description = "세트 번호 (1 | 2 | 3)")
+	int setNumber,
+	@Schema(description = "스코어 1")
+	int score1,
+	@Schema(description = "스코어 2")
+	int score2,
+	@Schema(description = "세트 상태")
+	SetStatus setStatus
 ) {
 
-    public static List<SinglesSetResponse> fromSinglesSetInfoList(List<SinglesSetInfo> singlesSetInfoList) {
-        List<SinglesSetResponse> singlesSetResponses = new ArrayList<>();
-        for (SinglesSetInfo singlesSetInfo : singlesSetInfoList) {
-            singlesSetResponses.add(new SinglesSetResponse(singlesSetInfo.setNumber(), singlesSetInfo.score1(),
-                    singlesSetInfo.score2()));
-        }
-        return singlesSetResponses;
-    }
+	public static List<SinglesSetResponse> fromSinglesSetInfoList(List<SinglesSetInfo> singlesSetInfoList) {
+		if (singlesSetInfoList == null) {
+			return null;
+		}
+		return singlesSetInfoList.stream()
+			.map(singlesSetInfo -> new SinglesSetResponse(singlesSetInfo.setNumber(), singlesSetInfo.score1(),
+				singlesSetInfo.score2(), singlesSetInfo.setStatus()))
+			.toList();
+	}
 }

--- a/domain/src/main/java/org/badminton/domain/domain/match/entity/DoublesMatch.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/entity/DoublesMatch.java
@@ -126,4 +126,11 @@ public class DoublesMatch extends AbstractBaseTime {
 			.filter(doublesSet -> doublesSet.getSetStatus() == SetStatus.IN_PROGRESS)
 			.findFirst();
 	}
+
+	public Integer getSetNumberInProgress() {
+		if (getSetInProgress().isEmpty()) {
+			return null;
+		}
+		return getSetInProgress().get().getSetNumber();
+	}
 }

--- a/domain/src/main/java/org/badminton/domain/domain/match/entity/SinglesMatch.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/entity/SinglesMatch.java
@@ -115,6 +115,13 @@ public class SinglesMatch extends AbstractBaseTime {
 			.findFirst();
 	}
 
+	public Integer getSetNumberInProgress() {
+		if (getSetInProgress().isEmpty()) {
+			return null;
+		}
+		return getSetInProgress().get().getSetNumber();
+	}
+
 	public SinglesSet getSinglesSet(int setNumber) {
 		return this.singlesSets.get(setNumber - 1);
 	}

--- a/domain/src/main/java/org/badminton/domain/domain/match/info/DoublesSetInfo.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/info/DoublesSetInfo.java
@@ -1,23 +1,22 @@
 package org.badminton.domain.domain.match.info;
 
-import java.util.ArrayList;
 import java.util.List;
 
+import org.badminton.domain.common.enums.SetStatus;
 import org.badminton.domain.domain.match.entity.DoublesSet;
 
 public record DoublesSetInfo(
 	int setNumber,
 	int score1,
-	int score2
+	int score2,
+	SetStatus setStatus
 ) {
 
-	public static List<DoublesSetInfo> fromDoublesSets(List<DoublesSet> doublesSets) {
-		List<DoublesSetInfo> doublesSetResponseList = new ArrayList<>();
-		for (DoublesSet doublesSet : doublesSets) {
-			doublesSetResponseList.add(new DoublesSetInfo(doublesSet.getSetNumber(), doublesSet.getTeam1Score(),
-				doublesSet.getTeam2Score()));
-		}
-		return doublesSetResponseList;
+	public static List<DoublesSetInfo> finishedSets(List<DoublesSet> doublesSets) {
+		return doublesSets.stream()
+			.filter(doublesSet -> doublesSet.getSetStatus() == SetStatus.FINISHED)
+			.map(doublesSet -> new DoublesSetInfo(doublesSet.getSetNumber(), doublesSet.getTeam1Score(),
+				doublesSet.getTeam2Score(), doublesSet.getSetStatus()))
+			.toList();
 	}
-
 }

--- a/domain/src/main/java/org/badminton/domain/domain/match/info/MatchInfo.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/info/MatchInfo.java
@@ -14,7 +14,9 @@ public class MatchInfo {
 	public record SetScoreDetails(
 		Long matchId,
 		Long leagueId,
+		String leagueName,
 		MatchType matchType,
+		Integer setNumberInProgress,
 		SinglesMatchInfo singlesMatch,
 		DoublesMatchInfo doublesMatch,
 		List<SinglesSetInfo> singlesSets,
@@ -25,24 +27,26 @@ public class MatchInfo {
 
 			return new SetScoreDetails(singlesMatch.getId(),
 				singlesMatch.getLeague().getLeagueId(),
+				singlesMatch.getLeague().getLeagueName(),
 				MatchType.SINGLES,
+				singlesMatch.getSetNumberInProgress(),
 				SinglesMatchInfo.fromSinglesMatch(singlesMatch),
 				null,
-				SinglesSetInfo.fromSinglesSets(singlesMatch.getSinglesSets()),
+				SinglesSetInfo.finishedSets(singlesMatch.getSinglesSets()),
 				null);
-
 		}
 
 		public static SetScoreDetails fromDoublesMatchToMatchDetails(DoublesMatch doublesMatch) {
 
 			return new SetScoreDetails(doublesMatch.getId(),
 				doublesMatch.getLeague().getLeagueId(),
+				doublesMatch.getLeague().getLeagueName(),
 				MatchType.DOUBLES,
+				doublesMatch.getSetNumberInProgress(),
 				null,
 				DoublesMatchInfo.fromDoublesMatch(doublesMatch),
 				null,
-				DoublesSetInfo.fromDoublesSets(doublesMatch.getDoublesSets()));
-
+				DoublesSetInfo.finishedSets(doublesMatch.getDoublesSets()));
 		}
 	}
 }

--- a/domain/src/main/java/org/badminton/domain/domain/match/info/SinglesSetInfo.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/info/SinglesSetInfo.java
@@ -1,22 +1,22 @@
 package org.badminton.domain.domain.match.info;
 
-import java.util.ArrayList;
 import java.util.List;
 
+import org.badminton.domain.common.enums.SetStatus;
 import org.badminton.domain.domain.match.entity.SinglesSet;
 
 public record SinglesSetInfo(
 	int setNumber,
 	int score1,
-	int score2
+	int score2,
+	SetStatus setStatus
 ) {
 
-	public static List<SinglesSetInfo> fromSinglesSets(List<SinglesSet> singlesSets) {
-		List<SinglesSetInfo> singlesSetResponseList = new ArrayList<>();
-		for (SinglesSet singlesSet : singlesSets) {
-			singlesSetResponseList.add(new SinglesSetInfo(singlesSet.getSetNumber(), singlesSet.getPlayer1Score(),
-				singlesSet.getPlayer2Score()));
-		}
-		return singlesSetResponseList;
+	public static List<SinglesSetInfo> finishedSets(List<SinglesSet> singlesSets) {
+		return singlesSets.stream()
+			.filter(singlesSet -> singlesSet.getSetStatus() == SetStatus.FINISHED)
+			.map(singlesSet -> new SinglesSetInfo(singlesSet.getSetNumber(), singlesSet.getPlayer1Score(),
+				singlesSet.getPlayer2Score(), singlesSet.getSetStatus()))
+			.toList();
 	}
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍

매치 점수 조회 Response를 수정했습니다.

- [x] 모든 세트를 응답에 포함하지 않고, 상태가 FINISHED인 세트를만 조회합니다.
- [x] 만약 FINISHED인 세트가 없다면 null 값을 return 합니다.
- [x] In Progress 인 세트가 없다면 setNumberInProgress 는 null 을 return 합니다.

```java
	@Schema(description = "상태가 FINISHED 인 단식 경기 세트")
	List<SinglesSetResponse> singlesSets,
	@Schema(description = "상태가 FINISHED 인 복식 경기 세트")
	List<DoublesSetResponse> doublesSets
```


## 변경된 사항 📝

- [x] Response 스키마가 변경되었습니다. 


## PR에서 중점적으로 확인되어야 하는 사항

null 을 리턴하는 것 말고 더 좋은 방법이 있을까요? Set Number를 Enum 으로 구현하는 것은 아직 FE와 논의해보지 못했습니다.