### PR TITLE
refactor: 최근 활동이 많은 top10  동호회 조회 redis 사용

### DIFF
--- a/api/src/main/java/org/badminton/api/application/club/ClubRankFacade.java
+++ b/api/src/main/java/org/badminton/api/application/club/ClubRankFacade.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.badminton.domain.domain.club.ClubService;
 import org.badminton.domain.domain.club.info.ClubCardInfo;
-import org.badminton.domain.domain.statistics.ClubStatistics;
 import org.badminton.domain.domain.statistics.ClubStatisticsService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,17 +21,13 @@ public class ClubRankFacade {
 	@Transactional(readOnly = true)
 	public List<ClubCardInfo> getTop10PopularClub() {
 
-		return clubStatisticsService.getTop10PopularClubStatistics();
+		return clubStatisticsService.getTop10PopularClub();
 	}
 
 	@Transactional(readOnly = true)
 	public List<ClubCardInfo> getTop10RecentlyActiveClub() {
-		List<ClubStatistics> top10RecentlyActiveClubStatistics = clubStatisticsService.getTop10RecentlyActiveClubStatistics();
 
-		return top10RecentlyActiveClubStatistics.stream()
-			.map(clubStatistics ->
-				ClubCardInfo.from(clubStatistics.getClub()))
-			.toList();
+		return clubStatisticsService.getTop10RecentlyActiveClub();
 	}
 
 	@Transactional(readOnly = true)

--- a/domain/src/main/java/org/badminton/domain/domain/club/vo/ClubRedisKey.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/vo/ClubRedisKey.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public class ClubRedisKey {
 	private static final String NAMESPACE = "club";
 	private static final String TOP10_POPULAR = "top10:popular";
+	private static final String TOP10_ACTIVITY = "top10:activity";
 
 	private ClubRedisKey() {
 
@@ -13,6 +14,10 @@ public class ClubRedisKey {
 
 	public static String getTop10PopularKey() {
 		return String.format("%s:%s", NAMESPACE, TOP10_POPULAR);
+	}
+
+	public static String getTop10ActivityKey() {
+		return String.format("%s:%s", NAMESPACE, TOP10_ACTIVITY);
 	}
 
 }

--- a/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsReader.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsReader.java
@@ -16,5 +16,5 @@ public interface ClubStatisticsReader {
 
 	List<ClubCardInfo> readTop10PopularClub();
 
-	List<ClubStatistics> readTop10RecentlyActiveClubStatistics();
+	List<ClubCardInfo> readTop10RecentlyActiveClub();
 }

--- a/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsService.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsService.java
@@ -17,7 +17,7 @@ public interface ClubStatisticsService {
 
 	void updateByCountAndClubId(Long clubId, int count);
 
-	List<ClubCardInfo> getTop10PopularClubStatistics();
+	List<ClubCardInfo> getTop10PopularClub();
 
-	List<ClubStatistics> getTop10RecentlyActiveClubStatistics();
+	List<ClubCardInfo> getTop10RecentlyActiveClub();
 }

--- a/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsServiceImpl.java
@@ -44,15 +44,16 @@ public class ClubStatisticsServiceImpl implements ClubStatisticsService {
 	}
 
 	@Override
-	public List<ClubCardInfo> getTop10PopularClubStatistics() {
+	public List<ClubCardInfo> getTop10PopularClub() {
 
 		return clubStatisticsReader.readTop10PopularClub();
 
 	}
 
 	@Override
-	public List<ClubStatistics> getTop10RecentlyActiveClubStatistics() {
-		return clubStatisticsReader.readTop10RecentlyActiveClubStatistics();
+	public List<ClubCardInfo> getTop10RecentlyActiveClub() {
+
+		return clubStatisticsReader.readTop10RecentlyActiveClub();
 	}
 
 	@Override


### PR DESCRIPTION
## PR에 대한 설명 🔍

- redis의 캐시를 사용해 최근 활동이 많은 top 10 동호회 응답속도 단축

## 변경된 사항 📝

<!-- 이번 PR에서의 변경점 -->

![스크린샷 2024-12-12 10 28 02](https://github.com/user-attachments/assets/16894507-052a-41a8-a52f-bd346de96a4d)

![스크린샷 2024-12-12 10 26 34](https://github.com/user-attachments/assets/cb0bfe03-47e8-4215-b7da-320811eb0557)

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF, 글 -->

### Before

### After

## PR에서 중점적으로 확인되어야 하는 사항

이와 비슷한 api로 최근 생성된 동호회 조회가 있는데 이 api는 실시간으로 반영이 되어야 하는 게 아닌가? 해서 redis를 적용하지 않았는데 실시간으로 정보가 업데이트되지 않아도 된다고 생각하시면 말씀해 주세요