### PR TITLE
refactor: 동호회 전체조회 및 검색 조회 레디스 적용

### DIFF
--- a/domain/src/main/java/org/badminton/domain/domain/club/ClubPage.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/ClubPage.java
@@ -2,6 +2,7 @@ package org.badminton.domain.domain.club;
 
 import org.badminton.domain.domain.club.entity.Club;
 import org.badminton.domain.domain.club.info.ClubCardInfo;
+import org.badminton.domain.domain.club.vo.RedisClub;
 import org.springframework.data.domain.Page;
 
 import lombok.Builder;
@@ -10,7 +11,13 @@ import lombok.ToString;
 @Builder
 @ToString
 public class ClubPage {
+	private final Page<RedisClub> redisClub;
 	private final Page<Club> club;
+
+	public Page<ClubCardInfo> clubToRedisPageCardInfo() {
+		return this.redisClub.map(ClubCardInfo::from);
+
+	}
 
 	public Page<ClubCardInfo> clubToPageCardInfo() {
 		return this.club.map(ClubCardInfo::from);

--- a/domain/src/main/java/org/badminton/domain/domain/club/ClubPage.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/ClubPage.java
@@ -2,7 +2,7 @@ package org.badminton.domain.domain.club;
 
 import org.badminton.domain.domain.club.entity.Club;
 import org.badminton.domain.domain.club.info.ClubCardInfo;
-import org.badminton.domain.domain.club.vo.RedisClub;
+import org.badminton.domain.domain.club.vo.ClubCache;
 import org.springframework.data.domain.Page;
 
 import lombok.Builder;
@@ -11,11 +11,11 @@ import lombok.ToString;
 @Builder
 @ToString
 public class ClubPage {
-	private final Page<RedisClub> redisClub;
+	private final Page<ClubCache> clubCaches;
 	private final Page<Club> club;
 
 	public Page<ClubCardInfo> clubToRedisPageCardInfo() {
-		return this.redisClub.map(ClubCardInfo::from);
+		return this.clubCaches.map(ClubCardInfo::from);
 
 	}
 

--- a/domain/src/main/java/org/badminton/domain/domain/club/ClubReader.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/ClubReader.java
@@ -4,14 +4,14 @@ import java.util.List;
 
 import org.badminton.domain.domain.club.entity.Club;
 import org.badminton.domain.domain.club.info.ClubCardInfo;
-import org.badminton.domain.domain.club.vo.RedisClub;
+import org.badminton.domain.domain.club.vo.ClubCache;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ClubReader {
-	Page<RedisClub> readAllClubs(Pageable pageable);
+	Page<ClubCache> readAllClubs(Pageable pageable);
 
-	Page<RedisClub> keywordSearch(String keyword, Pageable pageable);
+	Page<ClubCache> keywordSearch(String keyword, Pageable pageable);
 
 	List<ClubCardInfo> readRecentlyCreatedClubs();
 

--- a/domain/src/main/java/org/badminton/domain/domain/club/ClubReader.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/ClubReader.java
@@ -4,13 +4,14 @@ import java.util.List;
 
 import org.badminton.domain.domain.club.entity.Club;
 import org.badminton.domain.domain.club.info.ClubCardInfo;
+import org.badminton.domain.domain.club.vo.RedisClub;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ClubReader {
-	Page<Club> readAllClubs(Pageable pageable);
+	Page<RedisClub> readAllClubs(Pageable pageable);
 
-	Page<Club> keywordSearch(String keyword, Pageable pageable);
+	Page<RedisClub> keywordSearch(String keyword, Pageable pageable);
 
 	List<ClubCardInfo> readRecentlyCreatedClubs();
 

--- a/domain/src/main/java/org/badminton/domain/domain/club/ClubServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/ClubServiceImpl.java
@@ -14,7 +14,7 @@ import org.badminton.domain.domain.club.info.ClubCreateInfo;
 import org.badminton.domain.domain.club.info.ClubDeleteInfo;
 import org.badminton.domain.domain.club.info.ClubSummaryInfo;
 import org.badminton.domain.domain.club.info.ClubUpdateInfo;
-import org.badminton.domain.domain.club.vo.RedisClub;
+import org.badminton.domain.domain.club.vo.ClubCache;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -36,16 +36,16 @@ public class ClubServiceImpl implements ClubService {
 	@Override
 	@Transactional(readOnly = true)
 	public Page<ClubCardInfo> readAllClubs(Pageable pageable) {
-		Page<RedisClub> clubsPage = clubReader.readAllClubs(pageable);
-		var response = ClubPage.builder().redisClub(clubsPage).build();
+		Page<ClubCache> clubsPage = clubReader.readAllClubs(pageable);
+		var response = ClubPage.builder().clubCaches(clubsPage).build();
 		return response.clubToRedisPageCardInfo();
 	}
 
 	@Override
 	@Transactional(readOnly = true)
 	public Page<ClubCardInfo> searchClubs(String keyword, Pageable pageable) {
-		Page<RedisClub> clubsPage = getClubs(keyword, pageable);
-		var response = ClubPage.builder().redisClub(clubsPage).build();
+		Page<ClubCache> clubsPage = getClubs(keyword, pageable);
+		var response = ClubPage.builder().clubCaches(clubsPage).build();
 		return response.clubToRedisPageCardInfo();
 	}
 
@@ -115,7 +115,7 @@ public class ClubServiceImpl implements ClubService {
 			ClubApply.ApplyStatus.PENDING, pageable);
 	}
 
-	private Page<RedisClub> getClubs(String keyword, Pageable pageable) {
+	private Page<ClubCache> getClubs(String keyword, Pageable pageable) {
 		if (keyword == null || keyword.trim().isEmpty()) {
 			return clubReader.readAllClubs(pageable);
 		}

--- a/domain/src/main/java/org/badminton/domain/domain/club/ClubServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/ClubServiceImpl.java
@@ -14,6 +14,7 @@ import org.badminton.domain.domain.club.info.ClubCreateInfo;
 import org.badminton.domain.domain.club.info.ClubDeleteInfo;
 import org.badminton.domain.domain.club.info.ClubSummaryInfo;
 import org.badminton.domain.domain.club.info.ClubUpdateInfo;
+import org.badminton.domain.domain.club.vo.RedisClub;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -35,17 +36,17 @@ public class ClubServiceImpl implements ClubService {
 	@Override
 	@Transactional(readOnly = true)
 	public Page<ClubCardInfo> readAllClubs(Pageable pageable) {
-		Page<Club> clubsPage = clubReader.readAllClubs(pageable);
-		var response = ClubPage.builder().club(clubsPage).build();
-		return response.clubToPageCardInfo();
+		Page<RedisClub> clubsPage = clubReader.readAllClubs(pageable);
+		var response = ClubPage.builder().redisClub(clubsPage).build();
+		return response.clubToRedisPageCardInfo();
 	}
 
 	@Override
 	@Transactional(readOnly = true)
 	public Page<ClubCardInfo> searchClubs(String keyword, Pageable pageable) {
-		Page<Club> clubs = getClubs(keyword, pageable);
-		var response = ClubPage.builder().club(clubs).build();
-		return response.clubToPageCardInfo();
+		Page<RedisClub> clubsPage = getClubs(keyword, pageable);
+		var response = ClubPage.builder().redisClub(clubsPage).build();
+		return response.clubToRedisPageCardInfo();
 	}
 
 	@Override
@@ -114,7 +115,7 @@ public class ClubServiceImpl implements ClubService {
 			ClubApply.ApplyStatus.PENDING, pageable);
 	}
 
-	private Page<Club> getClubs(String keyword, Pageable pageable) {
+	private Page<RedisClub> getClubs(String keyword, Pageable pageable) {
 		if (keyword == null || keyword.trim().isEmpty()) {
 			return clubReader.readAllClubs(pageable);
 		}

--- a/domain/src/main/java/org/badminton/domain/domain/club/info/ClubCardInfo.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/info/ClubCardInfo.java
@@ -3,7 +3,7 @@ package org.badminton.domain.domain.club.info;
 import java.time.LocalDateTime;
 
 import org.badminton.domain.domain.club.entity.Club;
-import org.badminton.domain.domain.club.vo.RedisClub;
+import org.badminton.domain.domain.club.vo.ClubCache;
 import org.badminton.domain.domain.member.entity.Member;
 
 public record ClubCardInfo(
@@ -32,7 +32,7 @@ public record ClubCardInfo(
 		);
 	}
 
-	public static ClubCardInfo from(RedisClub club) {
+	public static ClubCardInfo from(ClubCache club) {
 		return new ClubCardInfo(
 			club.clubToken(),
 			club.clubName(),

--- a/domain/src/main/java/org/badminton/domain/domain/club/vo/ClubCache.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/vo/ClubCache.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 import org.badminton.domain.domain.club.entity.Club;
 import org.badminton.domain.domain.member.entity.Member;
 
-public record RedisClub(
+public record ClubCache(
 	String clubToken,
 	String clubName,
 	String clubDescription,
@@ -16,8 +16,8 @@ public record RedisClub(
 	Long silverClubMemberCount,
 	Long bronzeClubMemberCount
 ) {
-	public static RedisClub from(Club club) {
-		return new RedisClub(
+	public static ClubCache from(Club club) {
+		return new ClubCache(
 			club.getClubToken(),
 			club.getClubName(),
 			club.getClubDescription(),

--- a/domain/src/main/java/org/badminton/domain/domain/club/vo/ClubRedisKey.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/vo/ClubRedisKey.java
@@ -8,6 +8,7 @@ public class ClubRedisKey {
 	private static final String TOP10_POPULAR = "top10:popular";
 	private static final String TOP10_ACTIVITY = "top10:activity";
 	private static final String TOP10_RECENTLY = "top10:recently";
+	private static final String CLUBS_PAGE = "page";
 
 	private ClubRedisKey() {
 
@@ -15,6 +16,10 @@ public class ClubRedisKey {
 
 	public static String getTop10PopularKey() {
 		return String.format("%s:%s", NAMESPACE, TOP10_POPULAR);
+	}
+
+	public static String getClubsPageKey(int pageNumber) {
+		return String.format("%s:%s:%s", NAMESPACE, CLUBS_PAGE, pageNumber);
 	}
 
 	public static String getTop10ActivityKey() {

--- a/domain/src/main/java/org/badminton/domain/domain/club/vo/RedisClub.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/vo/RedisClub.java
@@ -1,12 +1,11 @@
-package org.badminton.domain.domain.club.info;
+package org.badminton.domain.domain.club.vo;
 
 import java.time.LocalDateTime;
 
 import org.badminton.domain.domain.club.entity.Club;
-import org.badminton.domain.domain.club.vo.RedisClub;
 import org.badminton.domain.domain.member.entity.Member;
 
-public record ClubCardInfo(
+public record RedisClub(
 	String clubToken,
 	String clubName,
 	String clubDescription,
@@ -16,10 +15,9 @@ public record ClubCardInfo(
 	Long goldClubMemberCount,
 	Long silverClubMemberCount,
 	Long bronzeClubMemberCount
-
 ) {
-	public static ClubCardInfo from(Club club) {
-		return new ClubCardInfo(
+	public static RedisClub from(Club club) {
+		return new RedisClub(
 			club.getClubToken(),
 			club.getClubName(),
 			club.getClubDescription(),
@@ -32,17 +30,4 @@ public record ClubCardInfo(
 		);
 	}
 
-	public static ClubCardInfo from(RedisClub club) {
-		return new ClubCardInfo(
-			club.clubToken(),
-			club.clubName(),
-			club.clubDescription(),
-			club.clubImage(),
-			club.createdAt(),
-			club.modifiedAt(),
-			club.goldClubMemberCount(),
-			club.silverClubMemberCount(),
-			club.bronzeClubMemberCount()
-		);
-	}
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubReaderImpl.java
@@ -8,6 +8,7 @@ import org.badminton.domain.domain.club.ClubReader;
 import org.badminton.domain.domain.club.entity.Club;
 import org.badminton.domain.domain.club.info.ClubCardInfo;
 import org.badminton.domain.domain.club.vo.ClubRedisKey;
+import org.badminton.domain.domain.club.vo.RedisClub;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -30,22 +31,43 @@ public class ClubReaderImpl implements ClubReader {
 	private final ObjectMapper objectMapper;
 
 	@Override
-	public Page<Club> readAllClubs(Pageable pageable) {
-		return clubRepository.findAllByIsClubDeletedIsFalse(pageable);
+	@Transactional(readOnly = true)
+	public Page<RedisClub> readAllClubs(Pageable pageable) {
+		String key = ClubRedisKey.getClubsPageKey(pageable.getPageNumber());
+		Object cachedClubs = redisTemplate.opsForValue().get(key);
+
+		if (cachedClubs != null) {
+			RedisPage<RedisClub> redisPage = objectMapper.convertValue(cachedClubs,
+				new TypeReference<>() {
+				});
+			return redisPage.toPage(pageable);
+		}
+
+		return refreshClubs(key, pageable);
+	}
+
+	private Page<RedisClub> refreshClubs(String key, Pageable pageable) {
+		Page<Club> clubs = clubRepository.findAllByIsClubDeletedIsFalse(pageable);
+		Page<RedisClub> redisClubs = clubs.map(RedisClub::from);
+		redisTemplate.opsForValue().set(key, redisClubs, 5, TimeUnit.MINUTES);
+		return redisClubs;
 	}
 
 	@Override
-	public Page<Club> keywordSearch(String keyword, Pageable pageable) {
-		return clubRepository.findAllByClubNameContainingIgnoreCaseAndIsClubDeletedIsFalse(keyword, pageable);
+	public Page<RedisClub> keywordSearch(String keyword, Pageable pageable) {
+		Page<Club> clubs = clubRepository.findAllByClubNameContainingIgnoreCaseAndIsClubDeletedIsFalse(keyword,
+			pageable);
+		return clubs.map(RedisClub::from);
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public List<ClubCardInfo> readRecentlyCreatedClubs() {
 
 		Object cachedClubs = redisTemplate.opsForValue().get(RECENTLY_TOP10_REDIS_KEY);
 
 		if (cachedClubs != null) {
-			return objectMapper.convertValue(cachedClubs, new TypeReference<List<ClubCardInfo>>() {
+			return objectMapper.convertValue(cachedClubs, new TypeReference<>() {
 			});
 		}
 
@@ -54,7 +76,6 @@ public class ClubReaderImpl implements ClubReader {
 	}
 
 	@Override
-	@Transactional(readOnly = true)
 	public List<ClubCardInfo> refreshRecentlyCreatedClubsCache() {
 		List<Club> clubs = clubRepository.findTop10ByIsClubDeletedIsFalseOrderByCreatedAtDesc();
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubReaderImpl.java
@@ -7,8 +7,8 @@ import org.badminton.domain.common.exception.club.ClubNotExistException;
 import org.badminton.domain.domain.club.ClubReader;
 import org.badminton.domain.domain.club.entity.Club;
 import org.badminton.domain.domain.club.info.ClubCardInfo;
+import org.badminton.domain.domain.club.vo.ClubCache;
 import org.badminton.domain.domain.club.vo.ClubRedisKey;
-import org.badminton.domain.domain.club.vo.RedisClub;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -32,12 +32,12 @@ public class ClubReaderImpl implements ClubReader {
 
 	@Override
 	@Transactional(readOnly = true)
-	public Page<RedisClub> readAllClubs(Pageable pageable) {
+	public Page<ClubCache> readAllClubs(Pageable pageable) {
 		String key = ClubRedisKey.getClubsPageKey(pageable.getPageNumber());
 		Object cachedClubs = redisTemplate.opsForValue().get(key);
 
 		if (cachedClubs != null) {
-			RedisPage<RedisClub> redisPage = objectMapper.convertValue(cachedClubs,
+			RedisPage<ClubCache> redisPage = objectMapper.convertValue(cachedClubs,
 				new TypeReference<>() {
 				});
 			return redisPage.toPage(pageable);
@@ -46,18 +46,18 @@ public class ClubReaderImpl implements ClubReader {
 		return refreshClubs(key, pageable);
 	}
 
-	private Page<RedisClub> refreshClubs(String key, Pageable pageable) {
+	private Page<ClubCache> refreshClubs(String key, Pageable pageable) {
 		Page<Club> clubs = clubRepository.findAllByIsClubDeletedIsFalse(pageable);
-		Page<RedisClub> redisClubs = clubs.map(RedisClub::from);
+		Page<ClubCache> redisClubs = clubs.map(ClubCache::from);
 		redisTemplate.opsForValue().set(key, redisClubs, 5, TimeUnit.MINUTES);
 		return redisClubs;
 	}
 
 	@Override
-	public Page<RedisClub> keywordSearch(String keyword, Pageable pageable) {
+	public Page<ClubCache> keywordSearch(String keyword, Pageable pageable) {
 		Page<Club> clubs = clubRepository.findAllByClubNameContainingIgnoreCaseAndIsClubDeletedIsFalse(keyword,
 			pageable);
-		return clubs.map(RedisClub::from);
+		return clubs.map(ClubCache::from);
 	}
 
 	@Override
@@ -67,7 +67,7 @@ public class ClubReaderImpl implements ClubReader {
 		Object cachedClubs = redisTemplate.opsForValue().get(RECENTLY_TOP10_REDIS_KEY);
 
 		if (cachedClubs != null) {
-			return objectMapper.convertValue(cachedClubs, new TypeReference<>() {
+			return objectMapper.convertValue(cachedClubs, new TypeReference<List<ClubCardInfo>>() {
 			});
 		}
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/club/RedisPage.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/club/RedisPage.java
@@ -1,0 +1,37 @@
+package org.badminton.infrastructure.club;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+public record RedisPage<T>(
+	List<T> content,
+	int totalPages,
+	long totalElements,
+	int size,
+	int number,
+	boolean first,
+	boolean last,
+	int numberOfElements,
+	boolean empty
+) {
+	public RedisPage(Page<T> page) {
+		this(
+			page.getContent(),
+			page.getTotalPages(),
+			page.getTotalElements(),
+			page.getSize(),
+			page.getNumber(),
+			page.isFirst(),
+			page.isLast(),
+			page.getNumberOfElements(),
+			page.isEmpty()
+		);
+	}
+
+	public Page<T> toPage(Pageable pageable) {
+		return new PageImpl<>(content, pageable, totalElements);
+	}
+}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsReaderImpl.java
@@ -56,7 +56,7 @@ public class ClubStatisticsReaderImpl implements ClubStatisticsReader {
 		Object cachedClubs = redisTemplate.opsForValue().get(POPULAR_TOP10_REDIS_KEY);
 
 		if (cachedClubs != null) {
-			return objectMapper.convertValue(cachedClubs, new TypeReference<>() {
+			return objectMapper.convertValue(cachedClubs, new TypeReference<List<ClubCardInfo>>() {
 			});
 		}
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsReaderImpl.java
@@ -50,12 +50,13 @@ public class ClubStatisticsReaderImpl implements ClubStatisticsReader {
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public List<ClubCardInfo> readTop10PopularClub() {
 
 		Object cachedClubs = redisTemplate.opsForValue().get(POPULAR_TOP10_REDIS_KEY);
 
 		if (cachedClubs != null) {
-			return objectMapper.convertValue(cachedClubs, new TypeReference<List<ClubCardInfo>>() {
+			return objectMapper.convertValue(cachedClubs, new TypeReference<>() {
 			});
 		}
 
@@ -64,7 +65,6 @@ public class ClubStatisticsReaderImpl implements ClubStatisticsReader {
 	}
 
 	@Override
-	@Transactional(readOnly = true)
 	public List<ClubCardInfo> refreshTop10PopularClubsCache() {
 		List<ClubStatistics> top10ByOrderByPopularityScoreDesc = clubStatisticsRepository.findTop10ByOrderByPopularityScoreDesc();
 


### PR DESCRIPTION
## PR에 대한 설명 🔍
- 기존 Club을 그대로 레디스 캐시로 저장할 경우 ClubMember depth가 깊어져 파싱에러가 발생합니다.
```
// 에러 내용
Could not write JSON: Document nesting depth (1001) exceeds the maximum allowed (1000, from StreamWriteConstraints.getMaxNestingDepth()) (through reference chain: 
```

## 변경된 사항 📝
- 이를 위해 ClubMember 부분을 맵핑을 통해 각 맴버 티어의 갯수만 가져오고 해당 객체를 가져오지 않습니다. 
- 파싱에러를 없애기 위해 객체를 추가했습니다. 각 객체는 domain과 infra에서 생성하고 사용하여 상위 계층에 영향을 주지 않습니다. 

## PR에서 중점적으로 확인되어야 하는 사항
