### PR TITLE
bug: 이미지 업로드 관련 버그 수정

### DIFF
--- a/api/src/main/java/org/badminton/api/aws/s3/event/clubImage/ClubImageEvent.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/event/clubImage/ClubImageEvent.java
@@ -1,13 +1,12 @@
 package org.badminton.api.aws.s3.event.clubImage;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public class ClubImageEvent {
-	private final MultipartFile multipartFile;
+	private final byte[] byteFile;
+	private final String originalFilename;
 	private final String uuid;
 }

--- a/api/src/main/java/org/badminton/api/aws/s3/event/clubImage/ClubImageEventHandler.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/event/clubImage/ClubImageEventHandler.java
@@ -17,6 +17,12 @@ public class ClubImageEventHandler {
 	@Async
 	@TransactionalEventListener
 	public void convertAndSaveImage(ClubImageEvent clubImageEvent) {
-		clubImageService.uploadFile(clubImageEvent.getMultipartFile(), clubImageEvent.getUuid());
+		log.info("ClubImageEventHandler : {} ", clubImageEvent);
+		clubImageService.uploadFile(
+			clubImageEvent.getByteFile(),
+			clubImageEvent.getOriginalFilename(),
+			clubImageEvent.getUuid()
+		);
+		log.info("ClubImageEventHandler 후 : {} ", clubImageEvent);
 	}
 }

