### PR TITLE
refactor: 이벤트 리스너로 수정

### DIFF
--- a/api/src/main/java/org/badminton/api/aws/s3/event/clubImage/ClubImageEventHandler.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/event/clubImage/ClubImageEventHandler.java
@@ -1,9 +1,9 @@
 package org.badminton.api.aws.s3.event.clubImage;
 
 import org.badminton.api.aws.s3.service.ClubImageService;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,7 +13,7 @@ public class ClubImageEventHandler {
 	private final ClubImageService clubImageService;
 
 	@Async
-	@TransactionalEventListener
+	@EventListener
 	public void convertAndSaveImage(ClubImageEvent clubImageEvent) {
 		clubImageService.uploadFile(clubImageEvent.getMultipartFile(), clubImageEvent.getUuid());
 	}

--- a/api/src/main/java/org/badminton/api/aws/s3/event/memeber/MemberImageEventHandler.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/event/memeber/MemberImageEventHandler.java
@@ -1,9 +1,9 @@
 package org.badminton.api.aws.s3.event.memeber;
 
 import org.badminton.api.aws.s3.service.MemberProfileImageService;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,7 +13,7 @@ public class MemberImageEventHandler {
 	private final MemberProfileImageService memberProfileImageService;
 
 	@Async
-	@TransactionalEventListener
+	@EventListener
 	public void convertAndSaveImage(MemberImageEvent memberImageEvent) {
 		memberProfileImageService.uploadFile(
 			memberImageEvent.getMultipartFile(),


### PR DESCRIPTION
## PR에 대한 설명 🔍
- 어노테이션 변경 

## 변경된 사항 📝
[@EventListener와 @TransactionalEventListener 의 차이](https://github.com/Kernel360/F2_PLAY_BADMINTON_BE/wiki/%EC%9D%B4%EB%AF%B8%EC%A7%80-%EB%B9%84%EB%8F%99%EA%B8%B0-%EC%B2%98%EB%A6%AC%EB%A1%9C-%EC%84%B1%EB%8A%A5-%EA%B0%9C%EC%84%A0%ED%95%98%EA%B8%B0)

### After
변경 사유는 위키의 글과 같습니다. 
 : EventListener로 충분히 커버할 수 있습니다.

## PR에서 중점적으로 확인되어야 하는 사항
