### PR TITLE
refactor: TournamentMatchStrategy 리팩토링

### DIFF
--- a/domain/src/main/java/org/badminton/domain/common/consts/Constants.java
+++ b/domain/src/main/java/org/badminton/domain/common/consts/Constants.java
@@ -18,4 +18,16 @@ public class Constants {
 	public static final int ADDRESS_MAX = 100;
 	public static final int APPLY_MIN = 2;
 	public static final int APPLY_MAX = 50;
+
+	public static final int PARTICIPANTS_PER_MATCH = 2;
+	public static final int SET_COUNT = 3;
+	public static final int FIRST_ROUND_NUMBER = 1;
+	public static final int SECOND_ROUND_NUMBER = 2;
+	public static final int PARTICIPANTS_PER_TEAM = 2;
+	public static final int TEAMS_PER_MATCH = 2;
+
+	public static final int FIRST_SET_NUMBER = 1;
+	public static final int LIMIT_SET_GAME = 3;
+	public static final int INIT_ROUND_NUMBER = 0;
+
 }

--- a/domain/src/main/java/org/badminton/domain/domain/league/entity/LeagueParticipant.java
+++ b/domain/src/main/java/org/badminton/domain/domain/league/entity/LeagueParticipant.java
@@ -52,6 +52,10 @@ public class LeagueParticipant extends AbstractBaseTime {
 		return null;
 	}
 
+	public static LeagueParticipant emptyWinner() {
+		return null;
+	}
+
 	public void cancelLeagueParticipation() {
 		this.canceled = true;
 	}

--- a/domain/src/main/java/org/badminton/domain/domain/league/entity/LeagueParticipant.java
+++ b/domain/src/main/java/org/badminton/domain/domain/league/entity/LeagueParticipant.java
@@ -48,6 +48,10 @@ public class LeagueParticipant extends AbstractBaseTime {
 		this.member = clubMember.getMember();
 	}
 
+	public static LeagueParticipant emptyParticipant() {
+		return null;
+	}
+
 	public void cancelLeagueParticipation() {
 		this.canceled = true;
 	}

--- a/domain/src/main/java/org/badminton/domain/domain/league/vo/Team.java
+++ b/domain/src/main/java/org/badminton/domain/domain/league/vo/Team.java
@@ -24,4 +24,8 @@ public class Team {
 		this.leagueParticipant1 = leagueParticipant1;
 		this.leagueParticipant2 = leagueParticipant2;
 	}
+
+	public static Team emptyParticipant() {
+		return null;
+	}
 }

--- a/domain/src/main/java/org/badminton/domain/domain/league/vo/Team.java
+++ b/domain/src/main/java/org/badminton/domain/domain/league/vo/Team.java
@@ -28,4 +28,8 @@ public class Team {
 	public static Team emptyParticipant() {
 		return null;
 	}
+
+	public static Team emptyWinner() {
+		return null;
+	}
 }

