### PR TITLE
bug : isParticipantBanned 에서 오류 발생 해결

### DIFF
--- a/domain/src/main/java/org/badminton/domain/domain/match/info/MatchTeamInfo.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/info/MatchTeamInfo.java
@@ -38,29 +38,30 @@ public record MatchTeamInfo(
 	}
 
 	private static Member.MemberTier getParticipantMemberTier(LeagueParticipant participant) {
-		if (isLeagueParticipantExist(participant))
+		if (isLeagueParticipantExist(participant)) {
 			return participant.getMember().getTier();
-
+		}
 		return null;
 	}
 
 	private static String getParticipantMemberToken(LeagueParticipant participant) {
-		if (isLeagueParticipantExist(participant))
+		if (isLeagueParticipantExist(participant)) {
 			return participant.getMember().getMemberToken();
-
+		}
 		return null;
 	}
 
 	private static String getParticipantName(LeagueParticipant participant) {
-		if (isLeagueParticipantExist(participant))
+		if (isLeagueParticipantExist(participant)) {
 			return participant.getMember().getName();
-
+		}
 		return null;
 	}
 
 	private static String getParticipantImage(LeagueParticipant participant) {
-		if (isLeagueParticipantExist(participant))
+		if (isLeagueParticipantExist(participant)) {
 			return participant.getMember().getProfileImage();
+		}
 		return null;
 	}
 
@@ -69,7 +70,9 @@ public record MatchTeamInfo(
 	}
 
 	private static boolean getIsParticipant(LeagueParticipant participant) {
-		return participant.getClubMember().isBanned();
+		return (participant != null && participant.getMember() != null)
+			? participant.getClubMember().isBanned()
+			: false;
 	}
 
 }

--- a/domain/src/main/java/org/badminton/domain/domain/match/info/SinglesMatchInfo.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/info/SinglesMatchInfo.java
@@ -46,8 +46,10 @@ public record SinglesMatchInfo(
 		);
 	}
 
-	private static boolean isParticipantBanned(LeagueParticipant leagueParticipant) {
-		return leagueParticipant.getClubMember().isBanned();
+	private static boolean isParticipantBanned(LeagueParticipant participant) {
+		return (participant != null && participant.getMember() != null)
+			? participant.getClubMember().isBanned()
+			: false;
 	}
 
 	private static Member.MemberTier getParticipantMemberTier(LeagueParticipant participant) {


### PR DESCRIPTION
## PR에 대한 설명 🔍
<img width="698" alt="image" src="https://github.com/user-attachments/assets/22dc9e0d-eb92-44f1-892d-e37e33ca3680">


## 변경된 사항 📝

### Before
위와 같이 사용자가 null 일 경우 nullpointException 이 발생하였습니다. 

### After
명시적 null 리턴으로 인하여 에러가 발생하는데 null 체크해서 임시적으로 해결하였습니다.

```java

	private static boolean isParticipantBanned(LeagueParticipant participant) {
		return (participant != null && participant.getMember() != null)
			? participant.getClubMember().isBanned()
			: false;
	}

```

null 체크로 Null 예외처리를 임시로 막은 겁니다. 
추후 명시적 null 리턴과 null을 반환할 것 같은 코드를 없애야 하겠습니다.

## PR에서 중점적으로 확인되어야 하는 사항
