### PR TITLE
hotfix: league id에 해당하는 in progress match 만 조회

### DIFF
--- a/domain/src/main/java/org/badminton/domain/domain/match/vo/LeagueMatchSetRedisKey.java
+++ b/domain/src/main/java/org/badminton/domain/domain/match/vo/LeagueMatchSetRedisKey.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 public class LeagueMatchSetRedisKey {
 
 	public static final String IN_PROGRESS_MATCH_PREFIX = "IN_PROGRESS_";
-	private static final String LEAGUE_ID_PREFIX = "_LEAGUE_";
+	public static final String LEAGUE_ID_PREFIX = "_LEAGUE_";
 	private static final String MATCH_ID_PREFIX = "_MATCH_";
 	private static final String SET_NUMBER_PREFIX = "_SET_";
 

--- a/infrastructure/build.gradle
+++ b/infrastructure/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'
+    implementation 'org.redisson:redisson:3.27.0'
 
     testImplementation 'net.datafaker:datafaker:1.5.0'
 

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/SetRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/SetRepository.java
@@ -90,7 +90,7 @@ public class SetRepository {
 	}
 
 	public List<LeagueSetsScoreInProgressInfo> getInProgressSet(Long leagueId) {
-		Set<String> keys = redisTemplate2.keys(IN_PROGRESS_MATCH_PREFIX + "*");
+		Set<String> keys = redisTemplate2.keys(IN_PROGRESS_MATCH_PREFIX + leagueId + "*");
 		if (keys == null || keys.isEmpty()) {
 			return Collections.emptyList();
 		}

--- a/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/SetRepository.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/match/repository/SetRepository.java
@@ -90,7 +90,7 @@ public class SetRepository {
 	}
 
 	public List<LeagueSetsScoreInProgressInfo> getInProgressSet(Long leagueId) {
-		Set<String> keys = redisTemplate2.keys(IN_PROGRESS_MATCH_PREFIX + leagueId + "*");
+		Set<String> keys = redisTemplate2.keys(IN_PROGRESS_MATCH_PREFIX + LEAGUE_ID_PREFIX + leagueId + "*");
 		if (keys == null || keys.isEmpty()) {
 			return Collections.emptyList();
 		}


### PR DESCRIPTION
## PR에 대한 설명 🔍
league id에 해당하는 In progress match 만 가져오도록 수정했습니다.

## 변경된 사항 📝

### Before
redis에 있는 모든 진행 중인 match의 score를 응답하고 있습니다.

### After
수정 완료했습니다. 

## PR에서 중점적으로 확인되어야 하는 사항
league id에 해당하는 match 만 조회