### PR TITLE
hotfix: JPA 쿼리 최적화

### DIFF
--- a/domain/src/main/java/org/badminton/domain/domain/club/ClubPage.java
+++ b/domain/src/main/java/org/badminton/domain/domain/club/ClubPage.java
@@ -1,5 +1,7 @@
 package org.badminton.domain.domain.club;
 
+import java.util.List;
+
 import org.badminton.domain.domain.club.entity.Club;
 import org.badminton.domain.domain.club.info.ClubCardInfo;
 import org.badminton.domain.domain.club.vo.ClubCache;
@@ -14,6 +16,9 @@ public class ClubPage {
 	private final Page<ClubCache> clubCaches;
 	private final Page<Club> club;
 
+	private final List<Club> clubList;
+	private final List<ClubCache> clubCacheList;
+
 	public Page<ClubCardInfo> clubToRedisPageCardInfo() {
 		return this.clubCaches.map(ClubCardInfo::from);
 
@@ -21,5 +26,14 @@ public class ClubPage {
 
 	public Page<ClubCardInfo> clubToPageCardInfo() {
 		return this.club.map(ClubCardInfo::from);
+	}
+
+	public List<ClubCardInfo> clubListToRedisPageCardInfo() {
+		return this.clubCacheList.stream().map(ClubCardInfo::from).toList();
+
+	}
+
+	public List<ClubCardInfo> clubListToPageCardInfo() {
+		return this.clubList.stream().map(ClubCardInfo::from).toList();
 	}
 }

--- a/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsReader.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsReader.java
@@ -2,7 +2,7 @@ package org.badminton.domain.domain.statistics;
 
 import java.util.List;
 
-import org.badminton.domain.domain.club.info.ClubCardInfo;
+import org.badminton.domain.domain.club.vo.ClubCache;
 
 public interface ClubStatisticsReader {
 
@@ -14,11 +14,11 @@ public interface ClubStatisticsReader {
 
 	List<ClubStatistics> findAll();
 
-	List<ClubCardInfo> readTop10PopularClub();
+	List<ClubCache> readTop10PopularClub();
 
-	List<ClubCardInfo> readTop10RecentlyActiveClub();
+	List<ClubCache> readTop10RecentlyActiveClub();
 
-	List<ClubCardInfo> refreshTop10PopularClubsCache();
+	List<ClubCache> refreshTop10PopularClubsCache();
 
-	List<ClubCardInfo> refreshActivityClubsCache();
+	List<ClubCache> refreshActivityClubsCache();
 }

--- a/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsServiceImpl.java
@@ -2,8 +2,10 @@ package org.badminton.domain.domain.statistics;
 
 import java.util.List;
 
+import org.badminton.domain.domain.club.ClubPage;
 import org.badminton.domain.domain.club.info.ClubCardInfo;
 import org.badminton.domain.domain.club.info.ClubCreateInfo;
+import org.badminton.domain.domain.club.vo.ClubCache;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,15 +54,18 @@ public class ClubStatisticsServiceImpl implements ClubStatisticsService {
 	@Transactional
 	public List<ClubCardInfo> getTop10PopularClub() {
 
-		return clubStatisticsReader.readTop10PopularClub();
-
+		List<ClubCache> clubCaches = clubStatisticsReader.readTop10PopularClub();
+		var response = ClubPage.builder().clubCacheList(clubCaches).build();
+		return response.clubListToRedisPageCardInfo();
 	}
 
 	@Override
 	@Transactional
 	public List<ClubCardInfo> getTop10RecentlyActiveClub() {
 
-		return clubStatisticsReader.readTop10RecentlyActiveClub();
+		List<ClubCache> clubCaches = clubStatisticsReader.readTop10RecentlyActiveClub();
+		var response = ClubPage.builder().clubCacheList(clubCaches).build();
+		return response.clubListToRedisPageCardInfo();
 	}
 
 	@Override

--- a/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubReaderImpl.java
@@ -47,7 +47,7 @@ public class ClubReaderImpl implements ClubReader {
 
 	private Page<ClubCache> refreshClubs(String key, Pageable pageable) {
 		Page<ClubCache> redisClubs = clubRepository.findAllClubs(pageable);
-		redisTemplate.opsForValue().set(key, redisClubs, 5, TimeUnit.MINUTES);
+		redisTemplate.opsForValue().set(key, redisClubs, 1, TimeUnit.MINUTES);
 		return redisClubs;
 	}
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsReaderImpl.java
@@ -70,10 +70,6 @@ public class ClubStatisticsReaderImpl implements ClubStatisticsReader {
 		List<ClubCache> top10ByOrderByPopularityScoreDesc = clubStatisticsRepository
 			.findTopPopularClubs(pageable);
 
-		// List<ClubCardInfo> top10ClubCardInfo = top10ByOrderByPopularityScoreDesc.stream()
-		// 	.map(clubStatistics -> ClubCardInfo.from(clubStatistics.getClub()))
-		// 	.toList();
-
 		redisTemplate.opsForValue()
 			.set(POPULAR_TOP10_REDIS_KEY, top10ByOrderByPopularityScoreDesc, 1, TimeUnit.MINUTES);
 
@@ -98,10 +94,6 @@ public class ClubStatisticsReaderImpl implements ClubStatisticsReader {
 		Pageable pageable = PageRequest.of(0, 10);
 		List<ClubCache> top10RecentlyActiveClubStatistics = clubStatisticsRepository
 			.findTop10ByActivityClubs(pageable);
-
-		// List<ClubCardInfo> top10ClubCardInfo = top10RecentlyActiveClubStatistics.stream()
-		// 	.map(clubStatistics -> ClubCardInfo.from(clubStatistics.getClub()))
-		// 	.toList();
 
 		redisTemplate.opsForValue()
 			.set(ACTIVITY_TOP10_REDIS_KEY, top10RecentlyActiveClubStatistics, 1, TimeUnit.MINUTES);

--- a/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsReaderImpl.java
@@ -3,7 +3,7 @@ package org.badminton.infrastructure.statistics;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.badminton.domain.domain.club.info.ClubCardInfo;
+import org.badminton.domain.domain.club.vo.ClubCache;
 import org.badminton.domain.domain.club.vo.ClubRedisKey;
 import org.badminton.domain.domain.statistics.ClubStatistics;
 import org.badminton.domain.domain.statistics.ClubStatisticsReader;
@@ -51,12 +51,12 @@ public class ClubStatisticsReaderImpl implements ClubStatisticsReader {
 	}
 
 	@Override
-	public List<ClubCardInfo> readTop10PopularClub() {
+	public List<ClubCache> readTop10PopularClub() {
 
 		Object cachedClubs = redisTemplate.opsForValue().get(POPULAR_TOP10_REDIS_KEY);
 
 		if (cachedClubs != null) {
-			return objectMapper.convertValue(cachedClubs, new TypeReference<List<ClubCardInfo>>() {
+			return objectMapper.convertValue(cachedClubs, new TypeReference<List<ClubCache>>() {
 			});
 		}
 
@@ -65,27 +65,28 @@ public class ClubStatisticsReaderImpl implements ClubStatisticsReader {
 	}
 
 	@Override
-	public List<ClubCardInfo> refreshTop10PopularClubsCache() {
+	public List<ClubCache> refreshTop10PopularClubsCache() {
 		Pageable pageable = PageRequest.of(0, 10);
-		List<ClubStatistics> top10ByOrderByPopularityScoreDesc = clubStatisticsRepository
+		List<ClubCache> top10ByOrderByPopularityScoreDesc = clubStatisticsRepository
 			.findTopPopularClubs(pageable);
 
-		List<ClubCardInfo> top10ClubCardInfo = top10ByOrderByPopularityScoreDesc.stream()
-			.map(clubStatistics -> ClubCardInfo.from(clubStatistics.getClub()))
-			.toList();
+		// List<ClubCardInfo> top10ClubCardInfo = top10ByOrderByPopularityScoreDesc.stream()
+		// 	.map(clubStatistics -> ClubCardInfo.from(clubStatistics.getClub()))
+		// 	.toList();
 
-		redisTemplate.opsForValue().set(POPULAR_TOP10_REDIS_KEY, top10ClubCardInfo, 1, TimeUnit.MINUTES);
+		redisTemplate.opsForValue()
+			.set(POPULAR_TOP10_REDIS_KEY, top10ByOrderByPopularityScoreDesc, 1, TimeUnit.MINUTES);
 
-		return top10ClubCardInfo;
+		return top10ByOrderByPopularityScoreDesc;
 	}
 
 	@Override
-	public List<ClubCardInfo> readTop10RecentlyActiveClub() {
+	public List<ClubCache> readTop10RecentlyActiveClub() {
 
 		Object cachedClubs = redisTemplate.opsForValue().get(ACTIVITY_TOP10_REDIS_KEY);
 
 		if (cachedClubs != null) {
-			return objectMapper.convertValue(cachedClubs, new TypeReference<List<ClubCardInfo>>() {
+			return objectMapper.convertValue(cachedClubs, new TypeReference<List<ClubCache>>() {
 			});
 		}
 
@@ -93,17 +94,18 @@ public class ClubStatisticsReaderImpl implements ClubStatisticsReader {
 	}
 
 	@Override
-	public List<ClubCardInfo> refreshActivityClubsCache() {
+	public List<ClubCache> refreshActivityClubsCache() {
 		Pageable pageable = PageRequest.of(0, 10);
-		List<ClubStatistics> top10RecentlyActiveClubStatistics = clubStatisticsRepository
+		List<ClubCache> top10RecentlyActiveClubStatistics = clubStatisticsRepository
 			.findTop10ByActivityClubs(pageable);
 
-		List<ClubCardInfo> top10ClubCardInfo = top10RecentlyActiveClubStatistics.stream()
-			.map(clubStatistics -> ClubCardInfo.from(clubStatistics.getClub()))
-			.toList();
+		// List<ClubCardInfo> top10ClubCardInfo = top10RecentlyActiveClubStatistics.stream()
+		// 	.map(clubStatistics -> ClubCardInfo.from(clubStatistics.getClub()))
+		// 	.toList();
 
-		redisTemplate.opsForValue().set(ACTIVITY_TOP10_REDIS_KEY, top10ClubCardInfo, 1, TimeUnit.MINUTES);
+		redisTemplate.opsForValue()
+			.set(ACTIVITY_TOP10_REDIS_KEY, top10RecentlyActiveClubStatistics, 1, TimeUnit.MINUTES);
 
-		return top10ClubCardInfo;
+		return top10RecentlyActiveClubStatistics;
 	}
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsRepository.java
@@ -2,6 +2,7 @@ package org.badminton.infrastructure.statistics;
 
 import java.util.List;
 
+import org.badminton.domain.domain.club.vo.ClubCache;
 import org.badminton.domain.domain.statistics.ClubStatistics;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,20 +17,36 @@ public interface ClubStatisticsRepository extends JpaRepository<ClubStatistics, 
 
 	ClubStatistics findByClubClubId(Long clubId);
 
-	@Query("SELECT DISTINCT cs " +
-		"FROM ClubStatistics cs " +
-		"JOIN FETCH cs.club c " +
-		"LEFT JOIN FETCH c.clubMembers cm " +
-		"LEFT JOIN FETCH cm.member m " +
-		"ORDER BY cs.popularityScore DESC")
-	List<ClubStatistics> findTopPopularClubs(Pageable pageable);
+	@Query("""
+		    SELECT new org.badminton.domain.domain.club.vo.ClubCache(
+		        c.clubToken, c.clubName, c.clubDescription, c.clubImage, c.createdAt, c.modifiedAt,
+		        SUM(CASE WHEN cm.member.tier = 'GOLD' THEN 1 ELSE 0 END),
+		        SUM(CASE WHEN cm.member.tier = 'SILVER' THEN 1 ELSE 0 END),
+		        SUM(CASE WHEN cm.member.tier = 'BRONZE' THEN 1 ELSE 0 END)
+		    )
+		    FROM ClubStatistics cs
+		    JOIN cs.club c
+		    LEFT JOIN c.clubMembers cm
+		    WHERE c.isClubDeleted = false
+		    GROUP BY c.clubToken, c.clubName, c.clubDescription, c.clubImage, c.createdAt, c.modifiedAt, cs.popularityScore
+		    ORDER BY cs.popularityScore DESC
+		""")
+	List<ClubCache> findTopPopularClubs(Pageable pageable);
 
-	@Query("SELECT DISTINCT cs " +
-		"FROM ClubStatistics cs " +
-		"JOIN FETCH cs.club c " +
-		"LEFT JOIN FETCH c.clubMembers cm " +
-		"LEFT JOIN FETCH cm.member m " +
-		"ORDER BY cs.activityScore DESC")
-	List<ClubStatistics> findTop10ByActivityClubs(Pageable pageable);
+	@Query("""
+		    SELECT new org.badminton.domain.domain.club.vo.ClubCache(
+		        c.clubToken, c.clubName, c.clubDescription, c.clubImage, c.createdAt, c.modifiedAt,
+		        SUM(CASE WHEN cm.member.tier = 'GOLD' THEN 1 ELSE 0 END),
+		        SUM(CASE WHEN cm.member.tier = 'SILVER' THEN 1 ELSE 0 END),
+		        SUM(CASE WHEN cm.member.tier = 'BRONZE' THEN 1 ELSE 0 END)
+		    )
+		    FROM ClubStatistics cs
+		    JOIN cs.club c
+		    LEFT JOIN c.clubMembers cm
+		    WHERE c.isClubDeleted = false
+		    GROUP BY c.clubToken, c.clubName, c.clubDescription, c.clubImage, c.createdAt, c.modifiedAt, cs.activityScore
+		    ORDER BY cs.activityScore DESC
+		""")
+	List<ClubCache> findTop10ByActivityClubs(Pageable pageable);
 
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsRepository.java
@@ -21,9 +21,7 @@ public interface ClubStatisticsRepository extends JpaRepository<ClubStatistics, 
 		"JOIN FETCH cs.club c " +
 		"LEFT JOIN FETCH c.clubMembers cm " +
 		"LEFT JOIN FETCH cm.member m " +
-		"LEFT JOIN FETCH m.leagueRecord lr " +
-		"ORDER BY cs.popularityScore DESC"
-	)
+		"ORDER BY cs.popularityScore DESC")
 	List<ClubStatistics> findTopPopularClubs(Pageable pageable);
 
 	@Query("SELECT DISTINCT cs " +
@@ -31,7 +29,6 @@ public interface ClubStatisticsRepository extends JpaRepository<ClubStatistics, 
 		"JOIN FETCH cs.club c " +
 		"LEFT JOIN FETCH c.clubMembers cm " +
 		"LEFT JOIN FETCH cm.member m " +
-		"LEFT JOIN FETCH m.leagueRecord lr " +
 		"ORDER BY cs.activityScore DESC")
 	List<ClubStatistics> findTop10ByActivityClubs(Pageable pageable);
 


### PR DESCRIPTION
## PR에 대한 설명 🔍

이전 PR에서의 최적화는 Select new 를 사용해 DTO 데이터를 DB에서 갖고 오는 것이 아니기 때문에 응답속도가 50%만 최적화 되었습니다.
ClubCache DTO를 DB에서 return 하는 것으로 JPQL을 변경해 쿼리를 더욱 더 최적화했습니다

## 변경된 사항 📝

<!-- 이번 PR에서의 변경점 -->

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF, 글 -->

### Before

### After

## PR에서 중점적으로 확인되어야 하는 사항
