### PR TITLE
feat: 토너먼트 세트 종료 제약 조건 추가 및 프리매치 DRAW 로직 추가

### DIFF
--- a/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
+++ b/domain/src/main/java/org/badminton/domain/common/error/ErrorCode.java
@@ -107,6 +107,8 @@ public enum ErrorCode {
 	NOT_LEAGUE_OWNER(412, "경기를 만든 사용자만 이용할 수 있습니다."),
 	CLUB_MEMBER_EXPEL_EXCEPTION(412, "해당 동호회에서 제제를 받아 가입 신청을 할 수 없습니다."),
 	BYE_MATCH_ACTION_NOT_ALLOWED(412, "해당 매치는 부전승 매치이기 때문에 점수를 수정할 수 없습니다"),
+	TIE_SCORE_NOT_ALLOWED(412, "토너먼트 경기에서는 점수가 동일할 수 없습니다"),
+	SET_SCORE_NOT_REACHED(412, "토너먼트에서 승자의 점수는 최소 21점이어야 합니다"),
 
 	// 500 Errors
 	INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다."),

--- a/domain/src/main/java/org/badminton/domain/common/exception/match/SetScoreNotReachedException.java
+++ b/domain/src/main/java/org/badminton/domain/common/exception/match/SetScoreNotReachedException.java
@@ -1,0 +1,15 @@
+package org.badminton.domain.common.exception.match;
+
+import org.badminton.domain.common.error.ErrorCode;
+import org.badminton.domain.common.exception.BadmintonException;
+
+public class SetScoreNotReachedException extends BadmintonException {
+
+	public SetScoreNotReachedException(int team1Score, int team2Score) {
+		super(ErrorCode.SET_SCORE_NOT_REACHED, "[팀1 점수 : " + team1Score + " 팀2 점수 : " + team2Score + "]");
+	}
+
+	public SetScoreNotReachedException(int team1Score, int team2Score, Exception e) {
+		super(ErrorCode.SET_SCORE_NOT_REACHED, "[팀1 점수 : " + team1Score + " 팀2 점수 : " + team2Score + "]", e);
+	}
+}

--- a/domain/src/main/java/org/badminton/domain/common/exception/match/TieScoreNotAllowedException.java
+++ b/domain/src/main/java/org/badminton/domain/common/exception/match/TieScoreNotAllowedException.java
@@ -1,0 +1,15 @@
+package org.badminton.domain.common.exception.match;
+
+import org.badminton.domain.common.error.ErrorCode;
+import org.badminton.domain.common.exception.BadmintonException;
+
+public class TieScoreNotAllowedException extends BadmintonException {
+
+	public TieScoreNotAllowedException(int team1Score, int team2Score) {
+		super(ErrorCode.TIE_SCORE_NOT_ALLOWED, "[팀1 점수 : " + team1Score + " 팀2 점수 : " + team2Score + "]");
+	}
+
+	public TieScoreNotAllowedException(int team1Score, int team2Score, Exception e) {
+		super(ErrorCode.TIE_SCORE_NOT_ALLOWED, "[팀1 점수 : " + team1Score + " 팀2 점수 : " + team2Score + "]", e);
+	}
+}

--- a/domain/src/main/java/org/badminton/domain/domain/match/entity/DoublesMatch.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/entity/DoublesMatch.java
@@ -102,6 +102,16 @@ public class DoublesMatch extends AbstractBaseTime {
 		}
 	}
 
+	public void setDrawMatch() {
+		this.team1MatchResult = MatchResult.DRAW;
+		this.team2MatchResult = MatchResult.DRAW;
+		this.matchStatus = MatchStatus.FINISHED;
+	}
+
+	public boolean isDrawMatch() {
+		return this.team1WinSetCount == this.team2WinSetCount;
+	}
+
 	public void defineTeam1(Team winner) {
 		this.team1 = winner;
 	}

--- a/domain/src/main/java/org/badminton/domain/domain/match/entity/SinglesMatch.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/entity/SinglesMatch.java
@@ -109,6 +109,16 @@ public class SinglesMatch extends AbstractBaseTime {
 		}
 	}
 
+	public void setDrawMatch() {
+		this.player1MatchResult = MatchResult.DRAW;
+		this.player2MatchResult = MatchResult.DRAW;
+		this.matchStatus = MatchStatus.FINISHED;
+	}
+
+	public boolean isDrawMatch() {
+		return this.player1WinSetCount == this.player2WinSetCount;
+	}
+
 	public void defineLeagueParticipant1(LeagueParticipant leagueParticipant1) {
 		this.leagueParticipant1 = leagueParticipant1;
 	}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentDoublesEndSetHandler.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentDoublesEndSetHandler.java