--- a/api/src/main/java/org/badminton/api/aws/s3/event/clubImage/ClubImageEventHandler.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/event/clubImage/ClubImageEventHandler.java
@@ -6,9 +6,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ClubImageEventHandler {
@@ -17,12 +15,10 @@ public class ClubImageEventHandler {
 	@Async
 	@TransactionalEventListener
 	public void convertAndSaveImage(ClubImageEvent clubImageEvent) {
-		log.info("ClubImageEventHandler : {} ", clubImageEvent);
 		clubImageService.uploadFile(
 			clubImageEvent.getByteFile(),
 			clubImageEvent.getOriginalFilename(),
 			clubImageEvent.getUuid()
 		);
-		log.info("ClubImageEventHandler 후 : {} ", clubImageEvent);
 	}
 }

--- a/api/src/main/java/org/badminton/api/aws/s3/event/memeber/MemberImageEvent.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/event/memeber/MemberImageEvent.java
@@ -1,13 +1,12 @@
 package org.badminton.api.aws.s3.event.memeber;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public class MemberImageEvent {
-	private final MultipartFile multipartFile;
+	private final byte[] byteFile;
+	private final String originalFilename;
 	private final String uuid;
 }

--- a/api/src/main/java/org/badminton/api/aws/s3/event/memeber/MemberImageEventHandler.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/event/memeber/MemberImageEventHandler.java
@@ -6,7 +6,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MemberImageEventHandler {
@@ -15,9 +17,13 @@ public class MemberImageEventHandler {
 	@Async
 	@TransactionalEventListener
 	public void convertAndSaveImage(MemberImageEvent memberImageEvent) {
+		log.info("memberException : {} ", memberImageEvent);
 		memberProfileImageService.uploadFile(
-			memberImageEvent.getMultipartFile(),
+			memberImageEvent.getByteFile(),
+			memberImageEvent.getOriginalFilename(),
 			memberImageEvent.getUuid()
 		);
+		log.info("memberException 후 : {} ", memberImageEvent);
+
 	}
 }

--- a/api/src/main/java/org/badminton/api/aws/s3/event/memeber/MemberImageEventHandler.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/event/memeber/MemberImageEventHandler.java
@@ -6,9 +6,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MemberImageEventHandler {
@@ -17,13 +15,10 @@ public class MemberImageEventHandler {
 	@Async
 	@TransactionalEventListener
 	public void convertAndSaveImage(MemberImageEvent memberImageEvent) {
-		log.info("memberException : {} ", memberImageEvent);
 		memberProfileImageService.uploadFile(
 			memberImageEvent.getByteFile(),
 			memberImageEvent.getOriginalFilename(),
 			memberImageEvent.getUuid()
 		);
-		log.info("memberException 후 : {} ", memberImageEvent);
-
 	}
 }

--- a/api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
@@ -35,12 +35,7 @@ public abstract class AbstractFileUploadService implements ImageService {
 		if (byteFiles.length > MAX_FILE_SIZE) {
 			throw new FileSizeOverException(byteFiles.length);
 		}
-		log.info("upload : {}", fileName);
-		// if (uploadFile.isEmpty() || Objects.isNull(uploadFile.getOriginalFilename())) {
-		// 	throw new EmptyFileException();
-		// }
-		log.info("upload validate 이후 : {}", fileName);
-
+		
 		try {
 			String fileExtension = getFileExtension(fileName);
 			byte[] processedImage = processImage(byteFiles, fileExtension);

--- a/api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/AbstractFileUploadService.java
@@ -2,12 +2,10 @@ package org.badminton.api.aws.s3.service;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.Objects;
 
 import org.badminton.api.common.exception.EmptyFileException;
 import org.badminton.api.common.exception.FileSizeOverException;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
@@ -33,29 +31,34 @@ public abstract class AbstractFileUploadService implements ImageService {
 	private static final String S3_URL_PREFIX = "https://badminton-team.s3.ap-northeast-2.amazonaws.com";
 	private static final String CLOUDFRONT_URL_PREFIX = "https://d36om9pjoifd2y.cloudfront.net";
 
-	public String uploadFile(MultipartFile uploadFile, String uuid) {
-		if (uploadFile.getSize() > MAX_FILE_SIZE) {
-			throw new FileSizeOverException(uploadFile.getSize());
+	public String uploadFile(byte[] byteFiles, String fileName, String uuid) {
+		if (byteFiles.length > MAX_FILE_SIZE) {
+			throw new FileSizeOverException(byteFiles.length);
 		}
+		log.info("upload : {}", fileName);
+		// if (uploadFile.isEmpty() || Objects.isNull(uploadFile.getOriginalFilename())) {
+		// 	throw new EmptyFileException();
+		// }
+		log.info("upload validate 이후 : {}", fileName);
 
-		if (uploadFile.isEmpty() || Objects.isNull(uploadFile.getOriginalFilename())) {
-			throw new EmptyFileException();
-		}
 		try {
-			String fileExtension = getFileExtension(uploadFile.getOriginalFilename());
-			byte[] processedImage = processImage(uploadFile, fileExtension);
+			String fileExtension = getFileExtension(fileName);
+			byte[] processedImage = processImage(byteFiles, fileExtension);
+			log.info(" try processedImage : {}", processedImage);
+
 			String newFileExtension = determineNewFileExtension(fileExtension);
-			String fileName = makeFileName(newFileExtension, uuid);
+			String newFileName = makeFileName(newFileExtension, uuid);
 
 			ObjectMetadata objectMetadata = new ObjectMetadata();
 			objectMetadata.setContentLength(processedImage.length);
 			objectMetadata.setContentType(CONTENT_TYPE);
 
-			s3Client.putObject(new PutObjectRequest(bucket, fileName,
+			s3Client.putObject(new PutObjectRequest(bucket, newFileName,
 				new ByteArrayInputStream(processedImage), objectMetadata)
 				.withCannedAcl(CannedAccessControlList.PublicRead));
+			log.info(" s3Client 실행 : {}", newFileName);
 
-			return toCloudFrontUrl(s3Client.getUrl(bucket, fileName).toString());
+			return toCloudFrontUrl(s3Client.getUrl(bucket, newFileName).toString());
 
 		} catch (IOException e) {
 			throw new EmptyFileException();
@@ -78,11 +81,11 @@ public abstract class AbstractFileUploadService implements ImageService {
 		}
 	}
 
-	private byte[] processImage(MultipartFile file, String extension) throws IOException {
+	private byte[] processImage(byte[] bytesFile, String extension) throws IOException {
 		if (WEBP.equalsIgnoreCase(extension) || AVIF.equalsIgnoreCase(extension)) {
-			return file.getBytes();
+			return bytesFile;
 		}
-		return imageConversionService.convertToWebP(file);
+		return imageConversionService.convertToWebP(bytesFile);
 	}
 
 	private String determineNewFileExtension(String extension) {

--- a/api/src/main/java/org/badminton/api/aws/s3/service/ClubImageService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/ClubImageService.java
@@ -1,7 +1,6 @@
 package org.badminton.api.aws.s3.service;
 
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.amazonaws.services.s3.AmazonS3;
 
@@ -13,8 +12,8 @@ public class ClubImageService extends AbstractFileUploadService {
 	}
 
 	@Override
-	public String uploadFile(MultipartFile file, String uuid) {
-		return super.uploadFile(file, uuid);
+	public String uploadFile(byte[] byteFiles, String fileName, String uuid) {
+		return super.uploadFile(byteFiles, fileName, uuid);
 	}
 
 	@Override

--- a/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
@@ -19,10 +19,9 @@ import lombok.extern.slf4j.Slf4j;
 public class ImageConversionService {
 
 	public byte[] convertToWebP(byte[] fileName) {
-		log.info("try 시작 전 :{}", fileName);
 		try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
 
-			log.info("try 시작 :{}", fileName);
+			log.info("try 시작 부분 :{}", fileName);
 
 			InputStream inputStream = new ByteArrayInputStream(fileName);
 
@@ -31,7 +30,6 @@ public class ImageConversionService {
 			ImageMetadata metadata = ImageMetadata.empty;
 
 			writer.write(image, metadata, outputStream);
-			log.info("writer.write 후");
 
 			return outputStream.toByteArray();
 		} catch (IOException exception) {

--- a/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/ImageConversionService.java
@@ -1,12 +1,12 @@
 package org.badminton.api.aws.s3.service;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
 import org.badminton.api.common.exception.EmptyFileException;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.sksamuel.scrimage.ImmutableImage;
 import com.sksamuel.scrimage.metadata.ImageMetadata;
@@ -18,20 +18,25 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 public class ImageConversionService {
 
-	public byte[] convertToWebP(MultipartFile file) {
-		try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			 InputStream inputStream = file.getInputStream()) {
+	public byte[] convertToWebP(byte[] fileName) {
+		log.info("try 시작 전 :{}", fileName);
+		try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+
+			log.info("try 시작 :{}", fileName);
+
+			InputStream inputStream = new ByteArrayInputStream(fileName);
 
 			ImmutableImage image = ImmutableImage.loader().fromStream(inputStream);
 			WebpWriter writer = WebpWriter.DEFAULT;
-
 			ImageMetadata metadata = ImageMetadata.empty;
 
 			writer.write(image, metadata, outputStream);
+			log.info("writer.write 후");
 
 			return outputStream.toByteArray();
 		} catch (IOException exception) {
 			throw new EmptyFileException(exception);
 		}
 	}
+
 }

--- a/api/src/main/java/org/badminton/api/aws/s3/service/ImageService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/ImageService.java
@@ -1,9 +1,7 @@
 package org.badminton.api.aws.s3.service;
 
-import org.springframework.web.multipart.MultipartFile;
-
 public interface ImageService {
-	String uploadFile(MultipartFile file, String uuid);
+	String uploadFile(byte[] byteFiles, String fileName, String uuid);
 
 	String makeFileName(String newFileExtension, String uuid);
 }

--- a/api/src/main/java/org/badminton/api/aws/s3/service/MemberProfileImageService.java
+++ b/api/src/main/java/org/badminton/api/aws/s3/service/MemberProfileImageService.java
@@ -1,7 +1,6 @@
 package org.badminton.api.aws.s3.service;
 
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.amazonaws.services.s3.AmazonS3;
 
@@ -13,8 +12,8 @@ public class MemberProfileImageService extends AbstractFileUploadService {
 	}
 
 	@Override
-	public String uploadFile(MultipartFile file, String uuid) {
-		return super.uploadFile(file, uuid);
+	public String uploadFile(byte[] byteFiles, String fileName, String uuid) {
+		return super.uploadFile(byteFiles, fileName, uuid);
 	}
 
 	@Override


### PR DESCRIPTION
## PR에 대한 설명 🔍
- 
```
Caused by: java.nio.file.NoSuchFileException: /tmp/tomcat.8080.1088530850146783459/work/Tomcat/localhost/ROOT/upload_f3f13601_c80c_4638_957e_c873885e6a18_00000001.tmp

```
위와 같이 @ModelAttribute로 받더라도 에러가 발생하는 것을 확인하였습니다. 
각 객체간의 MultipartFile이 이동 도 중 해당 경로의 임시 파일이 삭제되는 것을 유추 할 수 있었습니다. 
아마도 이벤트 핸들러를 사용하면서 이벤트 핸들러와 다른 스레드가 종료되면서 multipartfile이 삭제되는 것 같습니다.

그래서 이벤트 핸들러로 MultipartFile을 전달하기 전에 바이트배열과 원본 파일이름을 이벤트 핸들러 실행 전에 꺼내어 
이벤트 핸들러에 multipartfile 이 아닌 바이트 파일과 원본 이름을 직접 전달하면서 해결 할 수 있었습니다. 

즉 비동기로 실행되는 스레드가 아닌 원래의 스레드에서 바이트배열을 꺼내 소멸되는 것을 막고 이벤트 핸들러에는 직접 전달 받은 
바이트 배열을 통해 처리 할 수 있었습니다.

