### PR TITLE
refactor: 클럽 전체 조회 최적화

### DIFF
--- a/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubReaderImpl.java
@@ -46,8 +46,7 @@ public class ClubReaderImpl implements ClubReader {
 	}
 
 	private Page<ClubCache> refreshClubs(String key, Pageable pageable) {
-		Page<Club> clubs = clubRepository.findAllByIsClubDeletedIsFalse(pageable);
-		Page<ClubCache> redisClubs = clubs.map(ClubCache::from);
+		Page<ClubCache> redisClubs = clubRepository.findAllClubs(pageable);
 		redisTemplate.opsForValue().set(key, redisClubs, 5, TimeUnit.MINUTES);
 		return redisClubs;
 	}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubRepository.java
@@ -4,9 +4,11 @@ import java.util.List;
 import java.util.Optional;
 
 import org.badminton.domain.domain.club.entity.Club;
+import org.badminton.domain.domain.club.vo.ClubCache;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ClubRepository extends JpaRepository<Club, Long> {
 	Optional<Club> findByClubToken(String clubToken);
@@ -24,5 +26,20 @@ public interface ClubRepository extends JpaRepository<Club, Long> {
 	Club findByClubId(Long clubId);
 
 	boolean existsByClubNameAndIsClubDeletedFalse(String clubName);
+
+	@Query(value = """
+		    SELECT new org.badminton.domain.domain.club.vo.ClubCache(
+		        c.clubToken, c.clubName, c.clubDescription, c.clubImage, c.createdAt, c.modifiedAt,
+		        SUM(CASE WHEN cm.member.tier = 'GOLD' THEN 1 ELSE 0 END),
+		        SUM(CASE WHEN cm.member.tier = 'SILVER' THEN 1 ELSE 0 END),
+		        SUM(CASE WHEN cm.member.tier = 'BRONZE' THEN 1 ELSE 0 END)
+		    )
+		    FROM Club c
+		    LEFT JOIN c.clubMembers cm
+		    JOIN cm.member m
+		    WHERE c.isClubDeleted = false
+		    GROUP BY c.clubToken, c.clubName, c.clubDescription, c.clubImage, c.createdAt, c.modifiedAt, c.clubId
+		""")
+	Page<ClubCache> findAllClubs(Pageable pageable);
 }
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubRepository.java
@@ -15,12 +15,8 @@ public interface ClubRepository extends JpaRepository<Club, Long> {
 
 	Optional<Club> findByClubTokenAndIsClubDeletedFalse(String clubToken);
 
-	Page<Club> findAllByIsClubDeletedIsFalse(Pageable pageable);
-
 	Page<Club> findAllByClubNameContainingIgnoreCaseAndIsClubDeletedIsFalse(String keyword, Pageable pageable);
-
-	List<Club> findAllByIsClubDeletedIsFalse();
-
+	
 	List<Club> findTop10ByIsClubDeletedIsFalseOrderByCreatedAtDesc();
 
 	Club findByClubId(Long clubId);


### PR DESCRIPTION
## PR에 대한 설명 🔍
- PR의 내용에 대한 설명을 자세히 설명 


## 변경된 사항 📝
쿼리 요청을 최적화하여 응답시간을 단축하였습니다. 
홈서버 기준 1800ms -> 180ms로 응답시간을 단축하였습니다. 

### Before
![image](https://github.com/user-attachments/assets/784458a6-2585-4ba7-beec-b948e32995d5)

### After
![image](https://github.com/user-attachments/assets/c8061ad9-c802-4a94-98f1-778b42877d89)

### 성능이 나오지 않았던 이유 ⚠️
- 먼저 기본 JPA 기본 메서드를 이용하였을 때 연관관계를 이용하여 DB에 데이터를 조회하고 있었습니다.
- 그래서 클럽의 갯수에 따라 클럽 맴버의 맴버 엔티티의 티어를 가져옵니다. 클럽을 15개 조회했다면 각 클럽의 클럽 맴버 수 만큼 조회하고 클럽 맴버 수 만큼 다시 맴버를 조회하다보니 트랜잭션 내 쿼리 갯수가 많이 쌓이게 되었습니다.

쿼리문을 사용하여 한번에 조회해서 성능을 개선하게 되었습니다. 실제 쿼리는 1개만 요청되며 Page  타입으로 리턴할 필요가 있어 count 집계함수 까지 총 2개의 쿼리를 요청합니다.
기존에는 클럽의 클럽 맴버 수 만큼 요청하던 쿼리를 2개로 줄이면서 성능을 크게 향상 시킬 수 있게 되었습니다. 


## PR에서 중점적으로 확인되어야 하는 사항
