### PR TITLE
feat : 경기 전체 조회 엔드포인트 추가

### DIFF
--- a/api/src/main/java/org/badminton/api/application/league/LeagueFacade.java
+++ b/api/src/main/java/org/badminton/api/application/league/LeagueFacade.java
@@ -1,5 +1,6 @@
 package org.badminton.api.application.league;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -8,6 +9,8 @@ import org.badminton.domain.domain.league.LeagueParticipantService;
 import org.badminton.domain.domain.league.LeagueService;
 import org.badminton.domain.domain.league.command.LeagueCreateNoIncludeClubCommand;
 import org.badminton.domain.domain.league.command.LeagueUpdateCommand;
+import org.badminton.domain.domain.league.enums.AllowedLeagueStatus;
+import org.badminton.domain.domain.league.enums.Region;
 import org.badminton.domain.domain.league.info.IsLeagueParticipantInfo;
 import org.badminton.domain.domain.league.info.LeagueByDateInfo;
 import org.badminton.domain.domain.league.info.LeagueByDateInfoWithParticipantCountInfo;
@@ -16,13 +19,17 @@ import org.badminton.domain.domain.league.info.LeagueCreateInfo;
 import org.badminton.domain.domain.league.info.LeagueDetailsInfo;
 import org.badminton.domain.domain.league.info.LeagueParticipantDetailsInfo;
 import org.badminton.domain.domain.league.info.LeagueReadInfo;
+import org.badminton.domain.domain.league.info.LeagueReadPageInfo;
 import org.badminton.domain.domain.league.info.LeagueRecruitingCompleteInfo;
 import org.badminton.domain.domain.league.info.LeagueSummaryInfo;
 import org.badminton.domain.domain.league.info.LeagueUpdateInfo;
 import org.badminton.domain.domain.league.info.LeagueUpdateInfoWithParticipantCountInfo;
+import org.badminton.domain.domain.league.info.OngoingAndUpcomingLeagueInfo;
 import org.badminton.domain.domain.match.service.MatchRetrieveService;
 import org.badminton.domain.domain.match.service.MatchStrategy;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import lombok.extern.slf4j.Slf4j;
@@ -96,5 +103,14 @@ public class LeagueFacade {
 	public LeagueRecruitingCompleteInfo completeLeagueRecruiting(String clubToken, Long leagueId, String memberToken) {
 		clubMemberPolicy.validateClubMember(memberToken, clubToken);
 		return leagueService.completeLeagueRecruiting(clubToken, leagueId, memberToken);
+	}
+
+	public Page<OngoingAndUpcomingLeagueInfo> getOngoingAndUpcomingLeaguesByDate(AllowedLeagueStatus leagueStatus,
+		Region region, LocalDate date, Pageable pageable) {
+		return leagueService.getOngoingAndUpcomingLeaguesByDate(leagueStatus, region, date, pageable);
+	}
+
+	public List<LeagueReadPageInfo> getLeaguePageList(Pageable pageable) {
+		return leagueService.getLeaguePageable(pageable);
 	}
 }

--- a/api/src/main/java/org/badminton/api/interfaces/league/controller/MainLeagueController.java
+++ b/api/src/main/java/org/badminton/api/interfaces/league/controller/MainLeagueController.java
@@ -3,15 +3,16 @@ package org.badminton.api.interfaces.league.controller;
 import java.time.LocalDate;
 import java.util.List;
 
+import org.badminton.api.application.league.LeagueFacade;
 import org.badminton.api.application.match.MatchFacade;
 import org.badminton.api.common.response.CommonResponse;
 import org.badminton.api.interfaces.club.dto.CustomPageResponse;
 import org.badminton.api.interfaces.league.dto.OngoingAndUpcomingLeagueResponse;
 import org.badminton.api.interfaces.match.dto.LeagueSetsScoreInProgressResponse;
 import org.badminton.api.interfaces.match.dto.SetScoreResponse;
-import org.badminton.domain.domain.league.LeagueService;
 import org.badminton.domain.domain.league.enums.AllowedLeagueStatus;
 import org.badminton.domain.domain.league.enums.Region;
+import org.badminton.domain.domain.league.info.LeagueReadPageInfo;
 import org.badminton.domain.domain.league.info.OngoingAndUpcomingLeagueInfo;
 import org.badminton.domain.domain.match.info.LeagueSetsScoreInProgressInfo;
 import org.badminton.domain.domain.match.info.SetInfo;
