### PR TITLE
bug: 날짜별 리그 조회 개선

### DIFF
--- a/infrastructure/src/main/java/org/badminton/infrastructure/league/LeagueReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/league/LeagueReaderImpl.java
@@ -87,7 +87,7 @@ public class LeagueReaderImpl implements LeagueReader {
 	public Page<League> readLeagueStatusIsNotAllAndRegionIsNotAll(AllowedLeagueStatus leagueStatus, Region region,
 		LocalDate date, Pageable pageable) {
 		LocalDateTime startOfDay = date.atStartOfDay();
-		LocalDateTime endOfDay = date.atTime(23, 59, 59);
+		LocalDateTime endOfDay = date.atTime(23, 59, 59, 9);
 
 		return leagueRepository.findAllByLeagueAtBetweenAndLeagueStatusAndAddressRegion(
 			startOfDay,
@@ -101,7 +101,7 @@ public class LeagueReaderImpl implements LeagueReader {
 	@Override
 	public Page<League> readLeagueStatusIsAllAndRegionIsNotAll(Region region, LocalDate date, Pageable pageable) {
 		LocalDateTime startOfDay = date.atStartOfDay();
-		LocalDateTime endOfDay = date.atTime(23, 59, 59);
+		LocalDateTime endOfDay = date.atTime(23, 59, 59, 9);
 		return leagueRepository.findAllByLeagueAtBetweenAndAddressRegion(
 			startOfDay,
 			endOfDay,
@@ -114,7 +114,7 @@ public class LeagueReaderImpl implements LeagueReader {
 	public Page<League> readLeagueStatusIsNotAllAndRegionIsAll(AllowedLeagueStatus leagueStatus, LocalDate date,
 		Pageable pageable) {
 		LocalDateTime startOfDay = date.atStartOfDay();
-		LocalDateTime endOfDay = date.atTime(23, 59, 59);
+		LocalDateTime endOfDay = date.atTime(23, 59, 59, 9);
 		return leagueRepository.findAllByLeagueAtBetweenAndLeagueStatus(
 			startOfDay,
 			endOfDay,
@@ -126,7 +126,7 @@ public class LeagueReaderImpl implements LeagueReader {
 	@Override
 	public Page<League> readLeagueStatusIsAllAndRegionIsAll(LocalDate date, Pageable pageable) {
 		LocalDateTime startOfDay = date.atStartOfDay();
-		LocalDateTime endOfDay = date.atTime(23, 59, 59);
+		LocalDateTime endOfDay = date.atTime(23, 59, 59, 9);
 		return leagueRepository.findAllByLeagueAtBetween(
 			startOfDay,
 			endOfDay,

--- a/infrastructure/src/main/java/org/badminton/infrastructure/league/LeagueReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/league/LeagueReaderImpl.java
@@ -2,7 +2,6 @@ package org.badminton.infrastructure.league;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 
 import org.badminton.domain.common.enums.MatchGenerationType;
@@ -88,7 +87,7 @@ public class LeagueReaderImpl implements LeagueReader {
 	public Page<League> readLeagueStatusIsNotAllAndRegionIsNotAll(AllowedLeagueStatus leagueStatus, Region region,
 		LocalDate date, Pageable pageable) {
 		LocalDateTime startOfDay = date.atStartOfDay();
-		LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+		LocalDateTime endOfDay = date.atTime(23, 59, 59);
 
 		return leagueRepository.findAllByLeagueAtBetweenAndLeagueStatusAndAddressRegion(
 			startOfDay,
@@ -102,7 +101,7 @@ public class LeagueReaderImpl implements LeagueReader {
 	@Override
 	public Page<League> readLeagueStatusIsAllAndRegionIsNotAll(Region region, LocalDate date, Pageable pageable) {
 		LocalDateTime startOfDay = date.atStartOfDay();
-		LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+		LocalDateTime endOfDay = date.atTime(23, 59, 59);
 		return leagueRepository.findAllByLeagueAtBetweenAndAddressRegion(
 			startOfDay,
 			endOfDay,
@@ -115,7 +114,7 @@ public class LeagueReaderImpl implements LeagueReader {
 	public Page<League> readLeagueStatusIsNotAllAndRegionIsAll(AllowedLeagueStatus leagueStatus, LocalDate date,
 		Pageable pageable) {
 		LocalDateTime startOfDay = date.atStartOfDay();
-		LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+		LocalDateTime endOfDay = date.atTime(23, 59, 59);
 		return leagueRepository.findAllByLeagueAtBetweenAndLeagueStatus(
 			startOfDay,
 			endOfDay,
@@ -127,7 +126,7 @@ public class LeagueReaderImpl implements LeagueReader {
 	@Override
 	public Page<League> readLeagueStatusIsAllAndRegionIsAll(LocalDate date, Pageable pageable) {
 		LocalDateTime startOfDay = date.atStartOfDay();
-		LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+		LocalDateTime endOfDay = date.atTime(23, 59, 59);
 		return leagueRepository.findAllByLeagueAtBetween(
 			startOfDay,
 			endOfDay,


### PR DESCRIPTION
## PR에 대한 설명 🔍
- PR의 내용에 대한 설명을 자세히 설명 
- 날짜 기반 리그 조회 시 다음날 00시 00분 리그의 정보도 조회되는 오류 
  -  ex) 2024-12-20 조회 시 2024-12-21T00:00:00 의 리그도 조회  

## 변경된 사항 📝
- 앳지 케이스에서 발생하는 버그입니다. 
- 해당 버그의 원인으로 조회시 당일 00:00:00부터 23:59:59:999999999 로 조회하는데 이 케이스에서는 다음 날 00:00:00까지 조회됩니다. 
- 해당 케이스를 개선하기 위해 당일 00:00:00부터 23:59:59:9 까지 조회하는 것으로 변경하였습니다. 
