### PR TITLE
refactor: 대진표 조회 API 쿼리 최적화

### DIFF
--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/reader/DoublesMatchReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/reader/DoublesMatchReaderImpl.java
@@ -26,7 +26,7 @@ public class DoublesMatchReaderImpl implements DoublesMatchReader {
 
 	@Override
 	public List<DoublesMatch> getDoublesBracket(Long leagueId) {
-		List<DoublesMatch> bracketInLeague = doublesMatchRepository.findAllByLeague_LeagueId(leagueId);
+		List<DoublesMatch> bracketInLeague = doublesMatchRepository.findAllByLeagueIdWithAllByJpql(leagueId);
 		if (bracketInLeague.isEmpty()) {
 			throw new BracketNotExistException(leagueId);
 		}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/reader/DoublesMatchReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/reader/DoublesMatchReaderImpl.java
@@ -26,7 +26,7 @@ public class DoublesMatchReaderImpl implements DoublesMatchReader {
 
 	@Override
 	public List<DoublesMatch> getDoublesBracket(Long leagueId) {
-		List<DoublesMatch> bracketInLeague = doublesMatchRepository.findAllByLeagueIdWithJpql(leagueId);
+		List<DoublesMatch> bracketInLeague = doublesMatchRepository.findAllDoublesMatch(leagueId);
 		if (bracketInLeague.isEmpty()) {
 			throw new BracketNotExistException(leagueId);
 		}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/reader/DoublesMatchReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/reader/DoublesMatchReaderImpl.java
@@ -26,7 +26,7 @@ public class DoublesMatchReaderImpl implements DoublesMatchReader {
 
 	@Override
 	public List<DoublesMatch> getDoublesBracket(Long leagueId) {
-		List<DoublesMatch> bracketInLeague = doublesMatchRepository.findAllByLeagueIdWithAllByJpql(leagueId);
+		List<DoublesMatch> bracketInLeague = doublesMatchRepository.findAllByLeagueIdWithJpql(leagueId);
 		if (bracketInLeague.isEmpty()) {
 			throw new BracketNotExistException(leagueId);
 		}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/reader/SinglesMatchReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/reader/SinglesMatchReaderImpl.java
@@ -25,7 +25,7 @@ public class SinglesMatchReaderImpl implements SinglesMatchReader {
 
 	@Override
 	public List<SinglesMatch> getSinglesBracket(Long leagueId) {
-		List<SinglesMatch> bracketInLeague = singlesMatchRepository.findAllByLeagueIdWithJpql(leagueId);
+		List<SinglesMatch> bracketInLeague = singlesMatchRepository.findAllSinglesMatch(leagueId);
 		if (bracketInLeague.isEmpty()) {
 			throw new BracketNotExistException(leagueId);
 		}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/reader/SinglesMatchReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/reader/SinglesMatchReaderImpl.java
@@ -25,7 +25,7 @@ public class SinglesMatchReaderImpl implements SinglesMatchReader {
 
 	@Override
 	public List<SinglesMatch> getSinglesBracket(Long leagueId) {
-		List<SinglesMatch> bracketInLeague = singlesMatchRepository.findAllByLeague_LeagueId(leagueId);
+		List<SinglesMatch> bracketInLeague = singlesMatchRepository.findAllByLeagueIdWithJpql(leagueId);
 		if (bracketInLeague.isEmpty()) {
 			throw new BracketNotExistException(leagueId);
 		}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/DoublesMatchRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/DoublesMatchRepository.java
@@ -23,29 +23,21 @@ public interface DoublesMatchRepository extends JpaRepository<DoublesMatch, Long
 	@Query("""
 		    SELECT dm
 		    FROM DoublesMatch dm
-		    JOIN FETCH dm.league l
-		    JOIN FETCH l.club c
-		    JOIN FETCH dm.team1 t1
-		    JOIN FETCH t1.leagueParticipant1 lp1
-		    JOIN FETCH lp1.member m1
-		    LEFT JOIN FETCH m1.leagueRecord lr1
-		    JOIN FETCH lp1.clubMember cm1
-		    JOIN FETCH t1.leagueParticipant2 lp2
-		    JOIN FETCH lp2.member m2
-		    LEFT JOIN FETCH m2.leagueRecord lr2
-		    JOIN FETCH lp2.clubMember cm2
-		    JOIN FETCH dm.team2 t2
-		    JOIN FETCH t2.leagueParticipant1 lp3
-		    JOIN FETCH lp3.member m3
-		    LEFT JOIN FETCH m3.leagueRecord lr3
-		    JOIN FETCH lp3.clubMember cm3
-		    JOIN FETCH t2.leagueParticipant2 lp4
-		    JOIN FETCH lp4.member m4
-		    LEFT JOIN FETCH m4.leagueRecord lr4
-		    JOIN FETCH lp4.clubMember cm4
+		    LEFT JOIN FETCH dm.league l
+		    LEFT JOIN FETCH l.club c
+		    LEFT JOIN FETCH dm.team1 t1
+		    LEFT JOIN FETCH t1.leagueParticipant1 lp1
+		    LEFT JOIN FETCH lp1.member m1
+		    LEFT JOIN FETCH t1.leagueParticipant2 lp2
+		    LEFT JOIN FETCH lp2.member m2
+		    LEFT JOIN FETCH dm.team2 t2
+		    LEFT JOIN FETCH t2.leagueParticipant1 lp3
+		    LEFT JOIN FETCH lp3.member m3
+		    LEFT JOIN FETCH t2.leagueParticipant2 lp4
+		    LEFT JOIN FETCH lp4.member m4
 		    WHERE dm.league.leagueId = :leagueId
 		""")
-	List<DoublesMatch> findAllByLeagueIdWithAllByJpql(@Param("leagueId") Long leagueId);
+	List<DoublesMatch> findAllByLeagueIdWithJpql(@Param("leagueId") Long leagueId);
 
 	void deleteAllByLeague_LeagueId(Long leagueId);
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/DoublesMatchRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/DoublesMatchRepository.java
@@ -37,7 +37,7 @@ public interface DoublesMatchRepository extends JpaRepository<DoublesMatch, Long
 		    LEFT JOIN FETCH lp4.member m4
 		    WHERE dm.league.leagueId = :leagueId
 		""")
-	List<DoublesMatch> findAllByLeagueIdWithJpql(@Param("leagueId") Long leagueId);
+	List<DoublesMatch> findAllDoublesMatch(@Param("leagueId") Long leagueId);
 
 	void deleteAllByLeague_LeagueId(Long leagueId);
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/DoublesMatchRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/DoublesMatchRepository.java
@@ -20,6 +20,33 @@ public interface DoublesMatchRepository extends JpaRepository<DoublesMatch, Long
 
 	List<DoublesMatch> findAllByLeague_LeagueId(Long leagueId);
 
+	@Query("""
+		    SELECT dm
+		    FROM DoublesMatch dm
+		    JOIN FETCH dm.league l
+		    JOIN FETCH l.club c
+		    JOIN FETCH dm.team1 t1
+		    JOIN FETCH t1.leagueParticipant1 lp1
+		    JOIN FETCH lp1.member m1
+		    LEFT JOIN FETCH m1.leagueRecord lr1
+		    JOIN FETCH lp1.clubMember cm1
+		    JOIN FETCH t1.leagueParticipant2 lp2
+		    JOIN FETCH lp2.member m2
+		    LEFT JOIN FETCH m2.leagueRecord lr2
+		    JOIN FETCH lp2.clubMember cm2
+		    JOIN FETCH dm.team2 t2
+		    JOIN FETCH t2.leagueParticipant1 lp3
+		    JOIN FETCH lp3.member m3
+		    LEFT JOIN FETCH m3.leagueRecord lr3
+		    JOIN FETCH lp3.clubMember cm3
+		    JOIN FETCH t2.leagueParticipant2 lp4
+		    JOIN FETCH lp4.member m4
+		    LEFT JOIN FETCH m4.leagueRecord lr4
+		    JOIN FETCH lp4.clubMember cm4
+		    WHERE dm.league.leagueId = :leagueId
+		""")
+	List<DoublesMatch> findAllByLeagueIdWithAllByJpql(@Param("leagueId") Long leagueId);
+
 	void deleteAllByLeague_LeagueId(Long leagueId);
 
 	List<DoublesMatch> findAllByLeague_LeagueIdAndRoundNumber(Long leagueId, Integer roundNumber);

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/SinglesMatchRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/SinglesMatchRepository.java
@@ -35,7 +35,7 @@ public interface SinglesMatchRepository extends JpaRepository<SinglesMatch, Long
 		    LEFT JOIN FETCH lp2.clubMember cm2
 		    WHERE l.leagueId = :leagueId
 		""")
-	List<SinglesMatch> findAllByLeagueIdWithJpql(@Param("leagueId") Long leagueId);
+	List<SinglesMatch> findAllSinglesMatch(@Param("leagueId") Long leagueId);
 
 	void deleteAllByLeague_LeagueId(Long leagueId);
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/SinglesMatchRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/SinglesMatchRepository.java
@@ -20,6 +20,23 @@ public interface SinglesMatchRepository extends JpaRepository<SinglesMatch, Long
 
 	List<SinglesMatch> findAllByLeague_LeagueId(Long leagueId);
 
+	@Query("""
+		    SELECT sm
+		    FROM SinglesMatch sm
+		    JOIN FETCH sm.league l
+		    JOIN FETCH l.club c
+		    JOIN FETCH sm.leagueParticipant1 lp1
+		    JOIN FETCH lp1.member m1
+		    LEFT JOIN FETCH m1.leagueRecord lr1
+		    JOIN FETCH lp1.clubMember cm1
+		    JOIN FETCH sm.leagueParticipant2 lp2
+		    JOIN FETCH lp2.member m2
+		    LEFT JOIN FETCH m2.leagueRecord lr2
+		    JOIN FETCH lp2.clubMember cm2
+		    WHERE l.leagueId = :leagueId
+		""")
+	List<SinglesMatch> findAllByLeagueIdWithJpql(@Param("leagueId") Long leagueId);
+
 	void deleteAllByLeague_LeagueId(Long leagueId);
 
 	List<SinglesMatch> findAllByLeague_LeagueIdAndRoundNumber(Long leagueId, Integer roundNumber);

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/SinglesMatchRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/SinglesMatchRepository.java
@@ -23,16 +23,16 @@ public interface SinglesMatchRepository extends JpaRepository<SinglesMatch, Long
 	@Query("""
 		    SELECT sm
 		    FROM SinglesMatch sm
-		    JOIN FETCH sm.league l
-		    JOIN FETCH l.club c
-		    JOIN FETCH sm.leagueParticipant1 lp1
-		    JOIN FETCH lp1.member m1
+		    LEFT JOIN FETCH sm.league l
+		    LEFT JOIN FETCH l.club c
+		    LEFT JOIN FETCH sm.leagueParticipant1 lp1
+		    LEFT JOIN FETCH lp1.member m1
 		    LEFT JOIN FETCH m1.leagueRecord lr1
-		    JOIN FETCH lp1.clubMember cm1
-		    JOIN FETCH sm.leagueParticipant2 lp2
-		    JOIN FETCH lp2.member m2
+		    LEFT JOIN FETCH lp1.clubMember cm1
+		    LEFT JOIN FETCH sm.leagueParticipant2 lp2
+		    LEFT JOIN FETCH lp2.member m2
 		    LEFT JOIN FETCH m2.leagueRecord lr2
-		    JOIN FETCH lp2.clubMember cm2
+		    LEFT JOIN FETCH lp2.clubMember cm2
 		    WHERE l.leagueId = :leagueId
 		""")
 	List<SinglesMatch> findAllByLeagueIdWithJpql(@Param("leagueId") Long leagueId);


### PR DESCRIPTION
## PR에 대한 설명 🔍

싱글 대진표, 더블 대진표 조회 API의 쿼리를 JPQL를 사용해서 연관관계를 단일 쿼리로 조회할 수 있도록 변경했습니다.

## 변경된 사항 📝

프리 싱글 : 평균 819ms -> 524ms
프리 더블 : 평균 1.19s -> 640ms
토너먼트 싱글 : 평균 844ms -> 372ms
토너먼트 더블 : 평균 1.19s -> 887ms

