### PR TITLE
hotfix: 동호회 신청 후 거절 시 다시 가입신청 안되는 이슈 해결

### DIFF
--- a/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubApplyReaderImpl.java
+++ b/infrastructure/src/main/java/org/badminton/infrastructure/club/ClubApplyReaderImpl.java
@@ -24,7 +24,8 @@ public class ClubApplyReaderImpl implements ClubApplyReader {
 
 	@Override
 	public void validateApply(String clubToken, String memberToken) {
-		if (clubApplyRepository.existsByClubClubTokenAndMemberMemberToken(clubToken, memberToken)) {
+		if (clubApplyRepository.existsByClubClubTokenAndMemberMemberTokenAndStatus(clubToken, memberToken,
+			ClubApply.ApplyStatus.PENDING)) {
 			throw new MemberAlreadyApplyClubException(memberToken, clubToken);
 		}
 	}


### PR DESCRIPTION
## PR에 대한 설명 🔍

이전에는 동호회 가입신청을 한 후 거절당하면 다시 가입신청이 안되는 이슈 발생 -> clubApplyRepository에서 상태를 PENDING 인 것만 조회하지 않아 이슈 발생 -> 가입신청 테이블에서 회원 유무를 확인할 때 Status 포함하여 확인


## 변경된 사항 📝

<!-- 이번 PR에서의 변경점 -->

<!-- 개발 기능을 보여줄 수 있는 이미지, GIF, 글 -->

### Before

### After

## PR에서 중점적으로 확인되어야 하는 사항
