### PR TITLE
refactor: redis 사용해 api 응답 속도 최적화

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -20,11 +20,6 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     testImplementation 'org.springframework.security:spring-security-test'
 
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    implementation 'com.fasterxml.jackson.core:jackson-databind'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
-    implementation 'com.fasterxml.jackson.module:jackson-module-parameter-names'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
 
 }
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -20,6 +20,12 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'com.fasterxml.jackson.module:jackson-module-parameter-names'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
+
 }
 
 test {

--- a/api/src/main/java/org/badminton/api/application/club/ClubRankFacade.java
+++ b/api/src/main/java/org/badminton/api/application/club/ClubRankFacade.java
@@ -1,13 +1,19 @@
 package org.badminton.api.application.club;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.badminton.domain.domain.club.ClubService;
 import org.badminton.domain.domain.club.info.ClubCardInfo;
+import org.badminton.domain.domain.club.vo.ClubRedisKey;
 import org.badminton.domain.domain.statistics.ClubStatistics;
 import org.badminton.domain.domain.statistics.ClubStatisticsService;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,17 +22,30 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class ClubRankFacade {
+	private static final String POPULAR_TOP10_REDIS_KEY = ClubRedisKey.getTop10PopularKey();
 	private final ClubService clubService;
 	private final ClubStatisticsService clubStatisticsService;
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final ObjectMapper objectMapper;
 
 	@Transactional(readOnly = true)
 	public List<ClubCardInfo> getTop10PopularClub() {
+		Object cachedClubs = redisTemplate.opsForValue().get(POPULAR_TOP10_REDIS_KEY);
+
+		if (cachedClubs != null) {
+			return objectMapper.convertValue(cachedClubs, new TypeReference<List<ClubCardInfo>>() {
+			});
+		}
+
 		List<ClubStatistics> top10PopularClubStatistics = clubStatisticsService.getTop10PopularClubStatistics();
 
-		return top10PopularClubStatistics.stream()
-			.map(clubStatistics ->
-				ClubCardInfo.from(clubStatistics.getClub()))
+		List<ClubCardInfo> top10ClubCardInfo = top10PopularClubStatistics.stream()
+			.map(clubStatistics -> ClubCardInfo.from(clubStatistics.getClub()))
 			.toList();
+
+		redisTemplate.opsForValue().set(POPULAR_TOP10_REDIS_KEY, top10ClubCardInfo, 1, TimeUnit.HOURS);
+
+		return top10ClubCardInfo;
 	}
 
 	@Transactional(readOnly = true)

--- a/api/src/main/java/org/badminton/api/application/club/ClubRankFacade.java
+++ b/api/src/main/java/org/badminton/api/application/club/ClubRankFacade.java
@@ -1,19 +1,13 @@
 package org.badminton.api.application.club;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.badminton.domain.domain.club.ClubService;
 import org.badminton.domain.domain.club.info.ClubCardInfo;
-import org.badminton.domain.domain.club.vo.ClubRedisKey;
 import org.badminton.domain.domain.statistics.ClubStatistics;
 import org.badminton.domain.domain.statistics.ClubStatisticsService;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,30 +16,13 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class ClubRankFacade {
-	private static final String POPULAR_TOP10_REDIS_KEY = ClubRedisKey.getTop10PopularKey();
 	private final ClubService clubService;
 	private final ClubStatisticsService clubStatisticsService;
-	private final RedisTemplate<String, Object> redisTemplate;
-	private final ObjectMapper objectMapper;
 
 	@Transactional(readOnly = true)
 	public List<ClubCardInfo> getTop10PopularClub() {
-		Object cachedClubs = redisTemplate.opsForValue().get(POPULAR_TOP10_REDIS_KEY);
 
-		if (cachedClubs != null) {
-			return objectMapper.convertValue(cachedClubs, new TypeReference<List<ClubCardInfo>>() {
-			});
-		}
-
-		List<ClubStatistics> top10PopularClubStatistics = clubStatisticsService.getTop10PopularClubStatistics();
-
-		List<ClubCardInfo> top10ClubCardInfo = top10PopularClubStatistics.stream()
-			.map(clubStatistics -> ClubCardInfo.from(clubStatistics.getClub()))
-			.toList();
-
-		redisTemplate.opsForValue().set(POPULAR_TOP10_REDIS_KEY, top10ClubCardInfo, 1, TimeUnit.HOURS);
-
-		return top10ClubCardInfo;
+		return clubStatisticsService.getTop10PopularClubStatistics();
 	}
 
 	@Transactional(readOnly = true)

--- a/api/src/main/java/org/badminton/api/config/redis/RedisConfig.java
+++ b/api/src/main/java/org/badminton/api/config/redis/RedisConfig.java
@@ -1,0 +1,52 @@
+package org.badminton.api.config.redis;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class RedisConfig {
+
+	@Bean
+	public ObjectMapper objectMapper() {
+
+		// JSON 직렬화, 역직렬화를 위한 설정
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		// JavaTimeModule 추가 및 ISO-8601 형식 설정
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+
+		// 필드 매핑 오류 방지
+		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+		return objectMapper;
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(
+		RedisConnectionFactory connectionFactory,
+		ObjectMapper objectMapper
+	) {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(connectionFactory);
+
+		// Value 를 JSON 으로 저장
+		GenericJackson2JsonRedisSerializer valueSerializer =
+			new GenericJackson2JsonRedisSerializer(objectMapper);
+
+		// Key 를 문자열로 저장
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(valueSerializer);
+
+		return redisTemplate;
+	}
+}

--- a/domain/src/main/java/org/badminton/domain/domain/club/vo/ClubRedisKey.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/vo/ClubRedisKey.java
@@ -1,0 +1,18 @@
+package org.badminton.domain.domain.club.vo;
+
+import lombok.Getter;
+
+@Getter
+public class ClubRedisKey {
+	private static final String NAMESPACE = "club";
+	private static final String TOP10_POPULAR = "top10:popular";
+
+	private ClubRedisKey() {
+
+	}
+
+	public static String getTop10PopularKey() {
+		return String.format("%s:%s", NAMESPACE, TOP10_POPULAR);
+	}
+
+}

--- a/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsReader.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsReader.java
@@ -2,6 +2,8 @@ package org.badminton.domain.domain.statistics;
 
 import java.util.List;
 
+import org.badminton.domain.domain.club.info.ClubCardInfo;
+
 public interface ClubStatisticsReader {
 
 	ClubStatistics readClubStatistics(String clubToken);
@@ -12,7 +14,7 @@ public interface ClubStatisticsReader {
 
 	List<ClubStatistics> findAll();
 
-	List<ClubStatistics> readTop10PopularClubStatistics();
+	List<ClubCardInfo> readTop10PopularClub();
 
 	List<ClubStatistics> readTop10RecentlyActiveClubStatistics();
 }

--- a/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsService.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsService.java
@@ -2,6 +2,7 @@ package org.badminton.domain.domain.statistics;
 
 import java.util.List;
 
+import org.badminton.domain.domain.club.info.ClubCardInfo;
 import org.badminton.domain.domain.club.info.ClubCreateInfo;
 
 public interface ClubStatisticsService {
@@ -16,7 +17,7 @@ public interface ClubStatisticsService {
 
 	void updateByCountAndClubId(Long clubId, int count);
 
-	List<ClubStatistics> getTop10PopularClubStatistics();
+	List<ClubCardInfo> getTop10PopularClubStatistics();
 
 	List<ClubStatistics> getTop10RecentlyActiveClubStatistics();
 }

--- a/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsServiceImpl.java
@@ -2,6 +2,7 @@ package org.badminton.domain.domain.statistics;
 
 import java.util.List;
 
+import org.badminton.domain.domain.club.info.ClubCardInfo;
 import org.badminton.domain.domain.club.info.ClubCreateInfo;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,8 +44,10 @@ public class ClubStatisticsServiceImpl implements ClubStatisticsService {
 	}
 
 	@Override
-	public List<ClubStatistics> getTop10PopularClubStatistics() {
-		return clubStatisticsReader.readTop10PopularClubStatistics();
+	public List<ClubCardInfo> getTop10PopularClubStatistics() {
+
+		return clubStatisticsReader.readTop10PopularClub();
+
 	}
 
 	@Override

--- a/infrastructure/build.gradle
+++ b/infrastructure/build.gradle
@@ -18,6 +18,11 @@ dependencies {
     testImplementation 'net.datafaker:datafaker:1.5.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'com.fasterxml.jackson.module:jackson-module-parameter-names'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
 }
 
 bootJar {

--- a/infrastructure/src/main/java/org/badminton/infrastructure/config/RedisConfig.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/config/RedisConfig.java
@@ -1,4 +1,4 @@
-package org.badminton.api.config.redis;
+package org.badminton.infrastructure.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsReaderImpl.java
@@ -1,11 +1,18 @@
 package org.badminton.infrastructure.statistics;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import org.badminton.domain.domain.club.info.ClubCardInfo;
+import org.badminton.domain.domain.club.vo.ClubRedisKey;
 import org.badminton.domain.domain.statistics.ClubStatistics;
 import org.badminton.domain.domain.statistics.ClubStatisticsReader;
 import org.badminton.domain.domain.statistics.ClubStatisticsRepositoryCustom;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,8 +21,11 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class ClubStatisticsReaderImpl implements ClubStatisticsReader {
+	private static final String POPULAR_TOP10_REDIS_KEY = ClubRedisKey.getTop10PopularKey();
 	private final ClubStatisticsRepository clubStatisticsRepository;
 	private final ClubStatisticsRepositoryCustom clubStatisticsRepositoryCustom;
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final ObjectMapper objectMapper;
 
 	@Override
 	public ClubStatistics readClubStatistics(String clubToken) {
@@ -38,8 +48,25 @@ public class ClubStatisticsReaderImpl implements ClubStatisticsReader {
 	}
 
 	@Override
-	public List<ClubStatistics> readTop10PopularClubStatistics() {
-		return clubStatisticsRepository.findTop10ByOrderByPopularityScoreDesc();
+	public List<ClubCardInfo> readTop10PopularClub() {
+
+		Object cachedClubs = redisTemplate.opsForValue().get(POPULAR_TOP10_REDIS_KEY);
+
+		if (cachedClubs != null) {
+			return objectMapper.convertValue(cachedClubs, new TypeReference<List<ClubCardInfo>>() {
+			});
+		}
+
+		List<ClubStatistics> top10ByOrderByPopularityScoreDesc = clubStatisticsRepository.findTop10ByOrderByPopularityScoreDesc();
+
+		List<ClubCardInfo> top10ClubCardInfo = top10ByOrderByPopularityScoreDesc.stream()
+			.map(clubStatistics -> ClubCardInfo.from(clubStatistics.getClub()))
+			.toList();
+
+		redisTemplate.opsForValue().set(POPULAR_TOP10_REDIS_KEY, top10ClubCardInfo, 1, TimeUnit.HOURS);
+
+		return top10ClubCardInfo;
+
 	}
 
 	@Override


### PR DESCRIPTION
## PR에 대한 설명 🔍

- 인기 top 10 동호회 조회 시 redis 적용

1. api 실행
2. redis 조회
3. redis에 데이터가 없다면 db 조회
4. db에서 top 10 동호회 조회 후 redis에 `TTL` 1시간으로 저장, return 
5. api 실행 시 redis에 데이터가 있으면 db 조회 X


## 변경된 사항 📝

![image](https://github.com/user-attachments/assets/dd0509da-0328-4dc9-a40d-afbf8bd72d2a)

![image](https://github.com/user-attachments/assets/1c772ce8-6ae8-47f0-85e0-07041eac8f89)


## 추후 변경사항

추후에 인기 top 10 동호회 조회 뿐만이 아니라 다른 api 에서도 redis 를 사용해 응답 속도를 최적화 할 예정입니다


