### PR TITLE
feat: 이미지 비동기 처리

### DIFF
--- a/api/src/main/java/org/badminton/api/application/clubImage/ClubImageFacade.java
+++ b/api/src/main/java/org/badminton/api/application/clubImage/ClubImageFacade.java
@@ -1,0 +1,50 @@
+package org.badminton.api.application.clubImage;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import org.badminton.api.aws.s3.event.clubImage.ClubImageEvent;
+import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ClubImageFacade {
+	private final ApplicationEventPublisher eventPublisher;
+	private static final String CLOUDFRONT_URL_PREFIX = "https://d36om9pjoifd2y.cloudfront.net/club-banner/";
+	private static final String WEBP = "webp";
+	private static final String AVIF = "avif";
+
+	@Transactional
+	public String saveImage(ImageUploadRequest request) {
+		// uuid 객체 생성
+		String uuid = UUID.randomUUID().toString();
+		String extension = getFileExtension(Objects.requireNonNull(request.multipartFile().getOriginalFilename()));
+
+		// 비동기 처리
+		eventPublisher.publishEvent(new ClubImageEvent(request.multipartFile(), uuid));
+
+		// url 만드는 곳으로 전달
+		return preReturnUrl(uuid, extension);
+	}
+
+	private String preReturnUrl(String uuid, String extension) {
+		String origin = CLOUDFRONT_URL_PREFIX + uuid + ".";
+		if (extension.equals(WEBP) || extension.equals(AVIF)) {
+			return origin + extension;
+		}
+		return origin + WEBP;
+	}
+
+	private String getFileExtension(String filename) {
+		int dotIndex = filename.lastIndexOf(".");
+		if (dotIndex == -1) {
+			return "";
+		}
+		return filename.substring(dotIndex + 1);
+	}
+}

--- a/api/src/main/java/org/badminton/api/application/member/MemberFacade.java
+++ b/api/src/main/java/org/badminton/api/application/member/MemberFacade.java
@@ -3,7 +3,12 @@ package org.badminton.api.application.member;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
 
+import org.badminton.api.aws.s3.event.memeber.MemberImageEvent;
+import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
+import org.badminton.api.common.exception.member.MemberNotExistException;
 import org.badminton.api.interfaces.match.dto.MatchResultResponse;
 import org.badminton.domain.domain.club.info.ClubCardInfo;
 import org.badminton.domain.domain.clubmember.info.ClubMemberMyPageInfo;
@@ -17,6 +22,7 @@ import org.badminton.domain.domain.member.info.MemberMyPageInfo;
 import org.badminton.domain.domain.member.info.MemberUpdateInfo;
 import org.badminton.domain.domain.member.info.SimpleMemberInfo;
 import org.badminton.domain.domain.member.service.MemberService;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -32,6 +38,11 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class MemberFacade {
+	private final ApplicationEventPublisher eventPublisher;
+
+	private static final String CLOUDFRONT_URL_PREFIX = "https://d36om9pjoifd2y.cloudfront.net/member-profile/";
+	private static final String WEBP = "webp";
+	private static final String AVIF = "avif";
 	private static final String SORT_METHOD = "leagueAt";
 
 	private final MemberService memberService;
@@ -82,5 +93,37 @@ public class MemberFacade {
 		int end = Math.min((start + pageable.getPageSize()), allMatchResults.size());
 		return new PageImpl<>(allMatchResults
 			.subList(start, end), pageable, allMatchResults.size());
+	}
+
+	@Transactional
+	public String saveImage(ImageUploadRequest request, String memberToken) {
+		// uuid 객체 생성
+		String uuid = UUID.randomUUID().toString();
+		String extension = getFileExtension(Objects.requireNonNull(request.multipartFile().getOriginalFilename()));
+
+		if (memberToken == null) {
+			throw new MemberNotExistException("멤버 토큰이 없습니다. 로그인을 먼저 해주세요.");
+		}
+		// 비동기 처리
+		eventPublisher.publishEvent(new MemberImageEvent(request.multipartFile(), uuid));
+
+		// url 만드는 곳으로 전달
+		return preReturnUrl(uuid, extension);
+	}
+
+	private String preReturnUrl(String uuid, String extension) {
+		String origin = CLOUDFRONT_URL_PREFIX + uuid + ".";
+		if (extension.equals(WEBP) || extension.equals(AVIF)) {
+			return origin + extension;
+		}
+		return origin + WEBP;
+	}
+
+	private String getFileExtension(String filename) {
+		int dotIndex = filename.lastIndexOf(".");
+		if (dotIndex == -1) {
+			return "";
+		}
+		return filename.substring(dotIndex + 1);
 	}
 }

