### PR TITLE
refactor: 동호회 조회수 기능에서 레디스락 제거, querydsl 로 직접 수정 쿼리 작성

### DIFF
--- a/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatistics.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatistics.java
@@ -48,11 +48,6 @@ public class ClubStatistics extends AbstractBaseTime {
 		this.activityScore = 0.0;
 	}
 
-	public void increaseVisitedCount() {
-		this.visitedCount++;
-		updateScore();
-	}
-
 	public void increaseRegistrationCount(int count) {
 		this.registrationCount = count;
 		updateScore();

--- a/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsRepositoryCustom.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsRepositoryCustom.java
@@ -4,4 +4,6 @@ import java.util.List;
 
 public interface ClubStatisticsRepositoryCustom {
 	List<Long> findAllClubId();
+
+	void increaseClubVisitCount(String clubToken);
 }

--- a/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsServiceImpl.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsServiceImpl.java
@@ -20,11 +20,7 @@ public class ClubStatisticsServiceImpl implements ClubStatisticsService {
 	@Override
 	@Transactional
 	public void increaseVisitedClubCount(String clubToken) {
-		ClubStatistics clubStatistics = clubStatisticsReader.readClubStatistics(clubToken);
-		clubStatistics.increaseVisitedCount();
-		clubStatisticsStore.store(clubStatistics);
-		log.info("**** 스레드 이름 : {}", Thread.currentThread().getName());
-		log.info("***** club visit count : {}", clubStatistics.getVisitedCount());
+		clubStatisticsStore.increaseClubVisitCount(clubToken);
 	}
 
 	@Override

--- a/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsStore.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/ClubStatisticsStore.java
@@ -2,4 +2,6 @@ package org.badminton.domain.domain.statistics;
 
 public interface ClubStatisticsStore {
 	void store(ClubStatistics clubStatistics);
+
+	void increaseClubVisitCount(String clubToken);
 }

--- a/domain/src/main/java/org/badminton/domain/domain/statistics/event/ReadClubEventHandler.java
+++ b/domain/src/main/java/org/badminton/domain/domain/statistics/event/ReadClubEventHandler.java
@@ -7,9 +7,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class ReadClubEventHandler {
 
 	private final ClubStatisticsService clubStatisticsService;
@@ -18,9 +20,6 @@ public class ReadClubEventHandler {
 	@Async
 	@TransactionalEventListener
 	public void readClubEventListener(ReadClubEvent event) {
-		String lockName = "CLUB_VISIT_LOCK_" + event.getClubToken();
-		distributedLockProcessor.execute(lockName, 10000, 10000,
-			() -> clubStatisticsService.increaseVisitedClubCount(event.getClubToken())
-		);
+		clubStatisticsService.increaseVisitedClubCount(event.getClubToken());
 	}
 }

--- a/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsRepositoryImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsRepositoryImpl.java
@@ -7,15 +7,18 @@ import java.util.List;
 import org.badminton.domain.domain.club.entity.QClub;
 import org.badminton.domain.domain.statistics.ClubStatisticsRepositoryCustom;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Repository
 @RequiredArgsConstructor
+@Slf4j
 public class ClubStatisticsRepositoryImpl implements ClubStatisticsRepositoryCustom {
 	private final JPAQueryFactory queryFactory;
 
@@ -26,6 +29,15 @@ public class ClubStatisticsRepositoryImpl implements ClubStatisticsRepositoryCus
 			.from(clubStatistics)
 			.where(isClubNotNull(clubStatistics.club))
 			.fetch();
+	}
+
+	@Override
+	@Transactional
+	public void increaseClubVisitCount(String clubToken) {
+		queryFactory.update(clubStatistics)
+			.set(clubStatistics.visitedCount, clubStatistics.visitedCount.add(1))
+			.where(clubStatistics.club.clubToken.eq(clubToken))
+			.execute();
 	}
 
 	private BooleanExpression isClubNotNull(QClub club) {

--- a/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsStoreImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/statistics/ClubStatisticsStoreImpl.java
@@ -1,6 +1,7 @@
 package org.badminton.infrastructure.statistics;
 
 import org.badminton.domain.domain.statistics.ClubStatistics;
+import org.badminton.domain.domain.statistics.ClubStatisticsRepositoryCustom;
 import org.badminton.domain.domain.statistics.ClubStatisticsStore;
 import org.springframework.stereotype.Component;
 
@@ -12,9 +13,16 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ClubStatisticsStoreImpl implements ClubStatisticsStore {
 	private final ClubStatisticsRepository clubStatisticsRepository;
+	private final ClubStatisticsRepositoryCustom clubStatisticsRepositoryCustom;
 
 	@Override
 	public void store(ClubStatistics clubStatistics) {
 		clubStatisticsRepository.save(clubStatistics);
 	}
+
+	@Override
+	public void increaseClubVisitCount(String clubToken) {
+		clubStatisticsRepositoryCustom.increaseClubVisitCount(clubToken);
+	}
+
 }


### PR DESCRIPTION
## PR에 대한 설명 🔍

동호회 조회수 기능에서 레디스락을 제거했습니다. 
Querydsl로 직접 수정 쿼리를 작성했습니다.

## 변경된 사항 📝

### Before

1. Event Listener
```java
	@Async
	@TransactionalEventListener
	public void readClubEventListener(ReadClubEvent event) {
		String lockName = "CLUB_VISIT_LOCK_" + event.getClubToken();
		distributedLockProcessor.execute(lockName, 10000, 10000,
			() -> clubStatisticsService.increaseVisitedClubCount(event.getClubToken())
		);
	}
```

### After

1. Event Listener

```java
	@Async
	@TransactionalEventListener
	public void readClubEventListener(ReadClubEvent event) {
		clubStatisticsService.increaseVisitedClubCount(event.getClubToken());
	}
```

2. querydsl
```java
@Override
	@Transactional
	public void increaseClubVisitCount(String clubToken) {
		queryFactory.update(clubStatistics)
			.set(clubStatistics.visitedCount, clubStatistics.visitedCount.add(1))
			.where(clubStatistics.club.clubToken.eq(clubToken))
			.execute();
	}
```

## PR에서 중점적으로 확인되어야 하는 사항
조회수 기능에서 레디스락을 제거했습니다. 동시성 문제는 경기 참여에 적용할 예정입니다.
