### PR TITLE
fix: 대진표 재생성 조건 수정

### DIFF
--- a/api/src/main/java/org/badminton/api/config/security/SecurityConfig.java
+++ b/api/src/main/java/org/badminton/api/config/security/SecurityConfig.java
@@ -51,8 +51,7 @@ public class SecurityConfig {
 	public SecurityFilterChain publicFilterChain(HttpSecurity http) throws Exception {
 		http
 			.securityMatcher("/", "/oauth2/**", "/login/**", "/error", "/swagger-ui/**", "/v1/leagues/**",
-				"/v1/members/session",
-				"/v1/clubs/{clubToken}/clubMembers/check")
+				"/v1/members/session", "/v1/clubs/{clubToken}/clubMembers/check")
 			.csrf(AbstractHttpConfigurer::disable)
 			.cors(this::corsConfigurer)
 			.authorizeHttpRequests(auth -> auth

--- a/domain/src/main/java/org/badminton/domain/domain/match/service/AbstractDoublesMatchStrategy.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/service/AbstractDoublesMatchStrategy.java
@@ -10,7 +10,6 @@ import org.badminton.domain.common.exception.BadmintonException;
 import org.badminton.domain.common.exception.match.MatchAlreadyStartedExceptionWhenBracketGenerationException;
 import org.badminton.domain.domain.league.entity.League;
 import org.badminton.domain.domain.league.entity.LeagueParticipant;
-import org.badminton.domain.domain.match.command.MatchCommand;
 import org.badminton.domain.domain.match.entity.DoublesMatch;
 import org.badminton.domain.domain.match.entity.DoublesSet;
 import org.badminton.domain.domain.match.info.BracketInfo;
@@ -69,12 +68,6 @@ public abstract class AbstractDoublesMatchStrategy implements MatchStrategy {
 
 	@Override
 	public abstract BracketInfo makeBracket(League league, List<LeagueParticipant> leagueParticipantList);
-
-	@Override
-	public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setIndex,
-		MatchCommand.UpdateSetScore updateSetScoreCommand) {
-		return null;
-	}
 
 	@Override
 	public boolean isMatchInLeague(Long leagueId) {

--- a/domain/src/main/java/org/badminton/domain/domain/match/service/AbstractDoublesMatchStrategy.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/service/AbstractDoublesMatchStrategy.java
@@ -36,7 +36,7 @@ public abstract class AbstractDoublesMatchStrategy implements MatchStrategy {
 		if (doublesMatchReader.checkIfBracketEmpty(leagueId)) {
 			return;
 		}
-		if (doublesMatchReader.allMatchesFinishedForLeague(leagueId)) {
+		if (doublesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
 			doublesMatchStore.deleteDoublesBracket(leagueId);
 			return;
 		}

--- a/domain/src/main/java/org/badminton/domain/domain/match/service/AbstractSinglesMatchStrategy.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/service/AbstractSinglesMatchStrategy.java
@@ -37,7 +37,7 @@ public abstract class AbstractSinglesMatchStrategy implements MatchStrategy {
 		if (singlesMatchReader.checkIfBracketEmpty(leagueId)) {
 			return;
 		}
-		if (singlesMatchReader.allMatchesFinishedForLeague(leagueId)) {
+		if (singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
 			singlesMatchStore.deleteSinglesBracket(leagueId);
 			return;
 		}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/FreeBracketGenerationServiceImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/FreeBracketGenerationServiceImpl.java
@@ -66,9 +66,7 @@ public class FreeBracketGenerationServiceImpl implements BracketGenerationServic
 			throw new NotLeagueOwnerException(leagueId, memberToken);
 		}
 		matchStrategy.checkDuplicateInitialBracket(leagueId);
-
 		List<LeagueParticipant> leagueParticipantList = findLeagueParticipantList(leagueId);
-
 		return matchStrategy.makeBracket(findLeague(leagueId), leagueParticipantList);
 	}
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentBracketGenerationServiceImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentBracketGenerationServiceImpl.java
@@ -70,7 +70,6 @@ public class TournamentBracketGenerationServiceImpl implements BracketGeneration
 			throw new NotLeagueOwnerException(leagueId, memberToken);
 		}
 		matchStrategy.checkDuplicateInitialBracket(leagueId);
-
 		List<LeagueParticipant> leagueParticipantList = findLeagueParticipantList(leagueId);
 
 		return matchStrategy.makeBracket(findLeague(leagueId), leagueParticipantList);


### PR DESCRIPTION
## PR에 대한 설명 🔍

대진표 재생성 조건을 수정했습니다.
대진표는 아래의 상황에서 재생성이 가능합니다. 

- [x] RECRUITING_COMPLTED, PLAYING → 어떤 Match Set도 시작되지 않았다면 만들 수 있다.
- [x] RECRUITING_COMPLETED일 때! (그 어떤 Match Set 도 시작되지 않았기 때문에) 무조건 만들 수 있다.
- [x] 모집 마감 시간 전이라도 대진표 생성 가능
- [x] 경기 시작 시간이 지났는데 아무 Set도 시작 안했으면 재생성 가능하다.

## 변경된 사항 📝

### Before

allMatchesNotStartedForLeague 메서드를 사용해야 하는데, allMatchesFinishedForLeague 메서드를 사용하고 있었습니다.

### After

```java
@Override
	public void checkDuplicateInitialBracket(Long leagueId) {
		if (singlesMatchReader.checkIfBracketEmpty(leagueId)) {
			return;
		}
		if (singlesMatchReader.allMatchesNotStartedForLeague(leagueId)) {
			singlesMatchStore.deleteSinglesBracket(leagueId);
			return;
		}
		throw new MatchAlreadyStartedExceptionWhenBracketGenerationException(leagueId);
	}
```

## PR에서 중점적으로 확인되어야 하는 사항

- 대진표를 재생성하려면 기존의 대진표를 삭제하고 있습니다. 