@@ -37,6 +37,8 @@ public class TournamentDoublesEndSetHandler {
 	public void processEndSet(Integer setNumber, MatchCommand.UpdateSetScore updateSetScoreCommand,
 		DoublesMatch doublesMatch) {
 
+		matchUtils.validateSetScores(updateSetScoreCommand);
+		
 		updateWinnerWithSetScore(doublesMatch, setNumber, updateSetScoreCommand);
 
 		if (LIMIT_SET_GAME > setNumber) {

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentSinglesEndSetHandler.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/service/TournamentSinglesEndSetHandler.java
@@ -66,6 +66,9 @@ public class TournamentSinglesEndSetHandler {
 	public void processEndSet(SinglesMatch singlesMatch, Integer setNumber,
 		MatchCommand.UpdateSetScore updateSetScoreCommand) {
 
+		// 점수 검증
+		matchUtils.validateSetScores(updateSetScoreCommand);
+
 		// setScore 저장
 		updateWinnerWithSetScore(singlesMatch, setNumber, updateSetScoreCommand);
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/FreeDoublesMatchStrategy.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/FreeDoublesMatchStrategy.java
@@ -76,8 +76,14 @@ public class FreeDoublesMatchStrategy extends AbstractDoublesMatchStrategy {
 
 		if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
 			doublesMatch.team1WinSet();
-		} else {
+		}
+
+		if (updateSetScoreCommand.getScore2() > updateSetScoreCommand.getScore1()) {
 			doublesMatch.team2WinSet();
+		}
+
+		if (setNumber.equals(LIMIT_SET_GAME) && doublesMatch.isDrawMatch()) {
+			doublesMatch.setDrawMatch();
 		}
 
 		if (LIMIT_SET_GAME > setNumber) {

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/FreeSinglesMatchStrategy.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/FreeSinglesMatchStrategy.java
@@ -81,8 +81,14 @@ public class FreeSinglesMatchStrategy extends AbstractSinglesMatchStrategy {
 
 		if (updateSetScoreCommand.getScore1() > updateSetScoreCommand.getScore2()) {
 			singlesMatch.player1WinSet();
-		} else {
+		}
+
+		if (updateSetScoreCommand.getScore2() > updateSetScoreCommand.getScore1()) {
 			singlesMatch.player2WinSet();
+		}
+
+		if (setNumber.equals(LIMIT_SET_GAME) && singlesMatch.isDrawMatch()) {
+			singlesMatch.setDrawMatch();
 		}
 
 		if (LIMIT_SET_GAME > setNumber) {

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/MatchUtils.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/strategy/MatchUtils.java
@@ -3,9 +3,12 @@ package org.badminton.infrastructure.match.strategy;
 import static org.badminton.domain.common.consts.Constants.*;
 
 import org.badminton.domain.common.enums.MatchStatus;
+import org.badminton.domain.common.exception.match.SetScoreNotReachedException;
+import org.badminton.domain.common.exception.match.TieScoreNotAllowedException;
 import org.badminton.domain.domain.league.LeagueParticipantReader;
 import org.badminton.domain.domain.league.entity.LeagueParticipant;
 import org.badminton.domain.domain.league.vo.Team;
+import org.badminton.domain.domain.match.command.MatchCommand;
 import org.badminton.domain.domain.match.entity.DoublesMatch;
 import org.badminton.domain.domain.match.entity.SinglesMatch;
 import org.badminton.domain.domain.match.reader.DoublesMatchReader;
@@ -168,6 +171,20 @@ public class MatchUtils {
 		}
 		if (!nextRoundMatch.isTeam2Exist()) {
 			nextRoundMatch.defineTeam2(winner);
+		}
+
+	}
+
+	public void validateSetScores(MatchCommand.UpdateSetScore updateSetScore) {
+		int team1Score = updateSetScore.getScore1();
+		int team2Score = updateSetScore.getScore2();
+
+		if (team1Score == team2Score) {
+			throw new TieScoreNotAllowedException(team1Score, team2Score);
+		}
+
+		if (team1Score < 21 && team2Score < 21) {
+			throw new SetScoreNotReachedException(team1Score, team2Score);
 		}
 
 	}


### PR DESCRIPTION
## PR에 대한 설명 🔍

### 토너먼트
- endSet을 할 때 team1의 점수와 team2 점수가 동일하면 안됩니다.
- endSet을 할 때 team1의 점수나 team2의 점수가 21점 이상이어야 합니다.

### 프리
- 토너먼트와 달리 제약조건이 없습니다.
- endSet을 할 때 team1의 점수와 team2의 점수가 동일하면 team1, team2의 WinSet을 올리지 않습니다.
- endSet을 할 때 현재의 세트번호가  LIMIT_SET_GAME(3) 과 같고, team1, team2의 WinSet이 같다면, MatchResult를 DRAW로 바꿔줍니다.