@@ -33,10 +34,11 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/v1/leagues")
 public class MainLeagueController {
+
 	private static final String DEFAULT_PAGE_VALUE = "0";
 	private static final String DEFAULT_SIZE_VALUE = "9";
-	private final LeagueService leagueService;
 	private final MatchFacade matchFacade;
+	private final LeagueFacade leagueFacade;
 
 	@Operation(
 		summary = "메인페이지에서 일별로 진행 중, 또는 진행 예정인 경기 일정을 조회한다.",
@@ -54,7 +56,7 @@ public class MainLeagueController {
 	) {
 
 		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "leagueAt"));
-		Page<OngoingAndUpcomingLeagueInfo> leaguePage = leagueService.getOngoingAndUpcomingLeaguesByDate(
+		Page<OngoingAndUpcomingLeagueInfo> leaguePage = leagueFacade.getOngoingAndUpcomingLeaguesByDate(
 			leagueStatus, region, date, pageable);
 
 		Page<OngoingAndUpcomingLeagueResponse> response = leaguePage.map(OngoingAndUpcomingLeagueResponse::from);
@@ -94,5 +96,19 @@ public class MainLeagueController {
 	) {
 		SetInfo.Main setInfo = matchFacade.retrieveSetInfo(leagueId, matchId, setNumber);
 		return CommonResponse.success(SetScoreResponse.fromSetInfo(setInfo));
+	}
+
+	@Operation(
+		summary = "경기 전체에 대한 정보를 가져옵니다.",
+		description = "경기 전체에 대한 정보를 페이지네이션으로 가져옵니다.",
+		tags = {"main-league"}
+	)
+	@GetMapping("all")
+	public CommonResponse<List<LeagueReadPageInfo>> getAllLeague(
+		@RequestParam(defaultValue = DEFAULT_PAGE_VALUE) int page,
+		@RequestParam(defaultValue = DEFAULT_SIZE_VALUE) int size
+	) {
+		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "leagueAt"));
+		return CommonResponse.success(leagueFacade.getLeaguePageList(pageable));
 	}
 }

--- a/api/src/main/java/org/badminton/api/interfaces/league/controller/MainLeagueController.java
+++ b/api/src/main/java/org/badminton/api/interfaces/league/controller/MainLeagueController.java
@@ -103,7 +103,7 @@ public class MainLeagueController {
 		description = "경기 전체에 대한 정보를 페이지네이션으로 가져옵니다.",
 		tags = {"main-league"}
 	)
-	@GetMapping("all")
+	@GetMapping("/all")
 	public CommonResponse<List<LeagueReadPageInfo>> getAllLeague(
 		@RequestParam(defaultValue = DEFAULT_PAGE_VALUE) int page,
 		@RequestParam(defaultValue = DEFAULT_SIZE_VALUE) int size

--- a/domain/src/main/java/org/badminton/domain/domain/league/LeagueReader.java
+++ b/domain/src/main/java/org/badminton/domain/domain/league/LeagueReader.java
@@ -51,4 +51,6 @@ public interface LeagueReader {
 	MatchGenerationType getMatchGenerationTypeByLeagueId(Long leagueId);
 
 	void checkLeagueExistIn3Hours(String memberToken, LocalDateTime leagueAt);
+
+	Page<League> readLeagueByPageable(Pageable pageable);
 }

--- a/domain/src/main/java/org/badminton/domain/domain/league/LeagueService.java
+++ b/domain/src/main/java/org/badminton/domain/domain/league/LeagueService.java
@@ -12,6 +12,7 @@ import org.badminton.domain.domain.league.info.LeagueCancelInfo;
 import org.badminton.domain.domain.league.info.LeagueCreateInfo;
 import org.badminton.domain.domain.league.info.LeagueDetailInfo;
 import org.badminton.domain.domain.league.info.LeagueReadInfo;
+import org.badminton.domain.domain.league.info.LeagueReadPageInfo;
 import org.badminton.domain.domain.league.info.LeagueRecruitingCompleteInfo;
 import org.badminton.domain.domain.league.info.LeagueSummaryInfo;
 import org.badminton.domain.domain.league.info.LeagueUpdateInfo;
@@ -44,4 +45,6 @@ public interface LeagueService {
 		String memberToken);
 
 	LeagueRecruitingCompleteInfo completeLeagueRecruiting(String clubToken, Long leagueId, String memberToken);
+
+	List<LeagueReadPageInfo> getLeaguePageable(Pageable pageable);
 }

--- a/domain/src/main/java/org/badminton/domain/domain/league/LeagueServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/league/LeagueServiceImpl.java
@@ -24,6 +24,7 @@ import org.badminton.domain.domain.league.info.LeagueCancelInfo;
 import org.badminton.domain.domain.league.info.LeagueCreateInfo;
 import org.badminton.domain.domain.league.info.LeagueDetailInfo;
 import org.badminton.domain.domain.league.info.LeagueReadInfo;
