### PR TITLE
hotfix: allClubs 조회 레디스 제거

### DIFF
--- a/api/src/main/java/org/badminton/api/application/club/ClubFacade.java
+++ b/api/src/main/java/org/badminton/api/application/club/ClubFacade.java
@@ -38,16 +38,10 @@ public class ClubFacade {
 	private final ClubMemberPolicy clubMemberPolicy;
 
 	@Transactional(readOnly = true)
-	public Page<ClubCardInfo> readAllClubs(int page, int size, String sort) {
-		Pageable pageable = PageRequest.of(page, size, Sort.by(sort));
+	public Page<ClubCardInfo> readAllClubs(Pageable pageable) {
 		return clubService.readAllClubs(pageable);
 	}
-
-	@Transactional(readOnly = true)
-	public Page<ClubCardInfo> getAllClubs(Pageable pageable) {
-		return clubService.getAllClubs(pageable);
-	}
-
+	
 	@Transactional
 	public ClubDetailsInfo readClub(String clubToken) {
 		var club = clubService.readClub(clubToken);

--- a/api/src/main/java/org/badminton/api/interfaces/club/controller/ClubController.java
+++ b/api/src/main/java/org/badminton/api/interfaces/club/controller/ClubController.java
@@ -142,11 +142,9 @@ public class ClubController {
 		@RequestParam(defaultValue = DEFAULT_SIZE_VALUE) int size,
 		@RequestParam(defaultValue = DEFAULT_SORT_BY_VALUE) String sort) {
 		Pageable pageable = PageRequest.of(page, size, Sort.by(sort));
-
-		Page<ClubCardInfo> clubCard = clubFacade.getAllClubs(pageable);
+		Page<ClubCardInfo> clubCard = clubFacade.readAllClubs(pageable);
 		Page<ClubCardResponse> response = clubDtoMapper.of(clubCard);
 		CustomPageResponse<ClubCardResponse> pageResponse = new CustomPageResponse<>(response);
-
 		return CommonResponse.success(pageResponse);
 	}
 

--- a/domain/src/main/java/org/badminton/domain/domain/club/ClubReader.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/ClubReader.java
@@ -10,8 +10,6 @@ import org.springframework.data.domain.Pageable;
 public interface ClubReader {
 	Page<Club> readAllClubs(Pageable pageable);
 
-	Page<ClubCardInfo> getAllClubs(Pageable pageable);
-
 	Page<Club> keywordSearch(String keyword, Pageable pageable);
 
 	List<ClubCardInfo> readRecentlyCreatedClubs();
@@ -27,6 +25,4 @@ public interface ClubReader {
 	boolean UniqueClubName(String clubName);
 
 	List<ClubCardInfo> refreshRecentlyCreatedClubsCache();
-
-	List<ClubCardInfo> refreshAllClubsCache();
 }

--- a/domain/src/main/java/org/badminton/domain/domain/club/ClubService.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/ClubService.java
@@ -16,8 +16,6 @@ import org.springframework.data.domain.Pageable;
 public interface ClubService {
 	Page<ClubCardInfo> readAllClubs(Pageable pageable);
 
-	Page<ClubCardInfo> getAllClubs(Pageable pageable);
-
 	ClubSummaryInfo readClub(String clubToken);
 
 	Page<ClubCardInfo> searchClubs(String keyword, Pageable pageable);
@@ -35,6 +33,4 @@ public interface ClubService {
 	List<ClubCardInfo> getRecentlyCreatedClub();
 
 	void refreshRecentlyCreatedClubsCache();
-
-	void refreshAllClubsCache();
 }

--- a/domain/src/main/java/org/badminton/domain/domain/club/ClubServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/ClubServiceImpl.java
@@ -41,11 +41,6 @@ public class ClubServiceImpl implements ClubService {
 	}
 
 	@Override
-	public Page<ClubCardInfo> getAllClubs(Pageable pageable) {
-		return clubReader.getAllClubs(pageable);
-	}
-
-	@Override
 	@Transactional(readOnly = true)
 	public Page<ClubCardInfo> searchClubs(String keyword, Pageable pageable) {
 		Page<Club> clubs = getClubs(keyword, pageable);
@@ -63,11 +58,6 @@ public class ClubServiceImpl implements ClubService {
 	@Override
 	public void refreshRecentlyCreatedClubsCache() {
 		clubReader.refreshRecentlyCreatedClubsCache();
-	}
-
-	@Override
-	public void refreshAllClubsCache() {
-		clubReader.refreshAllClubsCache();
 	}
 
 	@Override

--- a/domain/src/main/java/org/badminton/domain/domain/club/event/UpdateClubEventHandler.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/event/UpdateClubEventHandler.java
@@ -20,6 +20,5 @@ public class UpdateClubEventHandler {
 		clubStatisticsService.refreshPopularClubsCache();
 		clubStatisticsService.refreshRecentlyActivityClubsCache();
 		clubService.refreshRecentlyCreatedClubsCache();
-		clubService.refreshAllClubsCache();
 	}
 }

--- a/domain/src/main/java/org/badminton/domain/domain/club/vo/ClubRedisKey.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/vo/ClubRedisKey.java
@@ -8,7 +8,6 @@ public class ClubRedisKey {
 	private static final String TOP10_POPULAR = "top10:popular";
 	private static final String TOP10_ACTIVITY = "top10:activity";
 	private static final String TOP10_RECENTLY = "top10:recently";
-	private static final String ALL = "all";
 
 	private ClubRedisKey() {
 
@@ -24,10 +23,6 @@ public class ClubRedisKey {
 
 	public static String getTop10RecentlyKey() {
 		return String.format("%s:%s", NAMESPACE, TOP10_RECENTLY);
-	}
-
-	public static String getAllClubsKey() {
-		return String.format("%s:%s", NAMESPACE, ALL);
 	}
 
 }

--- a/domain/src/main/java/org/badminton/domain/domain/statistics/event/CreateClubEventHandler.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/event/CreateClubEventHandler.java
@@ -21,6 +21,5 @@ public class CreateClubEventHandler {
 		clubStatisticsService.refreshPopularClubsCache();
 		clubStatisticsService.refreshRecentlyActivityClubsCache();
 		clubService.refreshRecentlyCreatedClubsCache();
-		clubService.refreshAllClubsCache();
 	}
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubReaderImpl.java
@@ -1,6 +1,5 @@
 package org.badminton.infrastructure.club;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -10,7 +9,6 @@ import org.badminton.domain.domain.club.entity.Club;
 import org.badminton.domain.domain.club.info.ClubCardInfo;
 import org.badminton.domain.domain.club.vo.ClubRedisKey;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
@@ -27,7 +25,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ClubReaderImpl implements ClubReader {
 	private static final String RECENTLY_TOP10_REDIS_KEY = ClubRedisKey.getTop10RecentlyKey();
-	private static final String ALL_CLUBS_KEY = ClubRedisKey.getAllClubsKey();
 	private final ClubRepository clubRepository;
 	private final RedisTemplate<String, Object> redisTemplate;
 	private final ObjectMapper objectMapper;
@@ -35,40 +32,6 @@ public class ClubReaderImpl implements ClubReader {
 	@Override
 	public Page<Club> readAllClubs(Pageable pageable) {
 		return clubRepository.findAllByIsClubDeletedIsFalse(pageable);
-	}
-
-	@Override
-	public Page<ClubCardInfo> getAllClubs(Pageable pageable) {
-
-		Object cachedClubs = redisTemplate.opsForValue().get("ALL_CLUBS_KEY");
-
-		List<ClubCardInfo> clubCardInfos;
-		if (cachedClubs == null) {
-			clubCardInfos = refreshAllClubsCache();
-		} else {
-			clubCardInfos = objectMapper.convertValue(cachedClubs, new TypeReference<ArrayList<ClubCardInfo>>() {
-			});
-		}
-
-		int start = (int)pageable.getOffset();
-		int end = Math.min(start + pageable.getPageSize(), clubCardInfos.size());
-		List<ClubCardInfo> pagedClubs = clubCardInfos.subList(start, end);
-
-		return new PageImpl<>(pagedClubs, pageable, clubCardInfos.size());
-	}
-
-	@Transactional(readOnly = true)
-	public List<ClubCardInfo> refreshAllClubsCache() {
-
-		List<Club> allClubs = clubRepository.findAllByIsClubDeletedIsFalse();
-
-		List<ClubCardInfo> clubCardInfos = allClubs.stream()
-			.map(ClubCardInfo::from)
-			.toList();
-
-		redisTemplate.opsForValue().set(ALL_CLUBS_KEY, clubCardInfos, 1, TimeUnit.MINUTES);
-
-		return clubCardInfos;
 	}
 
 	@Override


### PR DESCRIPTION
## PR에 대한 설명 🔍
- allClubs 조회를 레디스를 사용하면 페이지네이션으로 데이터를 조회하지 않기 때문에 오히려 응답속도가 느려지는 이슈가 발생했습니다. 그렇기 때문에 레디스를 제거했고, 레디스에 페이지네이션을 Value 로 설정하는 방법을 한 번 생각해보면 좋을 것 같습니다