### PR TITLE
bug: 파일 업로드 에러 수정

### DIFF
--- a/api/src/main/java/org/badminton/api/aws/s3/controller/ClubImageController.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/controller/ClubImageController.java
@@ -3,11 +3,10 @@ package org.badminton.api.aws.s3.controller;
 import org.badminton.api.application.clubImage.ClubImageFacade;
 import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
 import org.badminton.api.common.response.CommonResponse;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -32,8 +31,7 @@ public class ClubImageController {
 			)
 		)
 	)
-	public CommonResponse<String> saveImage(@RequestPart("multipartFile") MultipartFile multipartFile) {
-		ImageUploadRequest request = new ImageUploadRequest(multipartFile);
+	public CommonResponse<String> saveImage(@ModelAttribute ImageUploadRequest request) {
 		return CommonResponse.success(clubImageFacade.saveImage(request));
 	}
 }

--- a/api/src/main/java/org/badminton/api/aws/s3/event/clubImage/ClubImageEventHandler.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/event/clubImage/ClubImageEventHandler.java
@@ -6,7 +6,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ClubImageEventHandler {
@@ -15,6 +17,7 @@ public class ClubImageEventHandler {
 	@Async
 	@TransactionalEventListener
 	public void convertAndSaveImage(ClubImageEvent clubImageEvent) {
+		log.info("convertAndSaveImage 메서드 : {}", clubImageEvent.getMultipartFile().getName());
 		clubImageService.uploadFile(clubImageEvent.getMultipartFile(), clubImageEvent.getUuid());
 	}
 }

--- a/api/src/main/java/org/badminton/api/aws/s3/event/clubImage/ClubImageEventHandler.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/event/clubImage/ClubImageEventHandler.java
@@ -17,7 +17,6 @@ public class ClubImageEventHandler {
 	@Async
 	@TransactionalEventListener
 	public void convertAndSaveImage(ClubImageEvent clubImageEvent) {
-		log.info("convertAndSaveImage 메서드 : {}", clubImageEvent.getMultipartFile().getName());
 		clubImageService.uploadFile(clubImageEvent.getMultipartFile(), clubImageEvent.getUuid());
 	}
 }

--- a/api/src/main/java/org/badminton/api/aws/s3/model/dto/ImageUploadRequest.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/model/dto/ImageUploadRequest.java
@@ -6,9 +6,11 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.NonNull;
 
 @JsonNaming(PropertyNamingStrategies.LowerCamelCaseStrategy.class)
 public record ImageUploadRequest(
+	@NonNull
 	@Schema(description = "업로드할 이미지 파일", type = "string", format = "binary")
 	MultipartFile multipartFile
 ) {

--- a/api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
@@ -15,7 +15,9 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 public abstract class AbstractFileUploadService implements ImageService {
 	private static final long MAX_FILE_SIZE = 2548576; // 1.5MB
@@ -35,14 +37,16 @@ public abstract class AbstractFileUploadService implements ImageService {
 		if (uploadFile.getSize() > MAX_FILE_SIZE) {
 			throw new FileSizeOverException(uploadFile.getSize());
 		}
+		log.info("42 체크 전 : {}", uploadFile.getName());
 
 		if (uploadFile.isEmpty() || Objects.isNull(uploadFile.getOriginalFilename())) {
 			throw new EmptyFileException();
 		}
-
+		log.info("uploadFile try 전 : {}", uploadFile.getName());
 		try {
 			String fileExtension = getFileExtension(uploadFile.getOriginalFilename());
 			byte[] processedImage = processImage(uploadFile, fileExtension);
+			log.info(" try processedImage : {}", processedImage);
 			String newFileExtension = determineNewFileExtension(fileExtension);
 			String fileName = makeFileName(newFileExtension, uuid);
 
@@ -54,6 +58,7 @@ public abstract class AbstractFileUploadService implements ImageService {
 			s3Client.putObject(new PutObjectRequest(bucket, fileName,
 				new ByteArrayInputStream(processedImage), objectMetadata)
 				.withCannedAcl(CannedAccessControlList.PublicRead));
+			log.info(" s3Client 실행 : {}", fileName);
 
 			// 업로드 후 CloudFront URL 반환
 			return toCloudFrontUrl(s3Client.getUrl(bucket, fileName).toString());

--- a/api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
@@ -37,16 +37,13 @@ public abstract class AbstractFileUploadService implements ImageService {
 		if (uploadFile.getSize() > MAX_FILE_SIZE) {
 			throw new FileSizeOverException(uploadFile.getSize());
 		}
-		log.info("42 체크 전 : {}", uploadFile.getName());
 
 		if (uploadFile.isEmpty() || Objects.isNull(uploadFile.getOriginalFilename())) {
 			throw new EmptyFileException();
 		}
-		log.info("uploadFile try 전 : {}", uploadFile.getName());
 		try {
 			String fileExtension = getFileExtension(uploadFile.getOriginalFilename());
 			byte[] processedImage = processImage(uploadFile, fileExtension);
-			log.info(" try processedImage : {}", processedImage);
 			String newFileExtension = determineNewFileExtension(fileExtension);
 			String fileName = makeFileName(newFileExtension, uuid);
 
@@ -54,13 +51,10 @@ public abstract class AbstractFileUploadService implements ImageService {
 			objectMetadata.setContentLength(processedImage.length);
 			objectMetadata.setContentType(CONTENT_TYPE);
 
-			// S3에 파일 업로드
 			s3Client.putObject(new PutObjectRequest(bucket, fileName,
 				new ByteArrayInputStream(processedImage), objectMetadata)
 				.withCannedAcl(CannedAccessControlList.PublicRead));
-			log.info(" s3Client 실행 : {}", fileName);
 
-			// 업로드 후 CloudFront URL 반환
 			return toCloudFrontUrl(s3Client.getUrl(bucket, fileName).toString());
 
 		} catch (IOException e) {

--- a/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
@@ -33,7 +33,6 @@ public class ImageConversionService {
 
 			return outputStream.toByteArray();
 		} catch (IOException exception) {
-			log.error("Error converting image to WebP: {}", exception.getMessage(), exception);
 			throw new EmptyFileException(exception);
 		}
 	}

--- a/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
@@ -22,11 +22,9 @@ public class ImageConversionService {
 		try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 			 InputStream inputStream = file.getInputStream()) {
 
-			// 스트림을 한 번만 열어 사용
 			ImmutableImage image = ImmutableImage.loader().fromStream(inputStream);
 			WebpWriter writer = WebpWriter.DEFAULT;
 
-			// 메타데이터는 비워두거나 생성
 			ImageMetadata metadata = ImageMetadata.empty;
 
 			writer.write(image, metadata, outputStream);

--- a/api/src/main/java/org/badminton/api/interfaces/member/controller/MemberController.java
+++ b/api/src/main/java/org/badminton/api/interfaces/member/controller/MemberController.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.badminton.api.application.member.MemberFacade;
 import org.badminton.api.aws.s3.model.dto.ImageUploadRequest;
 import org.badminton.api.aws.s3.service.MemberProfileImageService;
-import org.badminton.api.common.exception.member.ImageFileNotFoundException;
 import org.badminton.api.common.response.CommonResponse;
 import org.badminton.api.interfaces.auth.dto.CustomOAuth2Member;
 import org.badminton.api.interfaces.club.dto.ClubCardResponse;
@@ -23,14 +22,13 @@ import org.badminton.domain.domain.member.info.SimpleMemberInfo;
 import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -125,14 +123,9 @@ public class MemberController {
 			)
 		)
 	)
-
 	@PostMapping("/profileImage")
 	public CommonResponse<String> uploadProfileImage(
-		@RequestPart(value = "multipartFile", required = false) MultipartFile multipartFile) {
-		if (multipartFile == null || multipartFile.isEmpty()) {
-			throw new ImageFileNotFoundException();
-		}
-		ImageUploadRequest request = new ImageUploadRequest(multipartFile);
+		@ModelAttribute ImageUploadRequest request) {
 		return CommonResponse.success(memberFacade.saveImage(request));
 	}
 


### PR DESCRIPTION
## PR에 대한 설명 🔍
- 파일을 업로드하면 이벤트핸들러 처리가 안되는 에러가 발생했습니다. 

<img width="1023" alt="image" src="https://github.com/user-attachments/assets/65e429fe-6e01-42ae-9033-15ed38d6880c">

다음과 같이 에러로그에는 임시파일 경로를 찾지 못해 null 이 발생했다고 합니다. 
RequestPart를 사용해서 파일을 받고 있습니다. 

## @RequestPart의 동작 방식
- @RequestPart는 multipart 요청을 개별적으로 분리하여 특정 Part(예: 파일, JSON 등)를 처리합니다.
Spring은 파일을 업로드할 때, 임시 파일로 저장한 뒤, MultipartFile로 변환하여 @RequestPart로 전달합니다.
이 과정에서 임시 파일은 일시적이며, 요청이 끝나면 삭제됩니다. 
발생 한 이유는 서버에 이미지가 업로드 될 때 임시파일을 제대로 생성하지 못하거나 혹은 S3를 요청할 때 임시파일이 삭제된다던가로
해당 문제가 발생할 수 있습니다. 

##  @ModelAttribute의 동작 방식
@ModelAttribute는 multipart 요청의 전체 폼 데이터를 객체로 바인딩합니다.
모든 MultipartFile과 추가 필드를 하나의 객체로 묶어 메모리 상에서 관리하고, 필요한 경우 이를 DTO로 매핑합니다.
MultipartResolver가 multipart 데이터를 파싱하고 임시 파일로 관리하기보다는, MultipartFile을 메모리에 직접 할당해 바인딩합니다.

즉 임시파일을 생성하지 않고 데이터를 그대로 사용하기 때문에 위와 같은 에러가 발생하지 않습니다. 

