### PR TITLE
feat : 파일사이즈 체크

### DIFF
--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -77,8 +77,8 @@ spring:
   servlet:
     multipart:
       enabled: true
-      max-file-size: 3MB
-      max-request-size: 3MB
+      max-file-size: 5MB
+      max-request-size: 5MB
 
   # AWS S3
 cloud:

--- a/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
+++ b/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
 	LIMIT_EXCEEDED(400, "파라미터 또는 리소스 속성값이 제한을 초과했습니다."),
 	OUT_OF_RANGE(400, "파라미터 또는 리소스 속성값이 범위를 벗어났습니다."),
 	FILE_NOT_EXIST(400, "파일이 존재하지 않거나 잘못된 파일입니다."),
-	FILE_SIZE_OVER(400, "파일의 크기는 2.5MB 이내야 됩니다."),
+	FILE_SIZE_OVER(400, "파일의 크기는 2.5MB 이내여야 됩니다."),
 	VALIDATION_ERROR(400, "입력값 검증에 실패했습니다"),
 
 	// 401 Errors


### PR DESCRIPTION
## PR에 대한 설명 🔍
- 기존 파일 체크 시 3MB 이상 시 500에러가 발생했습니다. 
- 스프링부트에서 application.yaml 파일에서 파일 사이즈 체크를 풀었지만 해당 에러는 계속 발생했고 파일 업로드 시 스프링부트의 업로드 파일 크기는 1MB로 제한되어있는 것을 확인했습니다. 


>스프링공식문서 [바로가기](https://docs.spring.io/spring-boot/how-to/spring-mvc.html#howto.spring-mvc.multipart-file-uploads)
Spring Boot embraces the servlet 5 [Part](https://jakarta.ee/specifications/servlet/6.0/apidocs/jakarta/servlet/http/Part.html) API to support uploading files. By default, Spring Boot configures Spring MVC with a maximum size of 1MB per file and a maximum of 10MB of file data in a single request. You may override these values, the location to which intermediate data is stored (for example, to the /tmp directory), and the threshold past which data is flushed to disk by using the properties exposed in the [MultipartProperties](https://docs.spring.io/spring-boot/3.4.0/api/java/org/springframework/boot/autoconfigure/web/servlet/MultipartProperties.html) class. For example, if you want to specify that files be unlimited, set the spring.servlet.multipart.max-file-size property to -1.

## 변경된 사항 📝
- 3MB 제한 -> 5MB 서버에서 제한
- 검증로직 2.5MB 이상 시 customException 반환 
- 프론트에서 2.5MB 이미지 업로드시 제한 

전체적인 파일 업로드 체크는 다음과 같습니다. 
이미지 업로드 시 
프론트에서 2.5MB 이미지 업로드 시 제한 --> 서버에서 2.5MB 이상 파일이 들어올 경우 검증 
application 에서는 기본 설정에서 넉넉하게 설정해서 에러가 터지지 않도록 5MB 로 설정하였습니다. 

## PR에서 중점적으로 확인되어야 하는 사항
