### PR TITLE
refactor: JPA N+1 해결

### DIFF
--- a/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsReaderImpl.java
@@ -8,6 +8,8 @@ import org.badminton.domain.domain.club.vo.ClubRedisKey;
 import org.badminton.domain.domain.statistics.ClubStatistics;
 import org.badminton.domain.domain.statistics.ClubStatisticsReader;
 import org.badminton.domain.domain.statistics.ClubStatisticsRepositoryCustom;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
@@ -64,8 +66,9 @@ public class ClubStatisticsReaderImpl implements ClubStatisticsReader {
 
 	@Override
 	public List<ClubCardInfo> refreshTop10PopularClubsCache() {
+		Pageable pageable = PageRequest.of(0, 10);
 		List<ClubStatistics> top10ByOrderByPopularityScoreDesc = clubStatisticsRepository
-			.findTop10ByOrderByPopularityScoreDesc();
+			.findTopPopularClubs(pageable);
 
 		List<ClubCardInfo> top10ClubCardInfo = top10ByOrderByPopularityScoreDesc.stream()
 			.map(clubStatistics -> ClubCardInfo.from(clubStatistics.getClub()))
@@ -91,8 +94,9 @@ public class ClubStatisticsReaderImpl implements ClubStatisticsReader {
 
 	@Override
 	public List<ClubCardInfo> refreshActivityClubsCache() {
+		Pageable pageable = PageRequest.of(0, 10);
 		List<ClubStatistics> top10RecentlyActiveClubStatistics = clubStatisticsRepository
-			.findTop10ByOrderByActivityScoreDesc();
+			.findTop10ByActivityClubs(pageable);
 
 		List<ClubCardInfo> top10ClubCardInfo = top10RecentlyActiveClubStatistics.stream()
 			.map(clubStatistics -> ClubCardInfo.from(clubStatistics.getClub()))

--- a/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsRepository.java
@@ -3,6 +3,7 @@ package org.badminton.infrastructure.statistics;
 import java.util.List;
 
 import org.badminton.domain.domain.statistics.ClubStatistics;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -15,7 +16,23 @@ public interface ClubStatisticsRepository extends JpaRepository<ClubStatistics, 
 
 	ClubStatistics findByClubClubId(Long clubId);
 
-	List<ClubStatistics> findTop10ByOrderByPopularityScoreDesc();
+	@Query("SELECT DISTINCT cs " +
+		"FROM ClubStatistics cs " +
+		"JOIN FETCH cs.club c " +
+		"LEFT JOIN FETCH c.clubMembers cm " +
+		"LEFT JOIN FETCH cm.member m " +
+		"LEFT JOIN FETCH m.leagueRecord lr " +
+		"ORDER BY cs.popularityScore DESC"
+	)
+	List<ClubStatistics> findTopPopularClubs(Pageable pageable);
 
-	List<ClubStatistics> findTop10ByOrderByActivityScoreDesc();
+	@Query("SELECT DISTINCT cs " +
+		"FROM ClubStatistics cs " +
+		"JOIN FETCH cs.club c " +
+		"LEFT JOIN FETCH c.clubMembers cm " +
+		"LEFT JOIN FETCH cm.member m " +
+		"LEFT JOIN FETCH m.leagueRecord lr " +
+		"ORDER BY cs.activityScore DESC")
+	List<ClubStatistics> findTop10ByActivityClubs(Pageable pageable);
+
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍
- 인기있는 top10 동호회 조회 API
- 활동이 많은 top10 동호회 조회 API

에서 LAZY Loading으로 인해 JPA의 N+1 문제가 발생했습니다.

JPQL의 LEFT JOIN 을 사용해서 API가 실행될 떄 하나의 쿼리만 생기도록 수정했습니다. -> 각 API의 응답속도가 로컬환경 기준에서 128ms -> 53ms 로 줄어든 것 확인했습니다

## 변경된 사항 📝

<!-- 이번 PR에서의 변경점 -->

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF, 글 -->

### Before

### After

## PR에서 중점적으로 확인되어야 하는 사항