--- a/domain/src/main/java/org/badminton/domain/domain/match/entity/DoublesMatch.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/entity/DoublesMatch.java
@@ -146,7 +146,7 @@ public class DoublesMatch extends AbstractBaseTime {
 		if (this.getTeam2MatchResult() == MatchResult.WIN) {
 			return this.getTeam2();
 		}
-		return null;
+		return Team.emptyWinner();
 	}
 
 	public boolean isTeam1Exist() {
@@ -155,6 +155,14 @@ public class DoublesMatch extends AbstractBaseTime {
 
 	public boolean isTeam2Exist() {
 		return this.getTeam2() != null;
+	}
+
+	public boolean isMatchWinnerDetermined() {
+		return this.team1MatchResult == MatchResult.WIN || this.team2MatchResult == MatchResult.WIN;
+	}
+
+	public boolean isByeMatch() {
+		return this.matchStatus == MatchStatus.BYE && this.isTeam1Exist();
 	}
 
 }

--- a/domain/src/main/java/org/badminton/domain/domain/match/entity/DoublesMatch.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/entity/DoublesMatch.java
@@ -137,4 +137,24 @@ public class DoublesMatch extends AbstractBaseTime {
 	public void byeMatch() {
 		this.matchStatus = MatchStatus.BYE;
 	}
+
+	public Team determineWinner() {
+		if (this.getMatchStatus() == MatchStatus.BYE || this.getTeam1MatchResult() == MatchResult.WIN) {
+			return this.getTeam1();
+		}
+
+		if (this.getTeam2MatchResult() == MatchResult.WIN) {
+			return this.getTeam2();
+		}
+		return null;
+	}
+
+	public boolean isTeam1Exist() {
+		return this.getTeam1() != null;
+	}
+
+	public boolean isTeam2Exist() {
+		return this.getTeam2() != null;
+	}
+
 }

--- a/domain/src/main/java/org/badminton/domain/domain/match/entity/SinglesMatch.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/entity/SinglesMatch.java
@@ -80,11 +80,11 @@ public class SinglesMatch extends AbstractBaseTime {
 	}
 
 	public boolean isLeagueParticipant1Exist() {
-		return this.getLeagueParticipant1() != null;
+		return this.leagueParticipant1 != null;
 	}
 
 	public boolean isLeagueParticipant2Exist() {
-		return this.getLeagueParticipant2() != null;
+		return this.leagueParticipant2 != null;
 	}
 
 	public void addSet(SinglesSet singlesSet) {
@@ -153,6 +153,14 @@ public class SinglesMatch extends AbstractBaseTime {
 		if (this.getPlayer2MatchResult() == MatchResult.WIN) {
 			return this.getLeagueParticipant2();
 		}
-		return null;
+		return LeagueParticipant.emptyWinner();
+	}
+
+	public boolean isMatchWinnerDetermined() {
+		return this.player1MatchResult == MatchResult.WIN || this.player2MatchResult == MatchResult.WIN;
+	}
+
+	public boolean isByeMatch() {
+		return this.matchStatus == MatchStatus.BYE && this.isLeagueParticipant1Exist();
 	}
 }

--- a/domain/src/main/java/org/badminton/domain/domain/match/entity/SinglesMatch.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/entity/SinglesMatch.java
@@ -79,6 +79,14 @@ public class SinglesMatch extends AbstractBaseTime {
 		this.roundNumber = roundNumber;
 	}
 
+	public boolean isLeagueParticipant1Exist() {
+		return this.getLeagueParticipant1() != null;
+	}
+
+	public boolean isLeagueParticipant2Exist() {
+		return this.getLeagueParticipant2() != null;
+	}
+
 	public void addSet(SinglesSet singlesSet) {
 		this.singlesSets.add(singlesSet);
 	}
@@ -136,5 +144,15 @@ public class SinglesMatch extends AbstractBaseTime {
 
 	public void byeMatch() {
 		this.matchStatus = MatchStatus.BYE;
+	}
+
+	public LeagueParticipant determineWinner() {
+		if (this.getMatchStatus() == MatchStatus.BYE || this.getPlayer1MatchResult() == MatchResult.WIN) {
+			return this.getLeagueParticipant1();
+		}
+		if (this.getPlayer2MatchResult() == MatchResult.WIN) {
+			return this.getLeagueParticipant2();
+		}
+		return null;
 	}
 }

--- a/domain/src/main/java/org/badminton/domain/domain/match/service/AbstractSinglesMatchStrategy.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/service/AbstractSinglesMatchStrategy.java
@@ -74,7 +74,7 @@ public abstract class AbstractSinglesMatchStrategy implements MatchStrategy {
 	public abstract BracketInfo makeBracket(League league, List<LeagueParticipant> leagueParticipantList);
 
 	@Override
-	public abstract SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setIndex,
+	public abstract SetInfo.Main endSet(Long matchId, Integer setIndex,
 		MatchCommand.UpdateSetScore updateSetScoreCommand);
 
 	@Override

--- a/domain/src/main/java/org/badminton/domain/domain/match/service/MatchStrategy.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/service/MatchStrategy.java
@@ -30,7 +30,7 @@ public interface MatchStrategy {
 
 	BracketInfo makeBracket(League league, List<LeagueParticipant> leagueParticipantList);
 
-	SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setIndex,
+	SetInfo.Main endSet(Long matchId, Integer setIndex,
 		MatchCommand.UpdateSetScore updateSetScoreCommand);
 
 	boolean isMatchInLeague(Long leagueId);

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/FreeMatchProgressServiceImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/FreeMatchProgressServiceImpl.java
@@ -45,7 +45,7 @@ public class FreeMatchProgressServiceImpl implements MatchProgressService {
 			throw new LeagueParticipationNotExistException(leagueId, memberToken);
 		}
 
-		return matchStrategy.registerSetScoreInMatch(matchId, setIndex, updateSetScoreCommand);
+		return matchStrategy.endSet(matchId, setIndex, updateSetScoreCommand);
 	}
 
 	private League findLeague(Long leagueId) {

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentBracketGenerationServiceImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentBracketGenerationServiceImpl.java
@@ -37,6 +37,10 @@ public class TournamentBracketGenerationServiceImpl implements BracketGeneration
 	private final SinglesMatchStore singlesMatchStore;
 	private final DoublesMatchStore doublesMatchStore;
 	private final LeagueParticipantReader leagueParticipantReader;
+	private final TournamentSinglesEndSetHandler tournamentSinglesEndSetHandler;
+	private final TournamentSinglesBracketCreator tournamentSinglesBracketCreator;
+	private final TournamentDoublesEndSetHandler tournamentDoublesEndSetHandler;
+	private final TournamentDoublesBracketCreator tournamentDoublesBracketCreator;
 
 	@Override
 	public void checkLeagueRecruitingStatus(Long leagueId) {
@@ -53,12 +57,10 @@ public class TournamentBracketGenerationServiceImpl implements BracketGeneration
 	public MatchStrategy makeSinglesOrDoublesMatchStrategy(Long leagueId) {
 		League league = findLeague(leagueId);
 		return switch (league.getMatchType()) {
-			case SINGLES ->
-				new TournamentSinglesMatchStrategy(singlesMatchReader, singlesMatchStore, leagueParticipantReader,
-					leagueReader);
-			case DOUBLES ->
-				new TournamentDoublesMatchStrategy(doublesMatchReader, doublesMatchStore, leagueParticipantReader,
-					leagueReader);
+			case SINGLES -> new TournamentSinglesMatchStrategy(singlesMatchReader, singlesMatchStore,
+				tournamentSinglesBracketCreator, tournamentSinglesEndSetHandler);
+			case DOUBLES -> new TournamentDoublesMatchStrategy(doublesMatchReader, doublesMatchStore,
+				tournamentDoublesEndSetHandler, tournamentDoublesBracketCreator);
 		};
 	}
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentDoublesBracketCreator.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentDoublesBracketCreator.java
@@ -1,0 +1,152 @@
+package org.badminton.infrastructure.match.service;
+
+import static org.badminton.domain.common.consts.Constants.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.badminton.domain.common.enums.MatchStatus;
+import org.badminton.domain.domain.league.entity.League;
+import org.badminton.domain.domain.league.entity.LeagueParticipant;
+import org.badminton.domain.domain.league.vo.Team;
+import org.badminton.domain.domain.match.entity.DoublesMatch;
+import org.badminton.domain.domain.match.entity.DoublesSet;
+import org.badminton.domain.domain.match.reader.DoublesMatchStore;
+import org.badminton.domain.domain.match.store.DoublesMatchReader;
+import org.badminton.infrastructure.match.strategy.MatchUtils;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TournamentDoublesBracketCreator {
+
+	private final MatchUtils matchUtils;
+	private final DoublesMatchStore doublesMatchStore;
+	private final DoublesMatchReader doublesMatchReader;
+
+	private static boolean isParticipantOddSize(List<LeagueParticipant> participants) {
+		return participants.size() % 4 != 0;
+	}
+
+	private static boolean isDoubleMatchOddSize(List<DoublesMatch> doublesMatches) {
+		return doublesMatches.size() % 2 != 0;
+	}
+
+	public List<LeagueParticipant> getLeagueParticipants(List<LeagueParticipant> leagueParticipantList) {
+
+		List<LeagueParticipant> currentParticipants = new ArrayList<>(leagueParticipantList);
+
+		Collections.shuffle(currentParticipants);
+		return currentParticipants;
+	}
+
+	public int getTotalRounds(League league, List<LeagueParticipant> currentParticipants) {
+
+		int totalRounds = MatchUtils.calculateTotalRounds(currentParticipants.size() / PARTICIPANTS_PER_TEAM);
+
+		league.defineTotalRounds(totalRounds);
+		return totalRounds;
+	}
+
+	public void generateAllMatches(League league, List<DoublesMatch> allMatches,
+		List<LeagueParticipant> currentParticipants,
+		int totalRounds) {
+
+		allMatches.addAll(createFirstRoundMatches(league, currentParticipants));
+
+		allMatches.addAll(createSubsequentRoundsMatches(league, totalRounds));
+
+		allMatches.stream()
+			.filter(doublesMatch -> doublesMatch.getMatchStatus() == MatchStatus.BYE && doublesMatch.isTeam1Exist())
+			.forEach(matchUtils::updateDoublesMatchNextRoundMatch);
+	}
+
+	private List<DoublesMatch> createFirstRoundMatches(League league, List<LeagueParticipant> participants) {
+		List<DoublesMatch> matches = new ArrayList<>();
+
+		for (int i = 0; i < participants.size() - 2; i += PARTICIPANTS_PER_TEAM * TEAMS_PER_MATCH) {
+			Team team1 = new Team(participants.get(i), participants.get(i + 1));
+			Team team2 = new Team(participants.get(i + 2), participants.get(i + 3));
+			DoublesMatch match = new DoublesMatch(league, team1, team2, FIRST_ROUND_NUMBER);
+
+			makeSetsInMatch(match);
+			doublesMatchStore.store(match);
+			matches.add(match);
+		}
+
+		if (isParticipantOddSize(participants)) {
+			Team byeTeam = new Team(participants.remove(participants.size() - 1),
+				participants.get(participants.size() - 2));
+			DoublesMatch byeMatch = new DoublesMatch(league, byeTeam, Team.emptyParticipant(), 1);
+			byeMatch.byeMatch();
+			doublesMatchStore.store(byeMatch);
+			matches.add(byeMatch);
+		}
+		return matches;
+	}
+
+	private List<DoublesMatch> createMatchesRound(League league, List<DoublesMatch> previousRoundMatches,
+		int roundNumber) {
+
+		List<DoublesMatch> currentRoundMatches = new ArrayList<>(
+			initializeRoundMatches(league, previousRoundMatches, roundNumber));
+
+		if (isDoubleMatchOddSize(previousRoundMatches)) {
+			currentRoundMatches.add(createByeRoundMatch(league, previousRoundMatches, roundNumber));
+		}
+
+		return currentRoundMatches;
+	}
+
+	private List<DoublesMatch> initializeRoundMatches(League league, List<DoublesMatch> previousRoundMatches,
+		int roundNumber) {
+		List<DoublesMatch> regularRoundMatches = new ArrayList<>();
+
+		for (int i = 0; i < previousRoundMatches.size() - 1; i += TEAMS_PER_MATCH) {
+			DoublesMatch match = new DoublesMatch(league, Team.emptyParticipant(), Team.emptyParticipant(),
+				roundNumber);
+			makeSetsInMatch(match);
+			doublesMatchStore.store(match);
+			regularRoundMatches.add(match);
+		}
+
+		return regularRoundMatches;
+	}
+
+	private DoublesMatch createByeRoundMatch(League league, List<DoublesMatch> previousRoundMatches,
+		int roundNumber) {
+		DoublesMatch byeMatch = previousRoundMatches.get(previousRoundMatches.size() - 1);
+		Team winner = byeMatch.determineWinner();
+
+		DoublesMatch nextByeMatch = new DoublesMatch(league, winner, Team.emptyParticipant(), roundNumber);
+		nextByeMatch.byeMatch();
+		doublesMatchStore.store(nextByeMatch);
+
+		return nextByeMatch;
+	}
+
+	private List<DoublesMatch> createSubsequentRoundsMatches(League league, int totalRounds) {
+		List<DoublesMatch> matches = new ArrayList<>();
+		List<DoublesMatch> previousMatches = doublesMatchReader.findMatchesByLeagueAndRound(league.getLeagueId(),
+			FIRST_ROUND_NUMBER);
+
+		for (int roundNumber = SECOND_ROUND_NUMBER; roundNumber <= totalRounds; roundNumber++) {
+			List<DoublesMatch> currentRoundMatches = createMatchesRound(league, previousMatches, roundNumber);
+			matches.addAll(currentRoundMatches);
+			previousMatches = currentRoundMatches;
+		}
+
+		return matches;
+	}
+
+	private void makeSetsInMatch(DoublesMatch doublesMatch) {
+		for (int i = 1; i <= SET_COUNT; i++) {
+			DoublesSet set = new DoublesSet(doublesMatch, i);
+			doublesMatch.addSet(set);
+		}
+		doublesMatchStore.store(doublesMatch);
+	}
+}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentDoublesBracketCreator.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentDoublesBracketCreator.java
@@ -3,10 +3,8 @@ package org.badminton.infrastructure.match.service;
 import static org.badminton.domain.common.consts.Constants.*;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
-import org.badminton.domain.common.enums.MatchStatus;
 import org.badminton.domain.domain.league.entity.League;
 import org.badminton.domain.domain.league.entity.LeagueParticipant;
 import org.badminton.domain.domain.league.vo.Team;
@@ -35,14 +33,6 @@ public class TournamentDoublesBracketCreator {
 		return doublesMatches.size() % 2 != 0;
 	}
 
-	public List<LeagueParticipant> getLeagueParticipants(List<LeagueParticipant> leagueParticipantList) {
-
-		List<LeagueParticipant> currentParticipants = new ArrayList<>(leagueParticipantList);
-
-		Collections.shuffle(currentParticipants);
-		return currentParticipants;
-	}
-
 	public int getTotalRounds(League league, List<LeagueParticipant> currentParticipants) {
 
 		int totalRounds = MatchUtils.calculateTotalRounds(currentParticipants.size() / PARTICIPANTS_PER_TEAM);
@@ -60,7 +50,7 @@ public class TournamentDoublesBracketCreator {
 		allMatches.addAll(createSubsequentRoundsMatches(league, totalRounds));
 
 		allMatches.stream()
-			.filter(doublesMatch -> doublesMatch.getMatchStatus() == MatchStatus.BYE && doublesMatch.isTeam1Exist())
+			.filter(DoublesMatch::isByeMatch)
 			.forEach(matchUtils::updateDoublesMatchNextRoundMatch);
 	}
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentDoublesEndSetHandler.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentDoublesEndSetHandler.java
@@ -15,7 +15,6 @@ import org.badminton.domain.common.exception.match.RegisterScoreInByeMatchExcept
 import org.badminton.domain.common.exception.match.RoundNotFinishedException;
 import org.badminton.domain.common.exception.match.SetFinishedException;
 import org.badminton.domain.domain.league.LeagueReader;
-import org.badminton.domain.domain.league.vo.Team;
 import org.badminton.domain.domain.match.command.MatchCommand;
 import org.badminton.domain.domain.match.entity.DoublesMatch;
 import org.badminton.domain.domain.match.entity.DoublesSet;
@@ -35,11 +34,6 @@ public class TournamentDoublesEndSetHandler {
 	private final LeagueReader leagueReader;
 	private final DoublesMatchStore doublesMatchStore;
 
-	private static boolean isMatchWinnerDetermined(DoublesMatch doublesMatch) {
-		return doublesMatch.getTeam1MatchResult() == MatchResult.WIN
-			|| doublesMatch.getTeam2MatchResult() == MatchResult.WIN;
-	}
-
 	public void processEndSet(Integer setNumber, MatchCommand.UpdateSetScore updateSetScoreCommand,
 		DoublesMatch doublesMatch) {
 
@@ -49,7 +43,7 @@ public class TournamentDoublesEndSetHandler {
 			changeNextSetStatus(doublesMatch, setNumber);
 		}
 
-		if (isMatchWinnerDetermined(doublesMatch)) {
+		if (doublesMatch.isMatchWinnerDetermined()) {
 			processNextRoundMatches(doublesMatch);
 		}
 
@@ -68,7 +62,7 @@ public class TournamentDoublesEndSetHandler {
 			throw new RegisterScoreInByeMatchException(doublesMatch.getId(), MatchType.DOUBLES);
 		}
 
-		if (isMatchWinnerDetermined(doublesMatch)) {
+		if (doublesMatch.isMatchWinnerDetermined()) {
 			throw new AlreadyWinnerDeterminedException(doublesMatch.getId());
 		}
 
@@ -76,7 +70,7 @@ public class TournamentDoublesEndSetHandler {
 			throw new SetFinishedException(setNumber);
 		}
 
-		if (doublesMatch.getTeam1() == Team.emptyParticipant() || doublesMatch.getTeam2() == Team.emptyParticipant()) {
+		if (!doublesMatch.isTeam1Exist() || !doublesMatch.isTeam2Exist()) {
 			throw new LeagueParticipantNotDeterminedException(matchId);
 		}
 	}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentDoublesEndSetHandler.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentDoublesEndSetHandler.java
@@ -1,0 +1,159 @@
+package org.badminton.infrastructure.match.service;
+
+import static org.badminton.domain.common.consts.Constants.*;
+
+import java.util.List;
+
+import org.badminton.domain.common.enums.MatchResult;
+import org.badminton.domain.common.enums.MatchStatus;
+import org.badminton.domain.common.enums.MatchType;
+import org.badminton.domain.common.enums.SetStatus;
+import org.badminton.domain.common.exception.match.AlreadyWinnerDeterminedException;
+import org.badminton.domain.common.exception.match.LeagueParticipantNotDeterminedException;
+import org.badminton.domain.common.exception.match.PreviousDetNotFinishedException;
+import org.badminton.domain.common.exception.match.RegisterScoreInByeMatchException;
+import org.badminton.domain.common.exception.match.RoundNotFinishedException;
+import org.badminton.domain.common.exception.match.SetFinishedException;
+import org.badminton.domain.domain.league.LeagueReader;
+import org.badminton.domain.domain.league.vo.Team;
+import org.badminton.domain.domain.match.command.MatchCommand;
+import org.badminton.domain.domain.match.entity.DoublesMatch;
+import org.badminton.domain.domain.match.entity.DoublesSet;
+import org.badminton.domain.domain.match.reader.DoublesMatchStore;
+import org.badminton.domain.domain.match.store.DoublesMatchReader;
+import org.badminton.infrastructure.match.strategy.MatchUtils;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TournamentDoublesEndSetHandler {
+
+	private final DoublesMatchReader doublesMatchReader;
+	private final MatchUtils matchUtils;
+	private final LeagueReader leagueReader;
+	private final DoublesMatchStore doublesMatchStore;
+
+	private static boolean isMatchWinnerDetermined(DoublesMatch doublesMatch) {
+		return doublesMatch.getTeam1MatchResult() == MatchResult.WIN
+			|| doublesMatch.getTeam2MatchResult() == MatchResult.WIN;
+	}
+
+	public void processEndSet(Integer setNumber, MatchCommand.UpdateSetScore updateSetScoreCommand,
+		DoublesMatch doublesMatch) {
+
+		updateWinnerWithSetScore(doublesMatch, setNumber, updateSetScoreCommand);
+
+		if (LIMIT_SET_GAME > setNumber) {
+			changeNextSetStatus(doublesMatch, setNumber);
+		}
+
+		if (isMatchWinnerDetermined(doublesMatch)) {
+			processNextRoundMatches(doublesMatch);
+		}
+
+		if (isAllMatchFinished(doublesMatch)) {
+			leagueReader.readLeagueById(doublesMatch.getLeague().getLeagueId()).finishLeague();
+		}
+
+	}
+
+	public void isEndSetAllowed(Long matchId, Integer setNumber, DoublesMatch doublesMatch) {
+		isPreviousSetComplete(setNumber, doublesMatch);
+
+		isPreviousRoundComplete(doublesMatch.getLeague().getLeagueId(), doublesMatch.getRoundNumber());
+
+		if (doublesMatch.getMatchStatus() == MatchStatus.BYE) {
+			throw new RegisterScoreInByeMatchException(doublesMatch.getId(), MatchType.DOUBLES);
+		}
+
+		if (isMatchWinnerDetermined(doublesMatch)) {
+			throw new AlreadyWinnerDeterminedException(doublesMatch.getId());
+		}
+
+		if (doublesMatch.getDoublesSet(setNumber).getSetStatus() == SetStatus.FINISHED) {
+			throw new SetFinishedException(setNumber);
+		}
+
+		if (doublesMatch.getTeam1() == Team.emptyParticipant() || doublesMatch.getTeam2() == Team.emptyParticipant()) {
+			throw new LeagueParticipantNotDeterminedException(matchId);
+		}
+	}
+
+	private void isPreviousRoundComplete(Long leagueId, int roundNumber) {
+
+		if (roundNumber == FIRST_ROUND_NUMBER) {
+			return;
+		}
+
+		int previousRoundNumber = roundNumber - 1;
+
+		if (!doublesMatchReader.allRoundMatchesDone(leagueId, previousRoundNumber)) {
+			throw new RoundNotFinishedException(previousRoundNumber);
+		}
+	}
+
+	private void isPreviousSetComplete(int setNumber, DoublesMatch doublesMatch) {
+
+		if (setNumber == FIRST_SET_NUMBER) {
+			return;
+		}
+		int previousSetNumber = setNumber - 1;
+		if (doublesMatch.getDoublesSet(previousSetNumber).getSetStatus() != SetStatus.FINISHED) {
+			throw new PreviousDetNotFinishedException(previousSetNumber);
+		}
+	}
+
+	private void changeNextSetStatus(DoublesMatch doublesMatch, Integer setNumber) {
+		setNumber++;
+		if (doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
+			doublesMatch.getDoublesSet(setNumber).open();
+		}
+		if (!doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
+			doublesMatch.getDoublesSet(setNumber).close();
+		}
+	}
+
+	private boolean isAllMatchFinished(DoublesMatch doublesMatch) {
+		return doublesMatchReader.allMatchesFinishedForLeague(
+			doublesMatch.getLeague().getLeagueId());
+	}
+
+	private void processNextRoundMatches(DoublesMatch doublesMatch) {
+
+		doublesMatchStore.store(doublesMatch);
+
+		matchUtils.updateDoublesMatchNextRoundMatch(doublesMatch);
+
+		boolean isCurrentRoundComplete = doublesMatchReader.allRoundMatchesDone(doublesMatch.getLeague().getLeagueId(),
+			doublesMatch.getRoundNumber());
+
+		boolean isCurrentRoundLessThanTotalRounds =
+			doublesMatch.getRoundNumber() < doublesMatch.getLeague().getTotalRounds();
+
+		if (isCurrentRoundComplete && isCurrentRoundLessThanTotalRounds) {
+
+			int nextRoundNumber = doublesMatch.getRoundNumber() + 1;
+
+			List<DoublesMatch> nextRoundMatches = doublesMatchReader.findMatchesByLeagueAndRound(
+				doublesMatch.getLeague().getLeagueId(), nextRoundNumber);
+
+			nextRoundMatches.stream()
+				.filter(match -> match.getMatchStatus() == MatchStatus.BYE)
+				.forEach(matchUtils::updateDoublesMatchNextRoundMatch);
+		}
+	}
+
+	private void updateWinnerWithSetScore(DoublesMatch doublesMatch, int setNumber,
+		MatchCommand.UpdateSetScore updateSetScoreCommand) {
+		DoublesSet set = doublesMatch.getDoublesSet(setNumber);
+		set.endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
+
+		if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
+			doublesMatch.team1WinSet();
+		} else {
+			doublesMatch.team2WinSet();
+		}
+	}
+}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentMatchProgressServiceImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentMatchProgressServiceImpl.java
@@ -28,17 +28,19 @@ public class TournamentMatchProgressServiceImpl implements MatchProgressService 
 	private final DoublesMatchStore doublesMatchStore;
 	private final LeagueReader leagueReader;
 	private final LeagueParticipantReader leagueParticipantReader;
+	private final TournamentSinglesEndSetHandler tournamentSinglesEndSetHandler;
+	private final TournamentSinglesBracketCreator tournamentSinglesBracketCreator;
+	private final TournamentDoublesEndSetHandler tournamentDoublesEndSetHandler;
+	private final TournamentDoublesBracketCreator tournamentDoublesBracketCreator;
 
 	@Override
 	public MatchStrategy makeSinglesOrDoublesMatchStrategy(Long leagueId) {
 		League league = findLeague(leagueId);
 		return switch (league.getMatchType()) {
-			case SINGLES ->
-				new TournamentSinglesMatchStrategy(singlesMatchReader, singlesMatchStore, leagueParticipantReader,
-					leagueReader);
-			case DOUBLES ->
-				new TournamentDoublesMatchStrategy(doublesMatchReader, doublesMatchStore, leagueParticipantReader,
-					leagueReader);
+			case SINGLES -> new TournamentSinglesMatchStrategy(singlesMatchReader, singlesMatchStore,
+				tournamentSinglesBracketCreator, tournamentSinglesEndSetHandler);
+			case DOUBLES -> new TournamentDoublesMatchStrategy(doublesMatchReader, doublesMatchStore,
+				tournamentDoublesEndSetHandler, tournamentDoublesBracketCreator);
 		};
 	}
 
@@ -48,7 +50,7 @@ public class TournamentMatchProgressServiceImpl implements MatchProgressService 
 		if (!leagueParticipantReader.isParticipant(memberToken, leagueId))
 			throw new LeagueParticipationNotExistException(leagueId, memberToken);
 
-		return matchStrategy.registerSetScoreInMatch(matchId, setIndex, updateSetScoreCommand);
+		return matchStrategy.endSet(matchId, setIndex, updateSetScoreCommand);
 	}
 
 	private League findLeague(Long leagueId) {

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentMatchRetrieveServiceImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentMatchRetrieveServiceImpl.java
@@ -1,6 +1,5 @@
 package org.badminton.infrastructure.match.service;
 
-import org.badminton.domain.domain.league.LeagueParticipantReader;
 import org.badminton.domain.domain.league.LeagueReader;
 import org.badminton.domain.domain.league.entity.League;
 import org.badminton.domain.domain.match.info.SetInfo;
@@ -14,7 +13,10 @@ import org.badminton.infrastructure.match.strategy.TournamentDoublesMatchStrateg
 import org.badminton.infrastructure.match.strategy.TournamentSinglesMatchStrategy;
 import org.springframework.stereotype.Service;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
+@RequiredArgsConstructor
 public class TournamentMatchRetrieveServiceImpl extends AbstractMatchRetrieveService {
 
 	private final LeagueReader leagueReader;
@@ -22,30 +24,19 @@ public class TournamentMatchRetrieveServiceImpl extends AbstractMatchRetrieveSer
 	private final DoublesMatchReader doublesMatchReader;
 	private final SinglesMatchStore singlesMatchStore;
 	private final DoublesMatchStore doublesMatchStore;
-	private final LeagueParticipantReader leagueParticipantReader;
-
-	public TournamentMatchRetrieveServiceImpl(LeagueReader leagueReader, SinglesMatchReader singlesMatchReader,
-		DoublesMatchReader doublesMatchReader,
-		SinglesMatchStore singlesMatchStore, DoublesMatchStore doublesMatchStore,
-		LeagueParticipantReader leagueParticipantReader) {
-		this.singlesMatchReader = singlesMatchReader;
-		this.doublesMatchReader = doublesMatchReader;
-		this.singlesMatchStore = singlesMatchStore;
-		this.doublesMatchStore = doublesMatchStore;
-		this.leagueReader = leagueReader;
-		this.leagueParticipantReader = leagueParticipantReader;
-	}
+	private final TournamentSinglesEndSetHandler tournamentSinglesEndSetHandler;
+	private final TournamentSinglesBracketCreator tournamentSinglesBracketCreator;
+	private final TournamentDoublesEndSetHandler tournamentDoublesEndSetHandler;
+	private final TournamentDoublesBracketCreator tournamentDoublesBracketCreator;
 
 	@Override
 	public MatchStrategy makeSinglesOrDoublesMatchStrategy(Long leagueId) {
 		League league = findLeague(leagueId);
 		return switch (league.getMatchType()) {
-			case SINGLES ->
-				new TournamentSinglesMatchStrategy(singlesMatchReader, singlesMatchStore, leagueParticipantReader,
-					leagueReader);
-			case DOUBLES ->
-				new TournamentDoublesMatchStrategy(doublesMatchReader, doublesMatchStore, leagueParticipantReader,
-					leagueReader);
+			case SINGLES -> new TournamentSinglesMatchStrategy(singlesMatchReader, singlesMatchStore,
+				tournamentSinglesBracketCreator, tournamentSinglesEndSetHandler);
+			case DOUBLES -> new TournamentDoublesMatchStrategy(doublesMatchReader, doublesMatchStore,
+				tournamentDoublesEndSetHandler, tournamentDoublesBracketCreator);
 		};
 	}
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentSinglesBracketCreator.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentSinglesBracketCreator.java
@@ -3,10 +3,8 @@ package org.badminton.infrastructure.match.service;
 import static org.badminton.domain.common.consts.Constants.*;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
-import org.badminton.domain.common.enums.MatchStatus;
 import org.badminton.domain.domain.league.entity.League;
 import org.badminton.domain.domain.league.entity.LeagueParticipant;
 import org.badminton.domain.domain.match.entity.SinglesMatch;
@@ -43,15 +41,6 @@ public class TournamentSinglesBracketCreator {
 		return totalRounds;
 	}
 
-	public List<LeagueParticipant> getLeagueParticipants(List<LeagueParticipant> leagueParticipantList) {
-		// 현재 라운드의 참가자 리스트
-		List<LeagueParticipant> currentParticipants = new ArrayList<>(leagueParticipantList);
-
-		// 참가자 리스트 섞기
-		Collections.shuffle(currentParticipants);
-		return currentParticipants;
-	}
-
 	public void generateAllMatches(League league, List<SinglesMatch> allMatches,
 		List<LeagueParticipant> currentParticipants,
 		int totalRounds) {
@@ -63,8 +52,7 @@ public class TournamentSinglesBracketCreator {
 
 		// 전체 매치 스트림 -> 부전승이고, leagueParticipant1 이 null 이 아닌 매치들 대상으로 -> leagueParticipant1 다음 라운드의 매치로 이동
 		allMatches.stream()
-			.filter(singlesMatch -> singlesMatch.getMatchStatus() == MatchStatus.BYE
-				&& singlesMatch.isLeagueParticipant1Exist())
+			.filter(SinglesMatch::isByeMatch)
 			.forEach(matchUtils::updateSinglesMatchNextRoundMatch);
 	}
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentSinglesBracketCreator.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentSinglesBracketCreator.java
@@ -1,0 +1,159 @@
+package org.badminton.infrastructure.match.service;
+
+import static org.badminton.domain.common.consts.Constants.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.badminton.domain.common.enums.MatchStatus;
+import org.badminton.domain.domain.league.entity.League;
+import org.badminton.domain.domain.league.entity.LeagueParticipant;
+import org.badminton.domain.domain.match.entity.SinglesMatch;
+import org.badminton.domain.domain.match.entity.SinglesSet;
+import org.badminton.domain.domain.match.reader.SinglesMatchStore;
+import org.badminton.domain.domain.match.store.SinglesMatchReader;
+import org.badminton.infrastructure.match.strategy.MatchUtils;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TournamentSinglesBracketCreator {
+
+	private final SinglesMatchStore singlesMatchStore;
+	private final SinglesMatchReader singlesMatchReader;
+	private final MatchUtils matchUtils;
+
+	private static boolean isParticipantOddSize(List<LeagueParticipant> participants) {
+		return participants.size() % 2 != 0;
+	}
+
+	private static boolean isSinglesMatchOddSize(List<SinglesMatch> singlesMatches) {
+		return singlesMatches.size() % 2 != 0;
+	}
+
+	public int getTotalRounds(League league, List<LeagueParticipant> currentParticipants) {
+		// 전체 라운드의 수 계산
+		int totalRounds = MatchUtils.calculateTotalRounds(currentParticipants.size());
+
+		// leagueEntity 에 전체 라운드 수 저장
+		league.defineTotalRounds(totalRounds);
+		return totalRounds;
+	}
+
+	public List<LeagueParticipant> getLeagueParticipants(List<LeagueParticipant> leagueParticipantList) {
+		// 현재 라운드의 참가자 리스트
+		List<LeagueParticipant> currentParticipants = new ArrayList<>(leagueParticipantList);
+
+		// 참가자 리스트 섞기
+		Collections.shuffle(currentParticipants);
+		return currentParticipants;
+	}
+
+	public void generateAllMatches(League league, List<SinglesMatch> allMatches,
+		List<LeagueParticipant> currentParticipants,
+		int totalRounds) {
+		// 전체 매치 배열에 첫번재 라운드 생성 후 넣기
+		allMatches.addAll(createFirstRoundMatches(league, currentParticipants));
+
+		// 전체 매치 배열에 첫번째 라운드 제외 모든 라운드 매치 생성 후 넣기
+		allMatches.addAll(createSubsequentRoundsMatches(league, totalRounds));
+
+		// 전체 매치 스트림 -> 부전승이고, leagueParticipant1 이 null 이 아닌 매치들 대상으로 -> leagueParticipant1 다음 라운드의 매치로 이동
+		allMatches.stream()
+			.filter(singlesMatch -> singlesMatch.getMatchStatus() == MatchStatus.BYE
+				&& singlesMatch.isLeagueParticipant1Exist())
+			.forEach(matchUtils::updateSinglesMatchNextRoundMatch);
+	}
+
+	private List<SinglesMatch> createFirstRoundMatches(League league, List<LeagueParticipant> participants) {
+		List<SinglesMatch> matches = new ArrayList<>();
+
+		for (int i = 0; i < participants.size() - 1; i += PARTICIPANTS_PER_MATCH) {
+			SinglesMatch match = new SinglesMatch(league, participants.get(i), participants.get(i + 1),
+				FIRST_ROUND_NUMBER);
+
+			makeSetsInMatch(match);
+			singlesMatchStore.store(match);
+			matches.add(match);
+		}
+
+		if (isParticipantOddSize(participants)) {
+			LeagueParticipant byeParticipant = participants.remove(participants.size() - 1);
+			SinglesMatch byeMatch = new SinglesMatch(league, byeParticipant, LeagueParticipant.emptyParticipant(),
+				FIRST_ROUND_NUMBER);
+
+			byeMatch.byeMatch();
+			singlesMatchStore.store(byeMatch);
+			matches.add(byeMatch);
+		}
+
+		return matches;
+	}
+
+	private void makeSetsInMatch(SinglesMatch singlesMatch) {
+		for (int i = 1; i <= SET_COUNT; i++) {
+			SinglesSet set = new SinglesSet(singlesMatch, i);
+			singlesMatch.addSet(set);
+		}
+		singlesMatchStore.store(singlesMatch);
+	}
+
+	private List<SinglesMatch> createSubsequentRoundsMatches(League league, int totalRounds) {
+		List<SinglesMatch> matches = new ArrayList<>();
+		List<SinglesMatch> previousRoundMatches = singlesMatchReader.findMatchesByLeagueAndRound(league.getLeagueId(),
+			FIRST_ROUND_NUMBER);
+
+		for (int roundNumber = SECOND_ROUND_NUMBER; roundNumber <= totalRounds; roundNumber++) {
+			List<SinglesMatch> currentRoundMatches = createMatchesRound(league, previousRoundMatches, roundNumber);
+			matches.addAll(currentRoundMatches);
+			previousRoundMatches = currentRoundMatches;
+		}
+
+		return matches;
+	}
+
+	private List<SinglesMatch> createMatchesRound(League league, List<SinglesMatch> previousRoundMatches,
+		int roundNumber) {
+
+		List<SinglesMatch> currentRoundMatches = new ArrayList<>(
+			initializeRoundMatches(league, previousRoundMatches, roundNumber));
+
+		if (isSinglesMatchOddSize(previousRoundMatches)) {
+			currentRoundMatches.add(createByeRoundMatch(league, previousRoundMatches, roundNumber));
+		}
+
+		return currentRoundMatches;
+	}
+
+	private List<SinglesMatch> initializeRoundMatches(League league, List<SinglesMatch> previousRoundMatches,
+		int roundNumber) {
+		List<SinglesMatch> regularRoundMatches = new ArrayList<>();
+
+		for (int i = 0; i < previousRoundMatches.size() - 1; i += PARTICIPANTS_PER_MATCH) {
+			SinglesMatch match = new SinglesMatch(league, LeagueParticipant.emptyParticipant(),
+				LeagueParticipant.emptyParticipant(), roundNumber);
+			makeSetsInMatch(match);
+			singlesMatchStore.store(match);
+			regularRoundMatches.add(match);
+		}
+
+		return regularRoundMatches;
+	}
+
+	private SinglesMatch createByeRoundMatch(League league, List<SinglesMatch> previousRoundMatches,
+		int roundNumber) {
+		SinglesMatch byeMatch = previousRoundMatches.get(previousRoundMatches.size() - 1);
+		LeagueParticipant winner = byeMatch.determineWinner();
+
+		SinglesMatch nextByeMatch = new SinglesMatch(league, winner, LeagueParticipant.emptyParticipant(),
+			roundNumber);
+		nextByeMatch.byeMatch();
+		singlesMatchStore.store(nextByeMatch);
+
+		return nextByeMatch;
+	}
+
+}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentSinglesEndSetHandler.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentSinglesEndSetHandler.java
@@ -1,0 +1,170 @@
+package org.badminton.infrastructure.match.service;
+
+import static org.badminton.domain.common.consts.Constants.*;
+
+import java.util.List;
+
+import org.badminton.domain.common.enums.MatchResult;
+import org.badminton.domain.common.enums.MatchStatus;
+import org.badminton.domain.common.enums.MatchType;
+import org.badminton.domain.common.enums.SetStatus;
+import org.badminton.domain.common.exception.match.AlreadyWinnerDeterminedException;
+import org.badminton.domain.common.exception.match.LeagueParticipantNotDeterminedException;
+import org.badminton.domain.common.exception.match.PreviousDetNotFinishedException;
+import org.badminton.domain.common.exception.match.RegisterScoreInByeMatchException;
+import org.badminton.domain.common.exception.match.RoundNotFinishedException;
+import org.badminton.domain.common.exception.match.SetFinishedException;
+import org.badminton.domain.domain.league.LeagueReader;
+import org.badminton.domain.domain.league.entity.LeagueParticipant;
+import org.badminton.domain.domain.match.command.MatchCommand;
+import org.badminton.domain.domain.match.entity.SinglesMatch;
+import org.badminton.domain.domain.match.entity.SinglesSet;
+import org.badminton.domain.domain.match.reader.SinglesMatchStore;
+import org.badminton.domain.domain.match.store.SinglesMatchReader;
+import org.badminton.infrastructure.match.strategy.MatchUtils;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TournamentSinglesEndSetHandler {
+
+	private final MatchUtils matchUtils;
+	private final SinglesMatchReader singlesMatchReader;
+	private final LeagueReader leagueReader;
+	private final SinglesMatchStore singlesMatchStore;
+
+	private static boolean isMatchWinnerDetermined(SinglesMatch singlesMatch) {
+		return singlesMatch.getPlayer1MatchResult() == MatchResult.WIN
+			|| singlesMatch.getPlayer2MatchResult() == MatchResult.WIN;
+	}
+
+	public void isEndSetAllowed(SinglesMatch singlesMatch, Integer setNumber, Long matchId) {
+
+		// 이전 세트 모두 종료 확인
+		isPreviousSetComplete(setNumber, singlesMatch);
+		// 이전 라운드 모두 종료 확인
+		isPreviousRoundComplete(singlesMatch.getLeague().getLeagueId(), singlesMatch.getRoundNumber());
+
+		// 부전승 EndSet 안됨
+		if (singlesMatch.getMatchStatus() == MatchStatus.BYE) {
+			throw new RegisterScoreInByeMatchException(singlesMatch.getId(), MatchType.SINGLES);
+		}
+
+		// Winner 가 이미 결정됨 -> 매치가 끝남
+		if (isMatchWinnerDetermined(singlesMatch)) {
+			throw new AlreadyWinnerDeterminedException(singlesMatch.getId());
+		}
+
+		// 해당 Set 의 상태가 FINISHED
+		if (singlesMatch.getSinglesSet(setNumber).getSetStatus() == SetStatus.FINISHED) {
+			throw new SetFinishedException(setNumber);
+		}
+
+		// LeagueParticipant 이 없을 때
+		if (singlesMatch.getLeagueParticipant1() == LeagueParticipant.emptyParticipant()
+			|| singlesMatch.getLeagueParticipant2() == LeagueParticipant.emptyParticipant()) {
+			throw new LeagueParticipantNotDeterminedException(matchId);
+		}
+
+	}
+
+	public void processEndSet(SinglesMatch singlesMatch, Integer setNumber,
+		MatchCommand.UpdateSetScore updateSetScoreCommand) {
+
+		// setScore 저장
+		updateWinnerWithSetScore(singlesMatch, setNumber, updateSetScoreCommand);
+
+		// 현재 세트 번호가 3보다 적다면 다음 세트 상태 변경
+		if (LIMIT_SET_GAME > setNumber) {
+			changeNextSetStatus(singlesMatch, setNumber);
+		}
+
+		// 승자가 결정 되었다면 승자 처우 결정(다음 라운드 진출 할 수 있으면 승자 이동)
+		if (isMatchWinnerDetermined(singlesMatch)) {
+			processNextRoundMatches(singlesMatch);
+		}
+
+		// 경기의 모든 매치가 끝났다면 경기 조회 후 finishLeague
+		if (isAllMatchFinished(singlesMatch)) {
+			leagueReader.readLeagueById(singlesMatch.getLeague().getLeagueId()).finishLeague();
+		}
+
+	}
+
+	private void isPreviousRoundComplete(Long leagueId, int roundNumber) {
+
+		if (roundNumber == FIRST_ROUND_NUMBER) {
+			return;
+		}
+		int previousRoundNumber = roundNumber - 1;
+
+		if (!singlesMatchReader.allRoundMatchesDone(leagueId, previousRoundNumber)) {
+			throw new RoundNotFinishedException(previousRoundNumber);
+		}
+	}
+
+	private void isPreviousSetComplete(int setNumber, SinglesMatch singlesMatch) {
+
+		if (setNumber == FIRST_SET_NUMBER) {
+			return;
+		}
+		int previousSetNumber = setNumber - 1;
+		if (singlesMatch.getSinglesSet(previousSetNumber).getSetStatus() != SetStatus.FINISHED) {
+			throw new PreviousDetNotFinishedException(previousSetNumber);
+		}
+	}
+
+	private void updateWinnerWithSetScore(SinglesMatch singlesMatch, int setNumber,
+		MatchCommand.UpdateSetScore updateSetScoreCommand) {
+		SinglesSet set = singlesMatch.getSinglesSet(setNumber);
+		set.endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
+
+		if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
+			singlesMatch.player1WinSet();
+		} else {
+			singlesMatch.player2WinSet();
+		}
+	}
+
+	private void processNextRoundMatches(SinglesMatch singlesMatch) {
+		// singleMatch 저장
+		singlesMatchStore.store(singlesMatch);
+
+		matchUtils.updateSinglesMatchNextRoundMatch(singlesMatch);
+
+		boolean isCurrentRoundComplete = singlesMatchReader.allRoundMatchesDone(singlesMatch.getLeague().getLeagueId(),
+			singlesMatch.getRoundNumber());
+
+		boolean isCurrentRoundLessThanTotalRounds =
+			singlesMatch.getRoundNumber() < singlesMatch.getLeague().getTotalRounds();
+
+		if (isCurrentRoundComplete && isCurrentRoundLessThanTotalRounds) {
+
+			int nextRoundNumber = singlesMatch.getRoundNumber() + 1;
+
+			List<SinglesMatch> nextRoundMatches = singlesMatchReader.findMatchesByLeagueAndRound(
+				singlesMatch.getLeague().getLeagueId(), nextRoundNumber);
+
+			nextRoundMatches.stream()
+				.filter(match -> match.getMatchStatus() == MatchStatus.BYE)
+				.forEach(matchUtils::updateSinglesMatchNextRoundMatch);
+		}
+	}
+
+	private void changeNextSetStatus(SinglesMatch singlesMatch, Integer setNumber) {
+		setNumber++;
+		if (singlesMatch.getPlayer1MatchResult().equals(MatchResult.NONE)) {
+			singlesMatch.getSinglesSet(setNumber).open();
+		}
+		if (!singlesMatch.getPlayer1MatchResult().equals(MatchResult.NONE)) {
+			singlesMatch.getSinglesSet(setNumber).close();
+		}
+	}
+
+	private boolean isAllMatchFinished(SinglesMatch singlesMatch) {
+		return singlesMatchReader.allMatchesFinishedForLeague(
+			singlesMatch.getLeague().getLeagueId());
+	}
+}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentSinglesEndSetHandler.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentSinglesEndSetHandler.java
@@ -15,7 +15,6 @@ import org.badminton.domain.common.exception.match.RegisterScoreInByeMatchExcept
 import org.badminton.domain.common.exception.match.RoundNotFinishedException;
 import org.badminton.domain.common.exception.match.SetFinishedException;
 import org.badminton.domain.domain.league.LeagueReader;
-import org.badminton.domain.domain.league.entity.LeagueParticipant;
 import org.badminton.domain.domain.match.command.MatchCommand;
 import org.badminton.domain.domain.match.entity.SinglesMatch;
 import org.badminton.domain.domain.match.entity.SinglesSet;
@@ -35,11 +34,6 @@ public class TournamentSinglesEndSetHandler {
 	private final LeagueReader leagueReader;
 	private final SinglesMatchStore singlesMatchStore;
 
-	private static boolean isMatchWinnerDetermined(SinglesMatch singlesMatch) {
-		return singlesMatch.getPlayer1MatchResult() == MatchResult.WIN
-			|| singlesMatch.getPlayer2MatchResult() == MatchResult.WIN;
-	}
-
 	public void isEndSetAllowed(SinglesMatch singlesMatch, Integer setNumber, Long matchId) {
 
 		// 이전 세트 모두 종료 확인
@@ -53,7 +47,7 @@ public class TournamentSinglesEndSetHandler {
 		}
 
 		// Winner 가 이미 결정됨 -> 매치가 끝남
-		if (isMatchWinnerDetermined(singlesMatch)) {
+		if (singlesMatch.isMatchWinnerDetermined()) {
 			throw new AlreadyWinnerDeterminedException(singlesMatch.getId());
 		}
 
@@ -63,8 +57,7 @@ public class TournamentSinglesEndSetHandler {
 		}
 
 		// LeagueParticipant 이 없을 때
-		if (singlesMatch.getLeagueParticipant1() == LeagueParticipant.emptyParticipant()
-			|| singlesMatch.getLeagueParticipant2() == LeagueParticipant.emptyParticipant()) {
+		if (!singlesMatch.isLeagueParticipant1Exist() || !singlesMatch.isLeagueParticipant2Exist()) {
 			throw new LeagueParticipantNotDeterminedException(matchId);
 		}
 
@@ -82,7 +75,7 @@ public class TournamentSinglesEndSetHandler {
 		}
 
 		// 승자가 결정 되었다면 승자 처우 결정(다음 라운드 진출 할 수 있으면 승자 이동)
-		if (isMatchWinnerDetermined(singlesMatch)) {
+		if (singlesMatch.isMatchWinnerDetermined()) {
 			processNextRoundMatches(singlesMatch);
 		}
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/FreeDoublesMatchStrategy.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/FreeDoublesMatchStrategy.java
@@ -57,7 +57,7 @@ public class FreeDoublesMatchStrategy extends AbstractDoublesMatchStrategy {
 	}
 
 	@Override
-	public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
+	public SetInfo.Main endSet(Long matchId, Integer setNumber,
 		MatchCommand.UpdateSetScore updateSetScoreCommand) {
 		DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/FreeSinglesMatchStrategy.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/FreeSinglesMatchStrategy.java
@@ -62,7 +62,7 @@ public class FreeSinglesMatchStrategy extends AbstractSinglesMatchStrategy {
 	}
 
 	@Override
-	public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
+	public SetInfo.Main endSet(Long matchId, Integer setNumber,
 		MatchCommand.UpdateSetScore updateSetScoreCommand) {
 		SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/MatchUtils.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/MatchUtils.java
@@ -56,10 +56,10 @@ public class MatchUtils {
 		return nextRoundStartId + nextMatchIndexInRound;
 	}
 
-	private static boolean isCurrentMatchInRound(int matchID, int roundStartId,
+	private static boolean isCurrentMatchInRound(int matchId, int roundStartId,
 		int matchesInCurrentRound) {
-		return isMatchIdGreaterThanOrEqualToRoundStart(matchID, roundStartId)
-			&& isMatchIdLessThanRoundEnd(matchID, roundStartId, matchesInCurrentRound);
+		return isMatchIdGreaterThanOrEqualToRoundStart(matchId, roundStartId)
+			&& isMatchIdLessThanRoundEnd(matchId, roundStartId, matchesInCurrentRound);
 	}
 
 	private static boolean isMatchIdLessThanRoundEnd(int currentMatchId, int currentRoundStartId,
@@ -83,7 +83,7 @@ public class MatchUtils {
 
 	public void updateSinglesMatchNextRoundMatch(SinglesMatch singlesMatch) {
 		LeagueParticipant winner = singlesMatch.determineWinner();
-		if (winner == null) {
+		if (winner == LeagueParticipant.emptyWinner()) {
 			return;
 		}
 
@@ -91,7 +91,7 @@ public class MatchUtils {
 		if (singlesMatch.getRoundNumber() == totalRounds) {
 			return;
 		}
-		
+
 		SinglesMatch startMatch = singlesMatchReader.findFirstMatchByLeagueId(
 			singlesMatch.getLeague().getLeagueId());
 
@@ -129,7 +129,7 @@ public class MatchUtils {
 
 	public void updateDoublesMatchNextRoundMatch(DoublesMatch doublesMatch) {
 		Team winner = doublesMatch.determineWinner();
-		if (winner == null) {
+		if (winner == Team.emptyWinner()) {
 			return;
 		}
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/MatchUtils.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/MatchUtils.java
@@ -1,27 +1,53 @@
 package org.badminton.infrastructure.match.strategy;
 
+import static org.badminton.domain.common.consts.Constants.*;
+
+import org.badminton.domain.common.enums.MatchStatus;
+import org.badminton.domain.domain.league.LeagueParticipantReader;
+import org.badminton.domain.domain.league.entity.LeagueParticipant;
+import org.badminton.domain.domain.league.vo.Team;
+import org.badminton.domain.domain.match.entity.DoublesMatch;
+import org.badminton.domain.domain.match.entity.SinglesMatch;
+import org.badminton.domain.domain.match.reader.DoublesMatchStore;
+import org.badminton.domain.domain.match.reader.SinglesMatchStore;
+import org.badminton.domain.domain.match.store.DoublesMatchReader;
+import org.badminton.domain.domain.match.store.SinglesMatchReader;
 import org.springframework.stereotype.Component;
 
+import lombok.RequiredArgsConstructor;
+
 @Component
+@RequiredArgsConstructor
 public class MatchUtils {
 
-	public static Integer calculateNextRoundMatchId(int currentMatchId, int totalParticipants, int startMatchId) {
+	private final SinglesMatchStore singlesMatchStore;
+	private final SinglesMatchReader singlesMatchReader;
+	private final LeagueParticipantReader leagueParticipantReader;
+	private final DoublesMatchReader doublesMatchReader;
+	private final DoublesMatchStore doublesMatchStore;
 
+	// 다음 라운드 matchId 계산
+	private static Integer determineNextRoundMatch(int matchId, int totalParticipants,
+		int roundStartId) {
+
+		// 전체 라운드 구하기
 		int totalRounds = calculateTotalRounds(totalParticipants);
-		int matchesInCurrentRound = (totalParticipants + 1) / 2;
-		int currentRoundStartId = startMatchId;
+		// 매치의 현재 라운드 계산
+		int matchCountInRound = (totalParticipants + 1) / 2;
 
-		for (int round = 1; round <= totalRounds; round++) {
-			if (isCurrentMatchInRound(currentMatchId, currentRoundStartId, matchesInCurrentRound)) {
-				return calculateNextMatchIdInRound(currentMatchId, currentRoundStartId, matchesInCurrentRound);
+		// for 문으로 돌면서 전체 라운드 수만큼 돌면서 현재 matchId, 현재 라운드의 startId, 현재 라운드의 번호를 이용해 어떤 라운드에 속하는지 확인하고 다음 라운드의 매치 아이디 계산
+		for (int round = FIRST_ROUND_NUMBER; round <= totalRounds; round++) {
+			if (isCurrentMatchInRound(matchId, roundStartId, matchCountInRound)) {
+				return calculateNextRoundMatchId(matchId, roundStartId, matchCountInRound);
 			}
-			currentRoundStartId += matchesInCurrentRound;
-			matchesInCurrentRound = (matchesInCurrentRound + 1) / 2;
+			roundStartId += matchCountInRound;
+			matchCountInRound = (matchCountInRound + 1) / 2;
 		}
 		return null;
 	}
 
-	private static int calculateNextMatchIdInRound(int currentMatchId, int currentRoundStartId,
+	// 다음 라운드 matchId 계산 로직만 분리
+	private static int calculateNextRoundMatchId(int currentMatchId, int currentRoundStartId,
 		int matchesInCurrentRound) {
 		int matchIndexInRound = currentMatchId - currentRoundStartId;
 		int nextMatchIndexInRound = matchIndexInRound / 2;
@@ -30,10 +56,10 @@ public class MatchUtils {
 		return nextRoundStartId + nextMatchIndexInRound;
 	}
 
-	private static boolean isCurrentMatchInRound(int currentMatchId, int currentRoundStartId,
+	private static boolean isCurrentMatchInRound(int matchID, int roundStartId,
 		int matchesInCurrentRound) {
-		return isMatchIdGreaterThanOrEqualToRoundStart(currentMatchId, currentRoundStartId)
-			&& isMatchIdLessThanRoundEnd(currentMatchId, currentRoundStartId, matchesInCurrentRound);
+		return isMatchIdGreaterThanOrEqualToRoundStart(matchID, roundStartId)
+			&& isMatchIdLessThanRoundEnd(matchID, roundStartId, matchesInCurrentRound);
 	}
 
 	private static boolean isMatchIdLessThanRoundEnd(int currentMatchId, int currentRoundStartId,
@@ -45,13 +71,106 @@ public class MatchUtils {
 		return currentMatchId >= currentRoundStartId;
 	}
 
+	// 전체 라운드 계산
 	public static int calculateTotalRounds(int currentTeams) {
-		int round = 0;
+		int round = INIT_ROUND_NUMBER;
 		while (currentTeams > 1) {
 			currentTeams = (currentTeams + 1) / 2;
 			round++;
 		}
 		return round;
 	}
+
+	public void updateSinglesMatchNextRoundMatch(SinglesMatch singlesMatch) {
+		LeagueParticipant winner = singlesMatch.determineWinner();
+		if (winner == null) {
+			return;
+		}
+
+		int totalRounds = singlesMatch.getLeague().getTotalRounds();
+		if (singlesMatch.getRoundNumber() == totalRounds) {
+			return;
+		}
+		
+		SinglesMatch startMatch = singlesMatchReader.findFirstMatchByLeagueId(
+			singlesMatch.getLeague().getLeagueId());
+
+		int nextRoundMatchId = MatchUtils.determineNextRoundMatch(
+			Math.toIntExact(singlesMatch.getId()),
+			leagueParticipantReader.countParticipantMember(singlesMatch.getLeague().getLeagueId()),
+			Math.toIntExact(startMatch.getId()));
+
+		SinglesMatch nextRoundMatch = singlesMatchReader.getSinglesMatch((long)nextRoundMatchId);
+
+		if (nextRoundMatch == null) {
+			return;
+		}
+
+		if (singlesMatch.getMatchStatus() == MatchStatus.BYE) {
+			nextRoundMatch.defineLeagueParticipant1(winner);
+			singlesMatchStore.store(nextRoundMatch);
+			return;
+		}
+
+		assignSinglesWinnerToNextRound(nextRoundMatch, winner);
+		singlesMatchStore.store(nextRoundMatch);
+	}
+
+	private void assignSinglesWinnerToNextRound(SinglesMatch nextRoundMatch, LeagueParticipant winner) {
+		if (!nextRoundMatch.isLeagueParticipant1Exist()) {
+			nextRoundMatch.defineLeagueParticipant1(winner);
+			return;
+		}
+
+		if (!nextRoundMatch.isLeagueParticipant2Exist()) {
+			nextRoundMatch.defineLeagueParticipant2(winner);
+		}
+	}
+
+	public void updateDoublesMatchNextRoundMatch(DoublesMatch doublesMatch) {
+		Team winner = doublesMatch.determineWinner();
+		if (winner == null) {
+			return;
+		}
+
+		int totalRounds = doublesMatch.getLeague().getTotalRounds();
+		if (doublesMatch.getRoundNumber() == totalRounds) {
+			return;
+		}
+
+		DoublesMatch startMatch = doublesMatchReader.findFirstMatchByLeagueId(
+			doublesMatch.getLeague().getLeagueId());
+
+		int nextRoundMatchId = MatchUtils.determineNextRoundMatch(Math.toIntExact(doublesMatch.getId()),
+			leagueParticipantReader.countParticipantMember(doublesMatch.getLeague().getLeagueId())
+				/ PARTICIPANTS_PER_TEAM, Math.toIntExact(startMatch.getId()));
+
+		DoublesMatch nextRoundMatch = doublesMatchReader.getDoublesMatch((long)nextRoundMatchId);
+
+		if (nextRoundMatch == null) {
+			return;
+		}
+
+		if (doublesMatch.getMatchStatus() == MatchStatus.BYE) {
+			nextRoundMatch.defineTeam1(winner);
+			doublesMatchStore.store(nextRoundMatch);
+			return;
+		}
+
+		assignDoublesWinnerToNextRound(nextRoundMatch, winner);
+		doublesMatchStore.store(nextRoundMatch);
+	}
+
+	private void assignDoublesWinnerToNextRound(DoublesMatch nextRoundMatch, Team winner) {
+		if (!nextRoundMatch.isTeam1Exist()) {
+			nextRoundMatch.defineTeam1(winner);
+			return;
+		}
+		if (!nextRoundMatch.isTeam2Exist()) {
+			nextRoundMatch.defineTeam2(winner);
+		}
+
+	}
+
 }
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/TournamentDoublesMatchStrategy.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/TournamentDoublesMatchStrategy.java
@@ -1,24 +1,10 @@
 package org.badminton.infrastructure.match.strategy;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
-import org.badminton.domain.common.enums.MatchResult;
-import org.badminton.domain.common.enums.MatchStatus;
-import org.badminton.domain.common.enums.MatchType;
-import org.badminton.domain.common.enums.SetStatus;
-import org.badminton.domain.common.exception.match.AlreadyWinnerDeterminedException;
-import org.badminton.domain.common.exception.match.LeagueParticipantNotDeterminedException;
-import org.badminton.domain.common.exception.match.PreviousDetNotFinishedException;
-import org.badminton.domain.common.exception.match.RegisterScoreInByeMatchException;
-import org.badminton.domain.common.exception.match.RoundNotFinishedException;
-import org.badminton.domain.common.exception.match.SetFinishedException;
-import org.badminton.domain.domain.league.LeagueParticipantReader;
-import org.badminton.domain.domain.league.LeagueReader;
 import org.badminton.domain.domain.league.entity.League;
 import org.badminton.domain.domain.league.entity.LeagueParticipant;
-import org.badminton.domain.domain.league.vo.Team;
 import org.badminton.domain.domain.match.command.MatchCommand;
 import org.badminton.domain.domain.match.entity.DoublesMatch;
 import org.badminton.domain.domain.match.entity.DoublesSet;
@@ -28,6 +14,8 @@ import org.badminton.domain.domain.match.info.SetInfo.Main;
 import org.badminton.domain.domain.match.reader.DoublesMatchStore;
 import org.badminton.domain.domain.match.service.AbstractDoublesMatchStrategy;
 import org.badminton.domain.domain.match.store.DoublesMatchReader;
+import org.badminton.infrastructure.match.service.TournamentDoublesBracketCreator;
+import org.badminton.infrastructure.match.service.TournamentDoublesEndSetHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,135 +25,55 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class TournamentDoublesMatchStrategy extends AbstractDoublesMatchStrategy {
 
-	public static final int SET_COUNT = 3;
-	public static final int PARTICIPANTS_PER_TEAM = 2;
-	public static final int TEAMS_PER_MATCH = 2;
-	static final Integer LIMIT_SET_GAME = 3;
 	private final DoublesMatchReader doublesMatchReader;
 	private final DoublesMatchStore doublesMatchStore;
-	private final LeagueParticipantReader leagueParticipantReader;
-	private final LeagueReader leagueReader;
+	private final TournamentDoublesEndSetHandler tournamentDoublesEndSetHandler;
+	private final TournamentDoublesBracketCreator tournamentDoublesBracketCreator;
 
 	public TournamentDoublesMatchStrategy(DoublesMatchReader doublesMatchReader, DoublesMatchStore doublesMatchStore,
-		LeagueParticipantReader leagueParticipantReader, LeagueReader leagueReader) {
+		TournamentDoublesEndSetHandler tournamentDoublesEndSetHandler,
+		TournamentDoublesBracketCreator tournamentDoublesBracketCreator) {
 		super(doublesMatchReader, doublesMatchStore);
 		this.doublesMatchReader = doublesMatchReader;
 		this.doublesMatchStore = doublesMatchStore;
-		this.leagueParticipantReader = leagueParticipantReader;
-		this.leagueReader = leagueReader;
+		this.tournamentDoublesEndSetHandler = tournamentDoublesEndSetHandler;
+		this.tournamentDoublesBracketCreator = tournamentDoublesBracketCreator;
 	}
 
-	private static boolean isMatchWinnerDetermined(DoublesMatch doublesMatch) {
-		return doublesMatch.getTeam1MatchResult() == MatchResult.WIN
-			|| doublesMatch.getTeam2MatchResult() == MatchResult.WIN;
-	}
-
-	private static boolean isParticipantOddSize(List<LeagueParticipant> participants) {
-		return participants.size() % 4 != 0;
-	}
-
-	private static boolean isDoubleMatchOddSize(List<DoublesMatch> doublesMatches) {
-		return doublesMatches.size() % 2 != 0;
-	}
-
+	// 대진표 생성
 	@Override
 	public BracketInfo makeBracket(League league, List<LeagueParticipant> leagueParticipantList) {
+
 		List<DoublesMatch> allMatches = new ArrayList<>();
-		List<LeagueParticipant> currentParticipants = new ArrayList<>(leagueParticipantList);
-		Collections.shuffle(currentParticipants);
 
-		int totalRounds = MatchUtils.calculateTotalRounds(currentParticipants.size() / PARTICIPANTS_PER_TEAM);
-		league.defineTotalRounds(totalRounds);
+		List<LeagueParticipant> currentParticipants = tournamentDoublesBracketCreator.getLeagueParticipants(
+			leagueParticipantList);
 
-		allMatches.addAll(createFirstRoundMatches(league, currentParticipants));
-		allMatches.addAll(createSubsequentRoundsMatches(league, totalRounds));
+		int totalRounds = tournamentDoublesBracketCreator.getTotalRounds(league, currentParticipants);
 
-		allMatches.stream()
-			.filter(doublesMatch -> doublesMatch.getMatchStatus() == MatchStatus.BYE && doublesMatch.getTeam1() != null)
-			.forEach(this::updateNextRoundMatch);
+		tournamentDoublesBracketCreator.generateAllMatches(league, allMatches, currentParticipants, totalRounds);
 
 		return BracketInfo.fromDoubles(totalRounds, allMatches);
 	}
 
+	// 세트 종료
 	@Override
 	@Transactional
-	public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
+	public SetInfo.Main endSet(Long matchId, Integer setNumber,
 		MatchCommand.UpdateSetScore updateSetScoreCommand) {
+
 		DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
 
-		validatePreviousSetCompletion(setNumber, doublesMatch);
+		tournamentDoublesEndSetHandler.isEndSetAllowed(matchId, setNumber, doublesMatch);
 
-		validatePreviousRoundCompletion(doublesMatch.getLeague().getLeagueId(), doublesMatch.getRoundNumber());
-
-		if (doublesMatch.getMatchStatus() == MatchStatus.BYE) {
-			throw new RegisterScoreInByeMatchException(doublesMatch.getId(), MatchType.DOUBLES);
-		}
-
-		if (isMatchWinnerDetermined(doublesMatch)) {
-			throw new AlreadyWinnerDeterminedException(doublesMatch.getId());
-		}
-
-		if (doublesMatch.getDoublesSet(setNumber).getSetStatus() == SetStatus.FINISHED) {
-			throw new SetFinishedException(setNumber);
-		}
-
-		if (doublesMatch.getTeam1() == null || doublesMatch.getTeam2() == null) {
-			throw new LeagueParticipantNotDeterminedException(matchId);
-		}
-
-		updateSetScore(doublesMatch, setNumber, updateSetScoreCommand);
-
-		if (LIMIT_SET_GAME > setNumber) {
-			changeNextSetStatus(doublesMatch, setNumber);
-		}
-
-		if (isMatchWinnerDetermined(doublesMatch)) {
-			processMatchAndNextRound(doublesMatch);
-		}
-		if (isAllMatchFinished(doublesMatch)) {
-			leagueReader.readLeagueById(doublesMatch.getLeague().getLeagueId()).finishLeague();
-		}
+		tournamentDoublesEndSetHandler.processEndSet(setNumber, updateSetScoreCommand, doublesMatch);
 
 		doublesMatchStore.store(doublesMatch);
+
 		return SetInfo.fromDoublesSet(matchId, setNumber, doublesMatch.getDoublesSets().get(setNumber - 1));
 	}
 
-	private void validatePreviousRoundCompletion(Long leagueId, int roundNumber) {
-
-		if (roundNumber == 1) {
-			return;
-		}
-
-		if (!doublesMatchReader.allRoundMatchesDone(leagueId, roundNumber - 1)) {
-			throw new RoundNotFinishedException(roundNumber - 1);
-		}
-	}
-
-	private void validatePreviousSetCompletion(int setNumber, DoublesMatch doublesMatch) {
-
-		if (setNumber == 1) {
-			return;
-		}
-		if (doublesMatch.getDoublesSet(setNumber - 1).getSetStatus() != SetStatus.FINISHED) {
-			throw new PreviousDetNotFinishedException(setNumber - 1);
-		}
-	}
-
-	private void changeNextSetStatus(DoublesMatch doublesMatch, Integer setNumber) {
-		setNumber++;
-		if (doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
-			doublesMatch.getDoublesSet(setNumber).open();
-		}
-		if (!doublesMatch.getTeam1MatchResult().equals(MatchResult.NONE)) {
-			doublesMatch.getDoublesSet(setNumber).close();
-		}
-	}
-
-	private boolean isAllMatchFinished(DoublesMatch doublesMatch) {
-		return doublesMatchReader.allMatchesFinishedForLeague(
-			doublesMatch.getLeague().getLeagueId());
-	}
-
+	// 세트 조회
 	@Override
 	public Main retrieveSet(Long matchId, int setNumber) {
 		DoublesMatch doublesMatch = doublesMatchReader.getDoublesMatch(matchId);
@@ -173,172 +81,4 @@ public class TournamentDoublesMatchStrategy extends AbstractDoublesMatchStrategy
 		return SetInfo.fromDoublesSet(matchId, setNumber, doublesSet);
 	}
 
-	private void processMatchAndNextRound(DoublesMatch doublesMatch) {
-		doublesMatchStore.store(doublesMatch);
-		updateNextRoundMatch(doublesMatch);
-		boolean allRoundMatchesDone = doublesMatchReader.allRoundMatchesDone(doublesMatch.getLeague().getLeagueId(),
-			doublesMatch.getRoundNumber());
-		boolean currentRoundInTotalRound =
-			doublesMatch.getRoundNumber() < doublesMatch.getLeague().getTotalRounds();
-
-		if (allRoundMatchesDone && currentRoundInTotalRound) {
-			List<DoublesMatch> nextRoundMatches = doublesMatchReader.findMatchesByLeagueAndRound(
-				doublesMatch.getLeague().getLeagueId(), doublesMatch.getRoundNumber() + 1
-			);
-			nextRoundMatches.stream()
-				.filter(match -> match.getMatchStatus() == MatchStatus.BYE)
-				.forEach(this::updateNextRoundMatch);
-		}
-	}
-
-	private List<DoublesMatch> createFirstRoundMatches(League league, List<LeagueParticipant> participants) {
-		List<DoublesMatch> matches = new ArrayList<>();
-
-		for (int i = 0; i < participants.size() - 2; i += PARTICIPANTS_PER_TEAM * TEAMS_PER_MATCH) {
-			Team team1 = new Team(participants.get(i), participants.get(i + 1));
-			Team team2 = new Team(participants.get(i + 2), participants.get(i + 3));
-			DoublesMatch match = new DoublesMatch(league, team1, team2, 1);
-			makeSetsInMatch(match);
-			doublesMatchStore.store(match);
-			matches.add(match);
-		}
-
-		if (isParticipantOddSize(participants)) {
-			Team byeTeam = new Team(participants.remove(participants.size() - 1),
-				participants.get(participants.size() - 2));
-			DoublesMatch byeMatch = new DoublesMatch(league, byeTeam, null, 1);
-			byeMatch.byeMatch();
-			doublesMatchStore.store(byeMatch);
-			matches.add(byeMatch);
-		}
-		return matches;
-	}
-
-	private List<DoublesMatch> createMatchesRound(League league, List<DoublesMatch> previousRoundMatches,
-		int roundNumber) {
-		List<DoublesMatch> currentRoundMatches = new ArrayList<>();
-
-		currentRoundMatches.addAll(createRegularMatchesForRound(league, previousRoundMatches, roundNumber));
-
-		if (isDoubleMatchOddSize(previousRoundMatches)) {
-			currentRoundMatches.add(createByeRoundMatch(league, previousRoundMatches, roundNumber));
-		}
-
-		return currentRoundMatches;
-	}
-
-	private List<DoublesMatch> createRegularMatchesForRound(League league, List<DoublesMatch> previousRoundMatches,
-		int roundNumber) {
-		List<DoublesMatch> regularRoundMatches = new ArrayList<>();
-
-		for (int i = 0; i < previousRoundMatches.size() - 1; i += TEAMS_PER_MATCH) {
-			DoublesMatch match = new DoublesMatch(league, null, null, roundNumber);
-			makeSetsInMatch(match);
-			doublesMatchStore.store(match);
-			regularRoundMatches.add(match);
-		}
-
-		return regularRoundMatches;
-	}
-
-	private DoublesMatch createByeRoundMatch(League league, List<DoublesMatch> previousRoundMatches,
-		int roundNumber) {
-		DoublesMatch byeMatch = previousRoundMatches.get(previousRoundMatches.size() - 1);
-		Team winner = determineWinner(byeMatch);
-
-		DoublesMatch nextByeMatch = new DoublesMatch(league, winner, null, roundNumber);
-		nextByeMatch.byeMatch();
-		doublesMatchStore.store(nextByeMatch);
-
-		return nextByeMatch;
-	}
-
-	private List<DoublesMatch> createSubsequentRoundsMatches(League league, int totalRounds) {
-		List<DoublesMatch> matches = new ArrayList<>();
-		List<DoublesMatch> previousMatches = doublesMatchReader.findMatchesByLeagueAndRound(league.getLeagueId(), 1);
-
-		for (int roundNumber = 2; roundNumber <= totalRounds; roundNumber++) {
-			List<DoublesMatch> currentRoundMatches = createMatchesRound(league, previousMatches, roundNumber);
-			matches.addAll(currentRoundMatches);
-			previousMatches = currentRoundMatches;
-		}
-
-		return matches;
-	}
-
-	private void makeSetsInMatch(DoublesMatch doublesMatch) {
-		for (int i = 1; i <= SET_COUNT; i++) {
-			DoublesSet set = new DoublesSet(doublesMatch, i);
-			doublesMatch.addSet(set);
-		}
-		doublesMatchStore.store(doublesMatch);
-	}
-
-	private void updateSetScore(DoublesMatch doublesMatch, int setNumber,
-		MatchCommand.UpdateSetScore updateSetScoreCommand) {
-		DoublesSet set = doublesMatch.getDoublesSet(setNumber);
-		set.endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
-
-		if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
-			doublesMatch.team1WinSet();
-		} else {
-			doublesMatch.team2WinSet();
-		}
-	}
-
-	private void updateNextRoundMatch(DoublesMatch doublesMatch) {
-		Team winner = determineWinner(doublesMatch);
-		if (winner == null) {
-			return;
-		}
-		int totalRounds = doublesMatch.getLeague().getTotalRounds();
-		if (doublesMatch.getRoundNumber() == totalRounds) {
-			return;
-		}
-
-		DoublesMatch startMatch = doublesMatchReader.findFirstMatchByLeagueId(
-			doublesMatch.getLeague().getLeagueId());
-
-		int nextRoundMatchId = MatchUtils.calculateNextRoundMatchId(Math.toIntExact(doublesMatch.getId()),
-			leagueParticipantReader.countParticipantMember(doublesMatch.getLeague().getLeagueId())
-				/ PARTICIPANTS_PER_TEAM,
-			Math.toIntExact(startMatch.getId()));
-
-		DoublesMatch nextRoundMatch = doublesMatchReader.getDoublesMatch((long)nextRoundMatchId);
-
-		if (nextRoundMatch == null) {
-			return;
-		}
-
-		if (doublesMatch.getMatchStatus() == MatchStatus.BYE) {
-			nextRoundMatch.defineTeam1(winner);
-			doublesMatchStore.store(nextRoundMatch);
-			return;
-		}
-
-		assignWinnerToNextRoundMatch(nextRoundMatch, winner);
-		doublesMatchStore.store(nextRoundMatch);
-	}
-
-	private void assignWinnerToNextRoundMatch(DoublesMatch nextRoundMatch, Team winner) {
-		if (nextRoundMatch.getTeam1() == null) {
-			nextRoundMatch.defineTeam1(winner);
-			return;
-		}
-		if (nextRoundMatch.getTeam2() == null) {
-			nextRoundMatch.defineTeam2(winner);
-		}
-
-	}
-
-	private Team determineWinner(DoublesMatch match) {
-		if (match.getMatchStatus() == MatchStatus.BYE || match.getTeam1MatchResult() == MatchResult.WIN) {
-			return match.getTeam1();
-		}
-
-		if (match.getTeam2MatchResult() == MatchResult.WIN) {
-			return match.getTeam2();
-		}
-		return null;
-	}
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/TournamentDoublesMatchStrategy.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/TournamentDoublesMatchStrategy.java
@@ -1,6 +1,7 @@
 package org.badminton.infrastructure.match.strategy;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.badminton.domain.domain.league.entity.League;
@@ -45,13 +46,11 @@ public class TournamentDoublesMatchStrategy extends AbstractDoublesMatchStrategy
 	public BracketInfo makeBracket(League league, List<LeagueParticipant> leagueParticipantList) {
 
 		List<DoublesMatch> allMatches = new ArrayList<>();
+		Collections.shuffle(leagueParticipantList);
 
-		List<LeagueParticipant> currentParticipants = tournamentDoublesBracketCreator.getLeagueParticipants(
-			leagueParticipantList);
+		int totalRounds = tournamentDoublesBracketCreator.getTotalRounds(league, leagueParticipantList);
 
-		int totalRounds = tournamentDoublesBracketCreator.getTotalRounds(league, currentParticipants);
-
-		tournamentDoublesBracketCreator.generateAllMatches(league, allMatches, currentParticipants, totalRounds);
+		tournamentDoublesBracketCreator.generateAllMatches(league, allMatches, leagueParticipantList, totalRounds);
 
 		return BracketInfo.fromDoubles(totalRounds, allMatches);
 	}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/TournamentSinglesMatchStrategy.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/TournamentSinglesMatchStrategy.java
@@ -1,6 +1,7 @@
 package org.badminton.infrastructure.match.strategy;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.badminton.domain.domain.league.entity.League;
@@ -45,20 +46,17 @@ public class TournamentSinglesMatchStrategy extends AbstractSinglesMatchStrategy
 
 		// 전체 매치 배열 생성
 		List<SinglesMatch> allMatches = new ArrayList<>();
-
-		// 현재 라운드의 참가자 리스트
-		// 참가자 리스트 섞기
-		List<LeagueParticipant> currentParticipants = tournamentSinglesBracketCreator.getLeagueParticipants(
-			leagueParticipantList);
+		
+		Collections.shuffle(leagueParticipantList);
 
 		// 전체 라운드의 수 계산
 		// leagueEntity 에 전체 라운드 수 저장
-		int totalRounds = tournamentSinglesBracketCreator.getTotalRounds(league, currentParticipants);
+		int totalRounds = tournamentSinglesBracketCreator.getTotalRounds(league, leagueParticipantList);
 
 		// 전체 매치 배열에 첫번재 라운드 생성 후 넣기
 		// 전체 매치 배열에 첫번째 라운드 제외 모든 라운드 매치 생성 후 넣기
 		// 전체 매치 스트림 -> 부전승이고, leagueParticipant1 이 null 이 아닌 매치들 대상으로 -> leagueParticipant1 다음 라운드의 매치로 이동
-		tournamentSinglesBracketCreator.generateAllMatches(league, allMatches, currentParticipants, totalRounds);
+		tournamentSinglesBracketCreator.generateAllMatches(league, allMatches, leagueParticipantList, totalRounds);
 
 		return BracketInfo.fromSingles(totalRounds, allMatches);
 	}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/TournamentSinglesMatchStrategy.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/TournamentSinglesMatchStrategy.java
@@ -1,21 +1,8 @@
 package org.badminton.infrastructure.match.strategy;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
-import org.badminton.domain.common.enums.MatchResult;
-import org.badminton.domain.common.enums.MatchStatus;
-import org.badminton.domain.common.enums.MatchType;
-import org.badminton.domain.common.enums.SetStatus;
-import org.badminton.domain.common.exception.match.AlreadyWinnerDeterminedException;
-import org.badminton.domain.common.exception.match.LeagueParticipantNotDeterminedException;
-import org.badminton.domain.common.exception.match.PreviousDetNotFinishedException;
-import org.badminton.domain.common.exception.match.RegisterScoreInByeMatchException;
-import org.badminton.domain.common.exception.match.RoundNotFinishedException;
-import org.badminton.domain.common.exception.match.SetFinishedException;
-import org.badminton.domain.domain.league.LeagueParticipantReader;
-import org.badminton.domain.domain.league.LeagueReader;
 import org.badminton.domain.domain.league.entity.League;
 import org.badminton.domain.domain.league.entity.LeagueParticipant;
 import org.badminton.domain.domain.match.command.MatchCommand;
@@ -26,6 +13,8 @@ import org.badminton.domain.domain.match.info.SetInfo;
 import org.badminton.domain.domain.match.reader.SinglesMatchStore;
 import org.badminton.domain.domain.match.service.AbstractSinglesMatchStrategy;
 import org.badminton.domain.domain.match.store.SinglesMatchReader;
+import org.badminton.infrastructure.match.service.TournamentSinglesBracketCreator;
+import org.badminton.infrastructure.match.service.TournamentSinglesEndSetHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,153 +24,66 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class TournamentSinglesMatchStrategy extends AbstractSinglesMatchStrategy {
 
-	public static final int SET_COUNT = 3;
-	public static final int PARTICIPANTS_PER_MATCH = 2;
-	static final Integer LIMIT_SET_GAME = 3;
-	private final SinglesMatchStore singlesMatchStore;
-	private final LeagueParticipantReader leagueParticipantReader;
 	private final SinglesMatchReader singlesMatchReader;
-	private final LeagueReader leagueReader;
+	private final SinglesMatchStore singlesMatchStore;
+	private final TournamentSinglesBracketCreator tournamentSinglesBracketCreator;
+	private final TournamentSinglesEndSetHandler tournamentSinglesEndSetHandler;
 
 	public TournamentSinglesMatchStrategy(SinglesMatchReader singlesMatchReader, SinglesMatchStore singlesMatchStore,
-		LeagueParticipantReader leagueParticipantReader, LeagueReader leagueReader) {
+		TournamentSinglesBracketCreator tournamentSinglesBracketCreator,
+		TournamentSinglesEndSetHandler tournamentSinglesEndSetHandler) {
 		super(singlesMatchReader, singlesMatchStore);
 		this.singlesMatchReader = singlesMatchReader;
 		this.singlesMatchStore = singlesMatchStore;
-		this.leagueParticipantReader = leagueParticipantReader;
-		this.leagueReader = leagueReader;
+		this.tournamentSinglesBracketCreator = tournamentSinglesBracketCreator;
+		this.tournamentSinglesEndSetHandler = tournamentSinglesEndSetHandler;
 	}
 
-	private static boolean isMatchWinnerDetermined(SinglesMatch singlesMatch) {
-		return singlesMatch.getPlayer1MatchResult() == MatchResult.WIN
-			|| singlesMatch.getPlayer2MatchResult() == MatchResult.WIN;
-	}
-
-	private static boolean isParticipantOddSize(List<LeagueParticipant> participants) {
-		return participants.size() % 2 != 0;
-	}
-
-	private static boolean isSinglesMatchOddSize(List<SinglesMatch> singlesMatches) {
-		return singlesMatches.size() % 2 != 0;
-	}
-
+	// 대진표 생성
 	@Override
 	public BracketInfo makeBracket(League league, List<LeagueParticipant> leagueParticipantList) {
+
+		// 전체 매치 배열 생성
 		List<SinglesMatch> allMatches = new ArrayList<>();
 
-		List<LeagueParticipant> currentParticipants = new ArrayList<>(leagueParticipantList);
-		Collections.shuffle(currentParticipants);
-		int totalRounds = MatchUtils.calculateTotalRounds(currentParticipants.size());
-		league.defineTotalRounds(totalRounds);
+		// 현재 라운드의 참가자 리스트
+		// 참가자 리스트 섞기
+		List<LeagueParticipant> currentParticipants = tournamentSinglesBracketCreator.getLeagueParticipants(
+			leagueParticipantList);
 
-		allMatches.addAll(createFirstRoundMatches(league, currentParticipants));
-		allMatches.addAll(createSubsequentRoundsMatches(league, totalRounds));
+		// 전체 라운드의 수 계산
+		// leagueEntity 에 전체 라운드 수 저장
+		int totalRounds = tournamentSinglesBracketCreator.getTotalRounds(league, currentParticipants);
 
-		allMatches.stream()
-			.filter(singlesMatch -> singlesMatch.getMatchStatus() == MatchStatus.BYE
-				&& singlesMatch.getLeagueParticipant1() != null)
-			.forEach(this::updateNextRoundMatch);
+		// 전체 매치 배열에 첫번재 라운드 생성 후 넣기
+		// 전체 매치 배열에 첫번째 라운드 제외 모든 라운드 매치 생성 후 넣기
+		// 전체 매치 스트림 -> 부전승이고, leagueParticipant1 이 null 이 아닌 매치들 대상으로 -> leagueParticipant1 다음 라운드의 매치로 이동
+		tournamentSinglesBracketCreator.generateAllMatches(league, allMatches, currentParticipants, totalRounds);
 
 		return BracketInfo.fromSingles(totalRounds, allMatches);
 	}
 
+	// 세트 종료 및 점수 저장
 	@Override
 	@Transactional
-	public SetInfo.Main registerSetScoreInMatch(Long matchId, Integer setNumber,
+	public SetInfo.Main endSet(Long matchId, Integer setNumber,
 		MatchCommand.UpdateSetScore updateSetScoreCommand) {
+
 		SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
 
-		validatePreviousSetCompletion(setNumber, singlesMatch);
+		// endSet 해도 되는지 검증
+		tournamentSinglesEndSetHandler.isEndSetAllowed(singlesMatch, setNumber, matchId);
 
-		validatePreviousRoundCompletion(singlesMatch.getLeague().getLeagueId(), singlesMatch.getRoundNumber());
+		// 세트 종료 로직
+		tournamentSinglesEndSetHandler.processEndSet(singlesMatch, setNumber, updateSetScoreCommand);
 
-		if (singlesMatch.getMatchStatus() == MatchStatus.BYE) {
-			throw new RegisterScoreInByeMatchException(singlesMatch.getId(), MatchType.SINGLES);
-		}
-
-		if (isMatchWinnerDetermined(singlesMatch)) {
-			throw new AlreadyWinnerDeterminedException(singlesMatch.getId());
-		}
-
-		if (singlesMatch.getSinglesSet(setNumber).getSetStatus() == SetStatus.FINISHED) {
-			throw new SetFinishedException(setNumber);
-		}
-
-		if (singlesMatch.getLeagueParticipant1() == null || singlesMatch.getLeagueParticipant2() == null) {
-			throw new LeagueParticipantNotDeterminedException(matchId);
-		}
-
-		updateSetScore(singlesMatch, setNumber, updateSetScoreCommand);
-
-		if (LIMIT_SET_GAME > setNumber) {
-			changeNextSetStatus(singlesMatch, setNumber);
-		}
-
-		if (isMatchWinnerDetermined(singlesMatch)) {
-			processMatchAndNextRound(singlesMatch);
-		}
-
-		if (isAllMatchFinished(singlesMatch)) {
-			leagueReader.readLeagueById(singlesMatch.getLeague().getLeagueId()).finishLeague();
-		}
+		// 변경한 부분 singlesMatchStore 로 저장
 		singlesMatchStore.store(singlesMatch);
+
 		return SetInfo.fromSinglesSet(matchId, setNumber, singlesMatch.getSinglesSets().get(setNumber - 1));
 	}
 
-	private void validatePreviousRoundCompletion(Long leagueId, int roundNumber) {
-
-		if (roundNumber == 1) {
-			return;
-		}
-
-		if (!singlesMatchReader.allRoundMatchesDone(leagueId, roundNumber - 1)) {
-			throw new RoundNotFinishedException(roundNumber - 1);
-		}
-	}
-
-	private void validatePreviousSetCompletion(int setNumber, SinglesMatch singlesMatch) {
-
-		if (setNumber == 1) {
-			return;
-		}
-		if (singlesMatch.getSinglesSet(setNumber - 1).getSetStatus() != SetStatus.FINISHED) {
-			throw new PreviousDetNotFinishedException(setNumber - 1);
-		}
-	}
-
-	private void processMatchAndNextRound(SinglesMatch singlesMatch) {
-		singlesMatchStore.store(singlesMatch);
-		updateNextRoundMatch(singlesMatch);
-		boolean allRoundMatchesDone = singlesMatchReader.allRoundMatchesDone(singlesMatch.getLeague().getLeagueId(),
-			singlesMatch.getRoundNumber());
-		boolean currentRoundInTotalRound =
-			singlesMatch.getRoundNumber() < singlesMatch.getLeague().getTotalRounds();
-
-		if (allRoundMatchesDone && currentRoundInTotalRound) {
-			List<SinglesMatch> nextRoundMatches = singlesMatchReader.findMatchesByLeagueAndRound(
-				singlesMatch.getLeague().getLeagueId(), singlesMatch.getRoundNumber() + 1
-			);
-			nextRoundMatches.stream()
-				.filter(match -> match.getMatchStatus() == MatchStatus.BYE)
-				.forEach(this::updateNextRoundMatch);
-		}
-	}
-
-	private void changeNextSetStatus(SinglesMatch singlesMatch, Integer setNumber) {
-		setNumber++;
-		if (singlesMatch.getPlayer1MatchResult().equals(MatchResult.NONE)) {
-			singlesMatch.getSinglesSet(setNumber).open();
-		}
-		if (!singlesMatch.getPlayer1MatchResult().equals(MatchResult.NONE)) {
-			singlesMatch.getSinglesSet(setNumber).close();
-		}
-	}
-
-	private boolean isAllMatchFinished(SinglesMatch singlesMatch) {
-		return singlesMatchReader.allMatchesFinishedForLeague(
-			singlesMatch.getLeague().getLeagueId());
-	}
-
+	// 세트 조회
 	@Override
 	public SetInfo.Main retrieveSet(Long matchId, int setNumber) {
 		SinglesMatch singlesMatch = singlesMatchReader.getSinglesMatch(matchId);
@@ -189,153 +91,4 @@ public class TournamentSinglesMatchStrategy extends AbstractSinglesMatchStrategy
 		return SetInfo.fromSinglesSet(matchId, setNumber, singlesSet);
 	}
 
-	private List<SinglesMatch> createFirstRoundMatches(League league, List<LeagueParticipant> participants) {
-		List<SinglesMatch> matches = new ArrayList<>();
-
-		for (int i = 0; i < participants.size() - 1; i += PARTICIPANTS_PER_MATCH) {
-			SinglesMatch match = new SinglesMatch(league, participants.get(i), participants.get(i + 1), 1);
-			makeSetsInMatch(match);
-			singlesMatchStore.store(match);
-			matches.add(match);
-		}
-
-		if (isParticipantOddSize(participants)) {
-			LeagueParticipant byeParticipant = participants.remove(participants.size() - 1);
-			SinglesMatch byeMatch = new SinglesMatch(league, byeParticipant, null, 1);
-			byeMatch.byeMatch();
-			singlesMatchStore.store(byeMatch);
-			matches.add(byeMatch);
-		}
-
-		return matches;
-	}
-
-	private void makeSetsInMatch(SinglesMatch singlesMatch) {
-		for (int i = 1; i <= SET_COUNT; i++) {
-			SinglesSet set = new SinglesSet(singlesMatch, i);
-			singlesMatch.addSet(set);
-		}
-		singlesMatchStore.store(singlesMatch);
-	}
-
-	private List<SinglesMatch> createSubsequentRoundsMatches(League league, int totalRounds) {
-		List<SinglesMatch> matches = new ArrayList<>();
-		List<SinglesMatch> previousRoundMatches = singlesMatchReader.findMatchesByLeagueAndRound(league.getLeagueId(),
-			1);
-
-		for (int roundNumber = 2; roundNumber <= totalRounds; roundNumber++) {
-			List<SinglesMatch> currentRoundMatches = createMatchesRound(league, previousRoundMatches, roundNumber);
-			matches.addAll(currentRoundMatches);
-			previousRoundMatches = currentRoundMatches;
-		}
-
-		return matches;
-	}
-
-	private List<SinglesMatch> createMatchesRound(League league, List<SinglesMatch> previousRoundMatches,
-		int roundNumber) {
-		List<SinglesMatch> currentRoundMatches = new ArrayList<>();
-
-		currentRoundMatches.addAll(createRegularMatchesForRound(league, previousRoundMatches, roundNumber));
-
-		if (isSinglesMatchOddSize(previousRoundMatches)) {
-			currentRoundMatches.add(createByeRoundMatch(league, previousRoundMatches, roundNumber));
-		}
-
-		return currentRoundMatches;
-	}
-
-	private List<SinglesMatch> createRegularMatchesForRound(League league, List<SinglesMatch> previousRoundMatches,
-		int roundNumber) {
-		List<SinglesMatch> regularRoundMatches = new ArrayList<>();
-
-		for (int i = 0; i < previousRoundMatches.size() - 1; i += PARTICIPANTS_PER_MATCH) {
-			SinglesMatch match = new SinglesMatch(league, null, null, roundNumber);
-			makeSetsInMatch(match);
-			singlesMatchStore.store(match);
-			regularRoundMatches.add(match);
-		}
-
-		return regularRoundMatches;
-	}
-
-	private SinglesMatch createByeRoundMatch(League league, List<SinglesMatch> previousRoundMatches,
-		int roundNumber) {
-		SinglesMatch byeMatch = previousRoundMatches.get(previousRoundMatches.size() - 1);
-		LeagueParticipant winner = determineWinner(byeMatch);
-
-		SinglesMatch nextByeMatch = new SinglesMatch(league, winner, null, roundNumber);
-		nextByeMatch.byeMatch();
-		singlesMatchStore.store(nextByeMatch);
-
-		return nextByeMatch;
-	}
-
-	private void updateSetScore(SinglesMatch singlesMatch, int setNumber,
-		MatchCommand.UpdateSetScore updateSetScoreCommand) {
-		SinglesSet set = singlesMatch.getSinglesSet(setNumber);
-		set.endSetScore(updateSetScoreCommand.getScore1(), updateSetScoreCommand.getScore2());
-
-		if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
-			singlesMatch.player1WinSet();
-		} else {
-			singlesMatch.player2WinSet();
-		}
-	}
-
-	private void updateNextRoundMatch(SinglesMatch singlesMatch) {
-		LeagueParticipant winner = determineWinner(singlesMatch);
-		if (winner == null) {
-			return;
-		}
-		int totalRounds = singlesMatch.getLeague().getTotalRounds();
-		if (singlesMatch.getRoundNumber() == totalRounds) {
-			return;
-		}
-		SinglesMatch startMatch = singlesMatchReader.findFirstMatchByLeagueId(
-			singlesMatch.getLeague().getLeagueId()
-		);
-		int nextRoundMatchId = MatchUtils.calculateNextRoundMatchId(
-			Math.toIntExact(singlesMatch.getId()),
-			leagueParticipantReader.countParticipantMember(singlesMatch.getLeague().getLeagueId()),
-			Math.toIntExact(startMatch.getId())
-		);
-		SinglesMatch nextRoundMatch = singlesMatchReader.getSinglesMatch((long)nextRoundMatchId);
-
-		if (nextRoundMatch == null) {
-			return;
-		}
-
-		if (singlesMatch.getMatchStatus() == MatchStatus.BYE) {
-			nextRoundMatch.defineLeagueParticipant1(winner);
-			singlesMatchStore.store(nextRoundMatch);
-			return;
-		}
-
-		assignWinnerToNextRoundMatch(nextRoundMatch, winner);
-		singlesMatchStore.store(nextRoundMatch);
-	}
-
-	private void assignWinnerToNextRoundMatch(SinglesMatch nextRoundMatch, LeagueParticipant winner) {
-		if (nextRoundMatch.getLeagueParticipant1() == null) {
-			nextRoundMatch.defineLeagueParticipant1(winner);
-			return;
-		}
-		if (nextRoundMatch.getLeagueParticipant2() == null) {
-			nextRoundMatch.defineLeagueParticipant2(winner);
-		}
-	}
-
-	private LeagueParticipant determineWinner(SinglesMatch match) {
-		if (match.getMatchStatus() == MatchStatus.BYE) {
-			return match.getLeagueParticipant1();
-		}
-		if (match.getPlayer1MatchResult() == MatchResult.WIN) {
-			return match.getLeagueParticipant1();
-		}
-		if (match.getPlayer2MatchResult() == MatchResult.WIN) {
-			return match.getLeagueParticipant2();
-		}
-		return null;
-	}
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍
- TournamentSinglesMatchStrategy, TournamentDoublesMatchStrategy, MatchUtils 리팩토링 PR 입니다.

## 변경된 사항 📝

- registerSetScoreInMatch -> endSet 으로 메서드명 변경
- Constants 클래스에 상수 추가
- DoublesMatch, SinglesMatch 에 determineWinner, isTeamExist 메서드 추가
- LeagueParticipant, Team 클래스에 emptyParticipant 정적 팩토리 메서드 추가
- TournamentSinglesMatchStrategy, DoublesMatchStrategy 의 대진표 생성 메서드, 세트 종료 메서드를 각각 TournamentBracketCreator 클래스와 TournamentDoublesEndSetHandler 로 분리
- MatchUtils 클래스에 updateMatchNextRoundMatch 메서드, assignWinnerToNextRound  추가

## PR에서 중점적으로 확인되어야 하는 사항

`MatchUtils` 클래스에 TournamentSingles 와 TournamentDoubles 사이에서 로직은 유사하지만 매개변수가 다른 메서드가 여러 개 존재합니다. 12/6에 제네릭을 사용해서 해결해보려고 했지만 스프링 애플리케이션이 실행 시 TournamnetSinglesReader 와 TournamentDoublesReader 중 어떤 빈을 주입 시켜야 할 지 명시적으로 표현하지 않으면 실행이 되지 않아 해결하지 못한 상태입니다.
좋은 생각 있으시면 말씀해주세요! 😄 