+import org.badminton.domain.domain.league.info.LeagueReadPageInfo;
 import org.badminton.domain.domain.league.info.LeagueRecruitingCompleteInfo;
 import org.badminton.domain.domain.league.info.LeagueSummaryInfo;
 import org.badminton.domain.domain.league.info.LeagueUpdateInfo;
@@ -32,8 +33,8 @@ import org.badminton.domain.domain.league.vo.LeagueSearchStrategy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -60,25 +61,27 @@ public class LeagueServiceImpl implements LeagueService {
 	}
 
 	@Override
-	@Transactional
+	@Transactional(readOnly = true)
 	public LeagueSummaryInfo getLeague(String clubToken, Long leagueId) {
 		var league = leagueReader.readLeague(clubToken, leagueId);
 		return LeagueSummaryInfo.from(league);
 	}
 
 	@Override
-	@Transactional
+	@Transactional(readOnly = true)
 	public LeagueDetailInfo getLeagueDetail(String clubToken, Long leagueId) {
 		var league = leagueReader.readLeague(clubToken, leagueId);
 		return LeagueDetailInfo.from(league);
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public Integer getLeagueCountByClubId(Long clubId) {
 		return leagueReader.getCountByClubId(clubId);
 	}
 
 	@Override
+	@Transactional
 	public LeagueUpdateInfo updateLeague(String clubToken, Long leagueId, LeagueUpdateCommand leagueUpdateCommand,
 		String memberToken) {
 		League league = leagueReader.readLeague(clubToken, leagueId);
@@ -95,6 +98,7 @@ public class LeagueServiceImpl implements LeagueService {
 	}
 
 	@Override
+	@Transactional
 	public LeagueRecruitingCompleteInfo completeLeagueRecruiting(String clubToken, Long leagueId, String memberToken) {
 		League league = leagueReader.readLeague(clubToken, leagueId);
 		validateLeagueOwner(memberToken, league);
@@ -104,6 +108,14 @@ public class LeagueServiceImpl implements LeagueService {
 	}
 
 	@Override
+	@Transactional(readOnly = true)
+	public List<LeagueReadPageInfo> getLeaguePageable(Pageable pageable) {
+		Page<League> leagues = leagueReader.readLeagueByPageable(pageable);
+		return leagues.stream().map(LeagueReadPageInfo::from).toList();
+	}
+
+	@Override
+	@Transactional(readOnly = true)
 	public List<LeagueReadInfo> getLeaguesByMonth(String clubToken, String date) {
 		LocalDate parsedDate = parseDateByMonth(date);
 		LocalDateTime startOfMonth = getStartOfMonth(parsedDate);
@@ -111,12 +123,13 @@ public class LeagueServiceImpl implements LeagueService {
 		List<League> result =
 			leagueReader.readLeagueByMonth(clubToken, startOfMonth, endOfMonth);
 		return result.stream()
-			.map(LeagueReadInfo::leagueReadEntityToInfo)
+			.map(LeagueReadInfo::from)
 			.collect(
 				Collectors.toList());
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public List<LeagueByDateInfo> getLeaguesByDate(String clubToken, String date) {
 		LocalDate parsedDate = parseDate(date);
 		LocalDateTime startOfDay = getStartOfDay(parsedDate);
@@ -130,6 +143,7 @@ public class LeagueServiceImpl implements LeagueService {
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public Page<OngoingAndUpcomingLeagueInfo> getOngoingAndUpcomingLeaguesByDate(
 		AllowedLeagueStatus leagueStatus,
 		Region region,
@@ -145,6 +159,7 @@ public class LeagueServiceImpl implements LeagueService {
 	}
 
 	@Override
+	@Transactional
 	public LeagueCancelInfo cancelLeague(String clubToken, Long leagueId, String memberToken) {
 		var league = leagueReader.readLeague(clubToken, leagueId);
 		validateLeagueOwner(memberToken, league);

--- a/domain/src/main/java/org/badminton/domain/domain/league/info/LeagueReadInfo.java
+++ b/domain/src/main/java/org/badminton/domain/domain/league/info/LeagueReadInfo.java
@@ -26,7 +26,7 @@ public record LeagueReadInfo(
 		);
 	}
 
-	public static LeagueReadInfo leagueReadEntityToInfo(League entity) {
+	public static LeagueReadInfo from(League entity) {
 		return new LeagueReadInfo(entity);
 	}
 }

--- a/domain/src/main/java/org/badminton/domain/domain/league/info/LeagueReadPageInfo.java
+++ b/domain/src/main/java/org/badminton/domain/domain/league/info/LeagueReadPageInfo.java
@@ -1,0 +1,47 @@
+package org.badminton.domain.domain.league.info;
+
+import java.time.LocalDateTime;
+
+import org.badminton.domain.domain.league.entity.League;
+import org.badminton.domain.domain.league.enums.LeagueStatus;
+
+public record LeagueReadPageInfo(
+
+	Long leagueId,
+
+	String leagueName,
+
+	String description,
+
+	LeagueStatus status,
+
+	LocalDateTime leagueAt,
+
+	String location,
+
+	LocalDateTime modifiedAt,
+
+	String clubName,
+
+	String clubDescription
+
+) {
+	public LeagueReadPageInfo(League league) {
+		this(
+			league.getLeagueId(),
+			league.getLeagueName(),
+			league.getDescription(),
+			league.getLeagueStatus(),
+			league.getLeagueAt(),
+			league.getAddress().getFullAddress(),
+			league.getModifiedAt(),
+			league.getClub().getClubName(),
+			league.getClub().getClubDescription()
+		);
+	}
+
+	public static LeagueReadPageInfo from(League league) {
+		return new LeagueReadPageInfo(league);
+	}
+
+}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/league/LeagueReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/league/LeagueReaderImpl.java
@@ -80,6 +80,11 @@ public class LeagueReaderImpl implements LeagueReader {
 	}
 
 	@Override
+	public Page<League> readLeagueByPageable(Pageable pageable) {
+		return leagueRepository.findAllByLeagueStatusNot(LeagueStatus.CANCELED, pageable);
+	}
+
+	@Override
 	public Page<League> readLeagueStatusIsNotAllAndRegionIsNotAll(AllowedLeagueStatus leagueStatus, Region region,
 		LocalDate date, Pageable pageable) {
 		LocalDateTime startOfDay = date.atStartOfDay();

--- a/infrastructure/src/main/java/org/badminton/infrastructure/league/LeagueRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/league/LeagueRepository.java
@@ -69,4 +69,6 @@ public interface LeagueRepository extends JpaRepository<League, Long> {
 		LocalDateTime startTime,
 		LocalDateTime endTime
 	);
+
+	Page<League> findAllByLeagueStatusNot(LeagueStatus leagueStatus, Pageable pageable);
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍
- 프론트에서 요청한 추가되 엔드포인트입니다. 
- 해당 엔드포인트는 요구되는 리그의 정보와 클럽의 정보를 반환합니다. 


## 변경된 사항 📝

### After
#### 클럽과 리그 정보 반환
<img width="697" alt="스크린샷 2024-12-10 오후 12 24 56" src="https://github.com/user-attachments/assets/dcc10792-e46d-4530-a19d-352a5f1292fa">

## PR에서 중점적으로 확인되어야 하는 사항
해당 엔드 포인트 요청 시 다수의 클럽이 요청되는
 현상이 있어 로깅을 찍어보았습니다.

#### 해당 엔드포인트 요청 시 최초 쿼리 
<img width="657" alt="스크린샷 2024-12-10 오후 12 21 29" src="https://github.com/user-attachments/assets/66ca95af-6c21-4ee0-b8e1-8bafb0a0c297">

#### 이후 클럽의 정보를 가져오기 위한 쿼리
<img width="630" alt="스크린샷 2024-12-10 오후 12 21 47" src="https://github.com/user-attachments/assets/fed95442-262e-412f-a75f-3762ee88b92f">
<img width="628" alt="스크린샷 2024-12-10 오후 12 21 58" src="https://github.com/user-attachments/assets/f50670b8-2813-4011-a5c6-fefd73c20b34">
<img width="621" alt="스크린샷 2024-12-10 오후 12 22 15" src="https://github.com/user-attachments/assets/17b292ab-15e8-4d37-b768-f8a1bc4041a8">
<img width="621" alt="스크린샷 2024-12-10 오후 12 22 25" src="https://github.com/user-attachments/assets/123502f0-0746-4c07-8347-7ff026ef8218">

위에서 보듯 해당 리그를 조회하는 과정에서 **조회되는** 리그의 클럽에 대해 쿼리를 보내는 모습니다. 
<img width="692" alt="스크린샷 2024-12-10 오후 12 22 40" src="https://github.com/user-attachments/assets/8d8f9548-e5c2-4172-960a-d9d5dd99cef7">

위의 정보에서 보여 주듯이 1, 2, 3, 31 의 클럽이 조회되고 있는 리그를 생성한 클럽이기때문에 쿼리를 보내는 모습입니다. 

문제 없이 쿼리를 요청하는 것 처럼 보이지만 만약 조회하고 있는 리그에 소속되어 있는 클럽의 갯수가 많아지면 기하급수적으로 쿼리를 보내는 양이 많아집니다. 

이 문제를 해결할 수 있는 방법이 있을까요?









