### PR TITLE
refactor: 스코어보드에서 점수 조회 시 레디스 캐시를 먼저 조회

### DIFF
--- a/api/src/main/java/org/badminton/api/application/match/MatchFacade.java
+++ b/api/src/main/java/org/badminton/api/application/match/MatchFacade.java
@@ -57,6 +57,7 @@ public class MatchFacade {
 		Map<RedisKey, Score> allScores = setRepository.getAllScores();
 		for (RedisKey key : allScores.keySet()) {
 			retrieveMatchSet.registerMatchSetScoreInDb(key, allScores.get(key));
+			retrieveMatchSet.deleteCache(key);
 		}
 	}
 

--- a/api/src/main/java/org/badminton/api/interfaces/match/controller/MatchController.java
+++ b/api/src/main/java/org/badminton/api/interfaces/match/controller/MatchController.java
@@ -122,6 +122,7 @@ public class MatchController {
 		@Valid @RequestBody SetScoreUpdateRequest setScoreUpdateRequest,
 		@AuthenticationPrincipal CustomOAuth2Member member
 	) {
+		clubMemberPolicy.validateLeagueParticipant(leagueId, member.getMemberToken());
 		String memberToken = member.getMemberToken();
 		SetInfo.Main setInfo = matchFacade.registerSetScore(leagueId, matchId, setNumber, setScoreUpdateRequest,
 			memberToken);

--- a/api/src/main/java/org/badminton/api/interfaces/match/dto/MatchSetResponse.java
+++ b/api/src/main/java/org/badminton/api/interfaces/match/dto/MatchSetResponse.java
@@ -27,15 +27,14 @@ public record MatchSetResponse(
 
 	public static MatchSetResponse from(MatchSetInfo matchSetInfo) {
 		return new MatchSetResponse(
-			SinglesMatchPlayerResponse.from(matchSetInfo.singlesMatchPlayerInfo()),
-			DoublesMatchPlayerResponse.of(matchSetInfo.doublesMatchPlayerInfo()),
-			matchSetInfo.setStatus(),
-			matchSetInfo.setScore1(),
-			matchSetInfo.setScore2(),
-			matchSetInfo.winSetScore1(),
-			matchSetInfo.winSetScore2(),
-			matchSetInfo.setNumber()
+			SinglesMatchPlayerResponse.from(matchSetInfo.getSinglesMatchPlayerInfo()),
+			DoublesMatchPlayerResponse.of(matchSetInfo.getDoublesMatchPlayerInfo()),
+			matchSetInfo.getSetStatus(),
+			matchSetInfo.getSetScore1(),
+			matchSetInfo.getSetScore2(),
+			matchSetInfo.getWinSetScore1(),
+			matchSetInfo.getWinSetScore2(),
+			matchSetInfo.getSetNumber()
 		);
 	}
-
 }

--- a/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
+++ b/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
@@ -26,7 +26,7 @@ public enum ErrorCode {
 	ACCESS_DENIED(403, "리소스에 대한 접근이 제한되었습니다."),
 	LIMIT_EXCEEDED_403(403, "리소스의 제한 설정을 초과했습니다."),
 	OUT_OF_RANGE_403(403, "리소스의 제한 범위를 벗어났습니다."),
-	UNAUTHORIZED_USER_FOR_BRACKET_GENERATION(403, "경기를 생성한 사람만 대진표를 만들 수 있습니다."),
+	UNAUTHORIZED_USER_FOR_BRACKET_GENERATION(403, "경기를 만든 사용자만 대진표를 만들 수 있습니다."),
 
 	// 404 Errors
 	NOT_FOUND(404, "요청한 리소스를 찾을 수 없습니다."),
@@ -102,7 +102,7 @@ public enum ErrorCode {
 	SET_FINISHED(412, "Set 의 상태가 FINISHED 입니다"),
 	ALREADY_WINNER_DETERMINED(412, "매치의 승리자가 정해졌습니다"),
 	CLUB_OWNER_CANT_WITHDRAW(412, "동호회원이 2명 이상인 동호회 회장은 동호회를 탈퇴할 수 없습니다."),
-	NOT_LEAGUE_OWNER(412, "경기를 만든 사용자만 수정 및 삭제를 할 수 있습니다"),
+	NOT_LEAGUE_OWNER(412, "경기를 만든 사용자만 이용할 수 있습니다."),
 	CLUB_MEMBER_EXPEL_EXCEPTION(412, "해당 동호회에서 제제를 받아 가입 신청을 할 수 없습니다."),
 	BYE_MATCH_ACTION_NOT_ALLOWED(412, "해당 매치는 부전승 매치이기 때문에 점수를 수정할 수 없습니다"),
 

--- a/domain/src/main/java/org/badminton/domain/domain/match/info/MatchSetInfo.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/info/MatchSetInfo.java
@@ -3,17 +3,23 @@ package org.badminton.domain.domain.match.info;
 import org.badminton.domain.common.enums.SetStatus;
 import org.badminton.domain.domain.match.entity.DoublesSet;
 import org.badminton.domain.domain.match.entity.SinglesSet;
+import org.badminton.domain.domain.match.vo.Score;
 
-public record MatchSetInfo(
-	SinglesMatchPlayerInfo singlesMatchPlayerInfo,
-	DoublesMatchPlayerInfo doublesMatchPlayerInfo,
-	SetStatus setStatus,
-	int setScore1,
-	int setScore2,
-	int winSetScore1,
-	int winSetScore2,
-	int setNumber
-) {
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class MatchSetInfo {
+
+	private final SinglesMatchPlayerInfo singlesMatchPlayerInfo;
+	private final DoublesMatchPlayerInfo doublesMatchPlayerInfo;
+	private final SetStatus setStatus;
+	private int setScore1;
+	private int setScore2;
+	private final int winSetScore1;
+	private final int winSetScore2;
+	private final int setNumber;
 
 	public static MatchSetInfo fromSingles(SinglesSet singlesSet) {
 		return new MatchSetInfo(
@@ -41,4 +47,8 @@ public record MatchSetInfo(
 		);
 	}
 
+	public void cacheScore(Score score) {
+		this.setScore1 = score.getLeft();
+		this.setScore2 = score.getRight();
+	}
 }

--- a/domain/src/main/java/org/badminton/domain/domain/match/vo/RedisKey.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/vo/RedisKey.java
@@ -6,11 +6,15 @@ import lombok.Getter;
 
 @Getter
 public class RedisKey {
+	private final String key;
+	private final String field;
 	private final MatchType matchType;
 	private final Long matchId;
 	private final int setNumber;
 
 	public RedisKey(String key, String field) {
+		this.key = key;
+		this.field = field;
 		this.matchType = parseMatchType(key);
 		this.matchId = parseMatchId(key);
 		this.setNumber = Integer.parseInt(field);

--- a/domain/src/main/java/org/badminton/domain/domain/match/vo/Score.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/vo/Score.java
@@ -1,5 +1,7 @@
 package org.badminton.domain.domain.match.vo;
 
+import java.util.Optional;
+
 import lombok.Getter;
 
 @Getter
@@ -17,6 +19,10 @@ public class Score {
 		String[] split = score.split(":");
 		this.left = Integer.parseInt(split[0]);
 		this.right = Integer.parseInt(split[1]);
+	}
+
+	public static Optional<Score> emptyScore() {
+		return Optional.empty();
 	}
 
 	@Override

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/SetRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/SetRepository.java
@@ -60,4 +60,8 @@ public class SetRepository {
 		}
 		return scores;
 	}
+
+	public void deleteScore(RedisKey redisKey) {
+		hashOps.delete(redisKey.getKey(), redisKey.getField());
+	}
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/SetRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/SetRepository.java
@@ -1,12 +1,11 @@
 package org.badminton.infrastructure.match.repository;
 
-import jakarta.annotation.PostConstruct;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
-import lombok.extern.slf4j.Slf4j;
+
 import org.badminton.domain.common.enums.MatchType;
-import org.badminton.domain.common.exception.match.SetScoreNotInCacheException;
 import org.badminton.domain.domain.match.vo.RedisKey;
 import org.badminton.domain.domain.match.vo.Score;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,48 +13,51 @@ import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
 @Repository
 @Slf4j
 public class SetRepository {
 
-    @Autowired
-    private StringRedisTemplate redisTemplate;
+	@Autowired
+	private StringRedisTemplate redisTemplate;
 
-    private HashOperations<String, String, String> hashOps;
+	private HashOperations<String, String, String> hashOps;
 
-    @PostConstruct
-    private void init() {
-        hashOps = redisTemplate.opsForHash();
-    }
+	@PostConstruct
+	private void init() {
+		hashOps = redisTemplate.opsForHash();
+	}
 
-    public void setMatchSetScore(MatchType matchType, Long matchId, int setNumber, Score score) {
-        hashOps.put(matchType.getDescription() + matchId, String.valueOf(setNumber),
-                score.toString());
-    }
+	public void setMatchSetScore(MatchType matchType, Long matchId, int setNumber, Score score) {
+		hashOps.put(matchType.getDescription() + matchId, String.valueOf(setNumber),
+			score.toString());
+	}
 
-    public Score getMatchSetScore(MatchType matchType, Long matchId, int setNumber) {
-        String score = hashOps.get(matchType.getDescription() + matchId, String.valueOf(setNumber));
-        if (score == null) {
-            throw new SetScoreNotInCacheException(matchType, matchId, setNumber);
-        }
-        return new Score(score);
-    }
+	public Optional<Score> getMatchSetScore(MatchType matchType, Long matchId, int setNumber) {
+		String score = hashOps.get(matchType.getDescription() + matchId, String.valueOf(setNumber));
+		if (score == null) {
+			return Score.emptyScore();
+		}
+		return Optional.of(new Score(score));
+	}
 
-    public Map<RedisKey, Score> getAllScores() {
-        Set<String> keys = redisTemplate.keys("*게임*");
+	public Map<RedisKey, Score> getAllScores() {
+		Set<String> keys = redisTemplate.keys("*게임*");
 
-        Map<RedisKey, Score> scores = new HashMap<>();
-        if (keys == null) {
-            return null;
-        }
-        for (String key : keys) {
-            log.info("*****key: {}", key);
-            Map<String, String> setNumberAndScore = hashOps.entries(key);
-            setNumberAndScore.forEach((field, value) -> {
-                log.info("*****field: {}, value: {}", field, value);
-                scores.put(new RedisKey(key, field), new Score(value));
-            });
-        }
-        return scores;
-    }
+		Map<RedisKey, Score> scores = new HashMap<>();
+		if (keys == null) {
+			return null;
+		}
+		for (String key : keys) {
+			log.info("*****key: {}", key);
+			Map<String, String> setNumberAndScore = hashOps.entries(key);
+			setNumberAndScore.forEach((field, value) -> {
+				log.info("*****field: {}, value: {}", field, value);
+				scores.put(new RedisKey(key, field), new Score(value));
+			});
+		}
+		return scores;
+	}
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/RetrieveMatchSet.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/RetrieveMatchSet.java
@@ -2,7 +2,6 @@ package org.badminton.infrastructure.match.service;
 
 import org.badminton.domain.common.enums.MatchType;
 import org.badminton.domain.common.enums.SetStatus;
-import org.badminton.domain.common.exception.league.LeagueParticipationNotExistException;
 import org.badminton.domain.common.exception.match.LeagueParticipantNotDeterminedException;
 import org.badminton.domain.common.exception.match.PreviousDetNotFinishedException;
 import org.badminton.domain.common.exception.match.RoundNotFinishedException;
@@ -37,10 +36,6 @@ public class RetrieveMatchSet {
 	private final DoublesMatchStore doublesMatchStore;
 
 	public void setMatchSetScore(Long leagueId, Long matchId, int setNumber, Score score, String memberToken) {
-		if (!leagueParticipantReader.isParticipant(memberToken, leagueId)) {
-			throw new LeagueParticipationNotExistException(leagueId, memberToken);
-		}
-
 		League league = leagueReader.readLeagueById(leagueId);
 
 		if (league.getMatchType() == MatchType.SINGLES) {

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/RetrieveMatchSet.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/RetrieveMatchSet.java
@@ -135,4 +135,8 @@ public class RetrieveMatchSet {
 		League league = leagueReader.readLeagueById(leagueId);
 		return league.getMatchType();
 	}
+
+	public void deleteCache(RedisKey key) {
+		setRepository.deleteScore(key);
+	}
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/RetrieveMatchSet.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/RetrieveMatchSet.java
@@ -1,5 +1,7 @@
 package org.badminton.infrastructure.match.service;
 
+import java.util.Optional;
+
 import org.badminton.domain.common.enums.MatchType;
 import org.badminton.domain.common.enums.SetStatus;
 import org.badminton.domain.common.exception.match.LeagueParticipantNotDeterminedException;
@@ -124,7 +126,7 @@ public class RetrieveMatchSet {
 		}
 	}
 
-	public Score getMatchSetScore(Long leagueId, Long matchId, int setNumber) {
+	public Optional<Score> getMatchSetScore(Long leagueId, Long matchId, int setNumber) {
 		League league = leagueReader.readLeagueById(leagueId);
 		return setRepository.getMatchSetScore(league.getMatchType(), matchId, setNumber);
 	}


### PR DESCRIPTION
## PR에 대한 설명 🔍

- [x] 스코어보드에서 점수 조회 시 레디스 캐시를 먼저 조회
- [x] DB에 Cache 의 내용을 스케줄러로 업데이트 시 Cache 데이터는 삭제

## 변경된 사항 📝

```java
	public void deleteScore(RedisKey redisKey) {
		hashOps.delete(redisKey.getKey(), redisKey.getField());
	}
```

해당 메서드를 추가했습니다. @CacheEvict를 알아보고, 수정하려고 합니다. 지금은 SetRepository가 아래와 같이 레디스에 대한 의존성을 주입받고 있는데 이 또한 다른 방법을 적용할 예정입니다.

```java
	@Autowired
	private StringRedisTemplate redisTemplate;

	private HashOperations<String, String, String> hashOps;
```


## PR에서 중점적으로 확인되어야 하는 사항

- 스코어 보드 점수 조회는 레디스를 먼저 조회해 실시간성을 완전하게 보장합니다. 
- 메인 리그 API 쪽에서는 DB의 데이터를 조회하며, 스케줄러가 100초마다 돌아가기 때문에 해당 시간만큼 데이터 정합성이 맞지 않는 문제가 있습니다. 