--- a/api/src/main/java/org/badminton/api/application/member/MemberFacade.java
+++ b/api/src/main/java/org/badminton/api/application/member/MemberFacade.java
@@ -6,9 +6,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
+import org.apache.commons.lang3.StringUtils;
 import org.badminton.api.aws.s3.event.memeber.MemberImageEvent;
 import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
-import org.badminton.api.common.exception.member.MemberNotExistException;
 import org.badminton.api.interfaces.match.dto.MatchResultResponse;
 import org.badminton.domain.domain.club.info.ClubCardInfo;
 import org.badminton.domain.domain.clubmember.info.ClubMemberMyPageInfo;
@@ -96,14 +96,11 @@ public class MemberFacade {
 	}
 
 	@Transactional
-	public String saveImage(ImageUploadRequest request, String memberToken) {
+	public String saveImage(ImageUploadRequest request) {
 		// uuid 객체 생성
 		String uuid = UUID.randomUUID().toString();
 		String extension = getFileExtension(Objects.requireNonNull(request.multipartFile().getOriginalFilename()));
 
-		if (memberToken == null) {
-			throw new MemberNotExistException("멤버 토큰이 없습니다. 로그인을 먼저 해주세요.");
-		}
 		// 비동기 처리
 		eventPublisher.publishEvent(new MemberImageEvent(request.multipartFile(), uuid));
 
@@ -122,7 +119,7 @@ public class MemberFacade {
 	private String getFileExtension(String filename) {
 		int dotIndex = filename.lastIndexOf(".");
 		if (dotIndex == -1) {
-			return "";
+			return StringUtils.EMPTY;
 		}
 		return filename.substring(dotIndex + 1);
 	}

--- a/api/src/main/java/org/badminton/api/aws/s3/controller/ClubImageController.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/controller/ClubImageController.java
@@ -1,7 +1,7 @@
 package org.badminton.api.aws.s3.controller;
 
+import org.badminton.api.application.clubImage.ClubImageFacade;
 import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
-import org.badminton.api.aws.s3.service.ClubImageService;
 import org.badminton.api.common.response.CommonResponse;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,11 +14,11 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/v1/clubs/images")
 public class ClubImageController {
-	private final ClubImageService clubImageService;
+	private final ClubImageFacade clubImageFacade;
 
 	@PostMapping
 	@Operation(
@@ -34,6 +34,6 @@ public class ClubImageController {
 	)
 	public CommonResponse<String> saveImage(@RequestPart("multipartFile") MultipartFile multipartFile) {
 		ImageUploadRequest request = new ImageUploadRequest(multipartFile);
-		return CommonResponse.success(clubImageService.uploadFile(request));
+		return CommonResponse.success(clubImageFacade.saveImage(request));
 	}
 }

--- a/api/src/main/java/org/badminton/api/aws/s3/event/clubImage/ClubImageEvent.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/event/clubImage/ClubImageEvent.java
@@ -1,0 +1,13 @@
+package org.badminton.api.aws.s3.event.clubImage;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ClubImageEvent {
+	private final MultipartFile multipartFile;
+	private final String uuid;
+}

--- a/api/src/main/java/org/badminton/api/aws/s3/event/clubImage/ClubImageEventHandler.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/event/clubImage/ClubImageEventHandler.java
@@ -1,0 +1,20 @@
+package org.badminton.api.aws.s3.event.clubImage;
+
+import org.badminton.api.aws.s3.service.ClubImageService;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ClubImageEventHandler {
+	private final ClubImageService clubImageService;
+
+	@Async
+	@TransactionalEventListener
+	public void convertAndSaveImage(ClubImageEvent clubImageEvent) {
+		clubImageService.uploadFile(clubImageEvent.getMultipartFile(), clubImageEvent.getUuid());
+	}
+}

--- a/api/src/main/java/org/badminton/api/aws/s3/event/memeber/MemberImageEvent.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/event/memeber/MemberImageEvent.java
@@ -1,0 +1,13 @@
+package org.badminton.api.aws.s3.event.memeber;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberImageEvent {
+	private final MultipartFile multipartFile;
+	private final String uuid;
+}

--- a/api/src/main/java/org/badminton/api/aws/s3/event/memeber/MemberImageEventHandler.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/event/memeber/MemberImageEventHandler.java
@@ -1,0 +1,23 @@
+package org.badminton.api.aws.s3.event.memeber;
+
+import org.badminton.api.aws.s3.service.MemberProfileImageService;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MemberImageEventHandler {
+	private final MemberProfileImageService memberProfileImageService;
+
+	@Async
+	@TransactionalEventListener
+	public void convertAndSaveImage(MemberImageEvent memberImageEvent) {
+		memberProfileImageService.uploadFile(
+			memberImageEvent.getMultipartFile(),
+			memberImageEvent.getUuid()
+		);
+	}
+}

--- a/api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Objects;
 
-import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
 import org.badminton.api.common.exception.EmptyFileException;
 import org.badminton.api.common.exception.FileSizeOverException;
 import org.springframework.beans.factory.annotation.Value;
@@ -32,22 +31,20 @@ public abstract class AbstractFileUploadService implements ImageService {
 	private static final String S3_URL_PREFIX = "https://badminton-team.s3.ap-northeast-2.amazonaws.com";
 	private static final String CLOUDFRONT_URL_PREFIX = "https://d36om9pjoifd2y.cloudfront.net";
 
-	public String uploadFile(ImageUploadRequest file) {
-		MultipartFile uploadFile = file.multipartFile();
+	public String uploadFile(MultipartFile uploadFile, String uuid) {
 		if (uploadFile.getSize() > MAX_FILE_SIZE) {
 			throw new FileSizeOverException(uploadFile.getSize());
 		}
 
-		// 파일이 비어있거나 파일 이름이 없는 경우 체크
 		if (uploadFile.isEmpty() || Objects.isNull(uploadFile.getOriginalFilename())) {
 			throw new EmptyFileException();
 		}
+
 		try {
 			String fileExtension = getFileExtension(uploadFile.getOriginalFilename());
-
 			byte[] processedImage = processImage(uploadFile, fileExtension);
 			String newFileExtension = determineNewFileExtension(fileExtension);
-			String fileName = makeFileName(newFileExtension);
+			String fileName = makeFileName(newFileExtension, uuid);
 
 			ObjectMetadata objectMetadata = new ObjectMetadata();
 			objectMetadata.setContentLength(processedImage.length);
@@ -98,5 +95,5 @@ public abstract class AbstractFileUploadService implements ImageService {
 	}
 
 	@Override
-	public abstract String makeFileName(String newFileExtension);
+	public abstract String makeFileName(String newFileExtension, String uuid);
 }

--- a/api/src/main/java/org/badminton/api/aws/s3/service/ClubImageService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/ClubImageService.java
@@ -1,9 +1,7 @@
 package org.badminton.api.aws.s3.service;
 
-import java.util.UUID;
-
-import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.amazonaws.services.s3.AmazonS3;
 
@@ -15,13 +13,13 @@ public class ClubImageService extends AbstractFileUploadService {
 	}
 
 	@Override
-	public String uploadFile(ImageUploadRequest file) {
-		return super.uploadFile(file);
+	public String uploadFile(MultipartFile file, String uuid) {
+		return super.uploadFile(file, uuid);
 	}
 
 	@Override
-	public String makeFileName(String newFileExtension) {
-		return "club-banner/" + UUID.randomUUID() + "." + newFileExtension;
+	public String makeFileName(String newFileExtension, String uuid) {
+		return "club-banner/" + uuid + "." + newFileExtension;
 	}
 }
 

--- a/api/src/main/java/org/badminton/api/aws/s3/service/ImageService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/ImageService.java
@@ -1,10 +1,10 @@
 package org.badminton.api.aws.s3.service;
 
-import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface ImageService {
-	String uploadFile(ImageUploadRequest file);
+	String uploadFile(MultipartFile file, String uuid);
 
-	String makeFileName(String newFileExtension);
+	String makeFileName(String newFileExtension, String uuid);
 }
 

--- a/api/src/main/java/org/badminton/api/aws/s3/service/MemberProfileImageService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/MemberProfileImageService.java
@@ -1,35 +1,25 @@
 package org.badminton.api.aws.s3.service;
 
-import java.util.UUID;
-
-import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
-import org.badminton.api.common.exception.member.MemberNotExistException;
-import org.badminton.domain.domain.member.service.MemberService;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.amazonaws.services.s3.AmazonS3;
 
 @Service
 public class MemberProfileImageService extends AbstractFileUploadService {
 
-	private String currentMemberToken;
-
-	public MemberProfileImageService(AmazonS3 s3Client, MemberService memberService,
-		ImageConversionService imageConversionService) {
+	public MemberProfileImageService(AmazonS3 s3Client, ImageConversionService imageConversionService) {
 		super(s3Client, imageConversionService);
 	}
 
-	public String uploadFile(ImageUploadRequest file, String memberToken) {
-		this.currentMemberToken = memberToken;
-		return super.uploadFile(file);
-
+	@Override
+	public String uploadFile(MultipartFile file, String uuid) {
+		return super.uploadFile(file, uuid);
 	}
 
 	@Override
-	public String makeFileName(String originalFilename) {
-		if (this.currentMemberToken == null) {
-			throw new MemberNotExistException("멤버 토큰이 없습니다. 로그인을 먼저 해주세요.");
-		}
-		return "member-profile/" + UUID.randomUUID() + ".webp";
+	public String makeFileName(String newFileExtension, String uuid) {
+		return "member-profile/" + uuid + "." + newFileExtension;
 	}
+
 }

--- a/api/src/main/java/org/badminton/api/interfaces/member/controller/MemberController.java
+++ b/api/src/main/java/org/badminton/api/interfaces/member/controller/MemberController.java
@@ -125,15 +125,15 @@ public class MemberController {
 			)
 		)
 	)
+
 	@PostMapping("/profileImage")
 	public CommonResponse<String> uploadProfileImage(
-		@RequestPart(value = "multipartFile", required = false) MultipartFile multipartFile,
-		@AuthenticationPrincipal CustomOAuth2Member member) {
+		@RequestPart(value = "multipartFile", required = false) MultipartFile multipartFile) {
 		if (multipartFile == null || multipartFile.isEmpty()) {
 			throw new ImageFileNotFoundException();
 		}
 		ImageUploadRequest request = new ImageUploadRequest(multipartFile);
-		return CommonResponse.success(memberFacade.saveImage(request, member.getMemberToken()));
+		return CommonResponse.success(memberFacade.saveImage(request));
 	}
 
 	@Operation(

--- a/api/src/main/java/org/badminton/api/interfaces/member/controller/MemberController.java
+++ b/api/src/main/java/org/badminton/api/interfaces/member/controller/MemberController.java
@@ -133,7 +133,7 @@ public class MemberController {
 			throw new ImageFileNotFoundException();
 		}
 		ImageUploadRequest request = new ImageUploadRequest(multipartFile);
-		return CommonResponse.success(memberProfileImageService.uploadFile(request, member.getMemberToken()));
+		return CommonResponse.success(memberFacade.saveImage(request, member.getMemberToken()));
 	}
 
 	@Operation(


### PR DESCRIPTION
## PR에 대한 설명 🔍
- PR의 내용에 대한 설명을 자세히 설명 
- 이미지를 비동기 처리하여 사용자 경험을 높히는 작업 

## 변경된 사항 📝

<!-- 이번 PR에서의 변경점 -->
- 기존 이미지를 컨버팅해서 동기 방식으로 저장을 비동기식으로 변경


<!-- 개발 기능을 보여줄 수 있는 이미지, GIF, 글 -->

### Before
![스크린샷 2024-11-26 오후 4 51 54](https://github.com/user-attachments/assets/f14786dd-55d9-4c95-a3b3-287853c0fcb4)
![스크린샷 2024-11-26 오후 4 54 07](https://github.com/user-attachments/assets/63845cb0-a2ce-4ab4-9d8c-5d4817be6fcd)

기존 방식으로 진행 시 응답 시간은 500m/s ~ 700m/s로 다소 지연이 발생함

### After
이미지 저장은 비동기 방식으로 처리함으로써 응답시간 단축 


<img width="901" alt="스크린샷 2024-12-03 오후 4 15 30" src="https://github.com/user-attachments/assets/04917a39-9242-4590-a808-0f210f837036">


### **541ms -> 43ms 응답시간 단축** 92% 성능 개선  ❗️


## PR에서 중점적으로 확인되어야 하는 사항